### PR TITLE
Show and group programmes by academic year

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1144,9 +1144,7 @@ export const en = {
       label: 'Programmes',
       title: 'Programmes',
       description:
-        'Use this area to:\n- organise vaccination sessions\n- report vaccinations',
-      adolescent: 'Adolescent',
-      seasonal: 'Seasonal'
+        'Use this area to:\n- organise vaccination sessions\n- report vaccinations'
     },
     show: {
       label: 'Overview',

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -6,7 +6,7 @@ import { formatLink } from '../utils/string.js'
 
 import { Cohort } from './cohort.js'
 import { PatientSession } from './patient-session.js'
-import { SchoolTerm } from './school.js'
+import { SchoolTerm, SchoolYear } from './school.js'
 import { Session } from './session.js'
 import { Vaccination } from './vaccination.js'
 import { Vaccine } from './vaccine.js'
@@ -133,6 +133,7 @@ export class Programme {
       options?.type && programmeTypes[options.type]?.information
     this.active = options?.type && programmeTypes[options.type]?.active
     this.seasonal = options?.type && programmeTypes[options.type]?.seasonal
+    this.year = options?.year || SchoolYear.Y2024
     this.term = options?.type && programmeTypes[options.type]?.term
     this.type = options?.type
     this.cohort_uids = options?.cohort_uids || []

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -24,6 +24,15 @@ export const SchoolTerm = {
   Summer: 'Summer'
 }
 
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const SchoolYear = {
+  Y2024: '2024/25',
+  Y2023: '2023/24'
+}
+
 export const schoolTerms = {
   [SchoolTerm.Autumn]: { from: '2024-09-03', to: '2024-12-13' },
   [SchoolTerm.Spring]: { from: '2025-01-06', to: '2025-04-11' },

--- a/app/views/programme/_navigation.njk
+++ b/app/views/programme/_navigation.njk
@@ -5,6 +5,7 @@
 
 {% macro programmeNavigation(params) %}
   {{ heading({
+    summary: params.programme.year,
     title: params.programme.name
   }) }}
 

--- a/app/views/programme/list.njk
+++ b/app/views/programme/list.njk
@@ -10,7 +10,7 @@
     title: title
   }) }}
 
-  {% for seasonal, programmes in programmes | groupby("seasonal") %}
+  {% for year, programmes in programmes | groupby("year") %}
     {% set programmeRows = [] %}
     {% for programme in programmes | sort(false, false, "name") %}
       {% set programmeRows = programmeRows | push([
@@ -36,7 +36,7 @@
     {{ actionTable({
       id: "programmes",
       sort: "name",
-      heading: __("programme.list.seasonal") if seasonal == "true" else __("programme.list.adolescent"),
+      heading: year,
       panel: true,
       responsive: true,
       head: [


### PR DESCRIPTION
This PR adds support for display the academic year a programme relates to (within the programme section only for now, maybe this information should be surfaced in other places down the line)

- On the Programmes list, programmes are now grouped by academic year. These should be listed in reverse chronological order
- On programme pages, the academic year is shown below the programme name 

<img width="540" alt="Screenshot of programmes list." src="https://github.com/user-attachments/assets/d78719ac-54d6-4720-906c-570c32d864c3" />
<img width="380" alt="Screenshot of programme page." src="https://github.com/user-attachments/assets/8390c1ce-f737-43b1-9514-581275afb516" />
