### PR TITLE
Allow nurses to get consent for a specific programme

### DIFF
--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -108,9 +108,8 @@ export const parentController = {
           }
         : {}),
       [`/${id}/${uuid}/${form}/parent`]: {
-        [`/${id}/${uuid}/${form}/contact-preference`]: () => {
-          return request.session.data.consent?.parent?.tel
-        }
+        [`/${id}/${uuid}/${form}/contact-preference`]: () =>
+          request.session.data.consent?.parent?.tel
       },
       [`/${id}/${uuid}/${form}/decision`]: {
         [`${id}/${uuid}/${form}/refusal-reason`]: {

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -25,7 +25,7 @@ export const replyController = {
   redirect(request, response) {
     const { id, nhsn } = request.params
 
-    response.redirect(`/sessions/${id}/${nhsn}`)
+    response.redirect(`/sessions/${id}/patients/${nhsn}`)
   },
 
   show(request, response) {

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -45,7 +45,6 @@ export const replyController = {
         patient_uuid: patient.uuid,
         session_id: session.id,
         selfConsent,
-        ...(!selfConsent && { method: ReplyMethod.Phone }),
         ...(data.token && { createdBy_uid: data.token?.uid })
       },
       data
@@ -253,15 +252,19 @@ export const replyController = {
     if (respondent) {
       switch (respondent) {
         case 'new': // Consent response is from a new contact
+          newReply.method = ReplyMethod.Phone
           newReply.parent = {}
           break
         case 'self':
+          newReply.method = ReplyMethod.InPerson
           newReply.parent = false
           break
         case 'parent-1': // Consent response is from CHIS record
+          newReply.method = ReplyMethod.Phone
           newReply.parent = patient.parents[0]
           break
         case 'parent-2': // Consent response is from CHIS record
+          newReply.method = ReplyMethod.Phone
           newReply.parent = patient.parents[1]
           break
         default: // Consent response is an existing respondent
@@ -269,6 +272,7 @@ export const replyController = {
           // We only want to do this when submitting replacement reply
           response.locals.invalidUuid = request.body.uuid
 
+          newReply.method = ReplyMethod.Phone
           newReply.parent = Reply.read(respondent, data).parent
       }
     }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1304,7 +1304,11 @@ export const en = {
       label: 'Parent'
     },
     programme: {
-      label: 'Programme'
+      label: 'Programme',
+      title: {
+        Child: 'Which vaccination is the child giving consent for?',
+        Parent: 'Which vaccination are they giving consent for?'
+      }
     },
     method: {
       title: 'How was the response given?',

--- a/app/views/reply/form/check-answers.njk
+++ b/app/views/reply/form/check-answers.njk
@@ -18,7 +18,9 @@
         method: {
           href: reply.uri + "/new/method"
         },
-        programme: {},
+        programme: {
+          href: reply.uri + "/new/programme" if isMultiProgrammeSession
+        },
         decision: {
           href: reply.uri + "/new/decision"
         },

--- a/app/views/reply/form/decision.njk
+++ b/app/views/reply/form/decision.njk
@@ -31,4 +31,10 @@
     }],
     decorate: "reply.decision"
   }) }}
+
+  {{ input({
+    type: "hidden",
+    value: programme.pid,
+    decorate: "reply.programme_pid"
+  }) if not isMultiProgrammeSession }}
 {% endblock %}

--- a/app/views/reply/form/health-answers.njk
+++ b/app/views/reply/form/health-answers.njk
@@ -8,7 +8,7 @@
     title: title
   }) }}
 
-  {% for key in reply.programme.vaccine.healthQuestionKeys %}
+  {% for key in programme.vaccine.healthQuestionKeys %}
     {{ radios({
       classes: "nhsuk-radios--inline",
       fieldset: {

--- a/app/views/reply/form/parent.njk
+++ b/app/views/reply/form/parent.njk
@@ -15,7 +15,7 @@
   {{ input({
     label: { text: __("parent.fullName.label") },
     decorate: "reply.parent.fullName"
-  }) if not reply.parent.fullName }}
+  }) }}
 
   {# `pop` removes `Other` and `Unknown` from ParentalRelationship array #}
   {{ radios({
@@ -44,7 +44,7 @@
       }
     }),
     decorate: "reply.parent.relationship"
-  }) if not reply.parent.relationship }}
+  }) }}
 
   {{ input({
     label: { text: __("parent.email.label") },

--- a/app/views/reply/form/programme.njk
+++ b/app/views/reply/form/programme.njk
@@ -1,0 +1,23 @@
+{% extends "_layouts/form.njk" %}
+
+{% if reply.selfConsent %}
+  {% set title = __("reply.programme.title.Child") %}
+{% else %}
+  {% set title = __("reply.programme.title.Parent") %}
+{% endif %}
+
+{% block form %}
+  {{ radios({
+    fieldset: {
+      legend: {
+        html: heading({
+          classes: "nhsuk-fieldset__legend--l",
+          caption: patient.fullName,
+          title: title
+        })
+      }
+    },
+    items: programmeItems,
+    decorate: "reply.programme_pid"
+  }) }}
+{% endblock %}


### PR DESCRIPTION
When a session is supporting multiple programmes, a nurse may need to get consent for a specific programme.

This PR:

- Asks for the programme a consent is for _if_ a session has more than one programme
- Shows the respective health questions for the selected programme
- Allows that programme to be edited from the check and confirm answers screen

If a session has only one programme, this question is not asked, and instead this value is pre-filled based on the single session the programme is in support of. You can view the programme when checking answers, but not change this value.

(This PR also fixed the consent journey so that a child who has been assessed as Gillick competent doesn’t prevent consent being recorded from a parent.)

## Select programme (parent)

<img width="760" alt="Screenshot 2025-02-03 at 16 58 19" src="https://github.com/user-attachments/assets/90cbe94b-15aa-4f4c-a2b3-716279152d62" />

## Select programme (child self-consenting)

<img width="760" alt="consent-programme-child" src="https://github.com/user-attachments/assets/0e1c5cad-7c9f-4d75-ab51-8fc57078348b" />

## Health answers

<img width="760" alt="Screenshot 2025-02-03 at 16 58 40" src="https://github.com/user-attachments/assets/e87dca63-5430-4621-af95-0a5b5ad045ee" />

## Check and confirm

<img width="770" alt="Screenshot 2025-02-03 at 16 58 53" src="https://github.com/user-attachments/assets/bba34345-21f0-492a-b61c-8364bf7fcc6c" />
 