### PR TITLE
Doubles emails

### DIFF
--- a/app/assets/stylesheets/_message.scss
+++ b/app/assets/stylesheets/_message.scss
@@ -18,6 +18,15 @@ $text-message-background-color: color.mix($color_nhsuk-grey-4, $color_nhsuk-whit
   .nhsuk-heading-l {
     @include nhsuk-font($size: 24, $weight: bold);
   }
+
+  .nhsuk-inset-text {
+    @include nhsuk-responsive-padding(2, bottom);
+    @include nhsuk-responsive-padding(2, top);
+    @include nhsuk-responsive-margin(4, bottom);
+
+    border-color: $nhsuk-border-color;
+    margin-top: 0;
+  }
 }
 
 .app-message--text {

--- a/app/emails/consent/capture-could-not-vaccinate.njk
+++ b/app/emails/consent/capture-could-not-vaccinate.njk
@@ -2,7 +2,7 @@ Dear {{ consent.parent.fullName }},
 
 {{ consent.child.fullAndPreferredNames }} did not get their {{ session.vaccination }} at {{ session.location.name }} today. This was because {{ placeholders.reason }}.
 
-If you’d still like your child to have a vaccination, you can book a slot at a catch-up clinic by contacting your local health team.
+If you’d still like your child to have a vaccination, you can book a slot at a catch-up clinic by contacting our team.
 
 {{ data.organisation.name }}<br>
 {{ data.organisation.email }}<br>

--- a/app/emails/consent/capture-vaccinated.njk
+++ b/app/emails/consent/capture-vaccinated.njk
@@ -5,12 +5,10 @@ Dear {{ consent.parent.fullName }},
 We suggest you record the following details {% if data.schools[session.school_urn].phase == "Primary" %}in their red book (also known as their personal child health record){% else %}somewhere{% endif %}:
 
 {% for programme in session.programmes %}
-## {{ programme.name }}
-
-- Vaccination: {{ programme.name }}
-- Vaccine: {{ programme.vaccine.brand }}
-- Date of vaccination: {{ session.formatted.firstDate }}
-- Batch number: AB1234
+Vaccination: {{ programme.name }}<br>
+Vaccine: {{ programme.vaccine.brand }}<br>
+Date of vaccination: {{ session.formatted.firstDate }}<br>
+Batch number: AB1234
 {% endfor %}
 
 ## Your child might have some side effects
@@ -24,10 +22,16 @@ Your child might have some of the following side effects:
 - loss of appetite
 
 {% else %}
-- bruising or itching at the site of the injection
-- a high temperature, or feeling hot and shivery
-- feeling sick (nausea)
-- pain in the arms, hands, fingers
+- pain, swelling or itchiness at the injection site
+- a headache
+- dizziness
+- feeling or being sick
+- a rash
+- feeling irritable
+- feeling drowsy
+- loss of appetite
+- a high temperature
+- generally feeling unwell
 
 {% endif %}
 

--- a/app/emails/consent/consent-conflicts.njk
+++ b/app/emails/consent/consent-conflicts.njk
@@ -8,6 +8,6 @@ By law, our nursing team cannot vaccinate a child if someone with parental respo
 
 If {{ placeholders.refuser }} changes their mind, we’ll let you know.
 
-## Contact the local health team
+## Get in touch with us
 
-You can speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.

--- a/app/emails/consent/consent-given.njk
+++ b/app/emails/consent/consent-given.njk
@@ -4,4 +4,4 @@ You’ve given consent for {{ consent.child.fullAndPreferredNames }} to get thei
 
 If {{ consent.child.firstName }}’s health changes, or you arrange to have the vaccination elsewhere, please get in touch.
 
-Speak to a member of the local health team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.

--- a/app/emails/consent/invite-catch-up.njk
+++ b/app/emails/consent/invite-catch-up.njk
@@ -1,4 +1,4 @@
-Your local health team are coming to {{ session.location.name }} on {{ session.summary.dates }} to give {% if programme.type == ProgrammeType.Flu %} this year’s flu vaccine{% elif programme.type == ProgrammeType.HPV %}the human papillomavirus (HPV) vaccine{% elif programme.type == ProgrammeType.TdIPV %}the Td/IPV (3-in-1 teenage booster) vaccines{% endif %}.
+We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to give {% if programme.type == ProgrammeType.Flu %} this year’s flu vaccine{% elif programme.type == ProgrammeType.HPV %}the human papillomavirus (HPV) vaccine{% elif programme.type == ProgrammeType.TdIPV %}the Td/IPV (3-in-1 teenage booster) vaccines{% endif %}.
 
 Our records show your child has not had their HPV vaccination. Pupils usually have this when they’re in Year 8.
 
@@ -72,6 +72,6 @@ We suggest you talk to your child about the vaccine before you respond to us.
 
 If you have any trouble using the online form, you can respond over the phone using the contact details below.
 
-## Contact the local health team
+## Get in touch with us
 
-Speak to a member of the local health team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.

--- a/app/emails/consent/invite-clinic-consent.njk
+++ b/app/emails/consent/invite-clinic-consent.njk
@@ -4,6 +4,6 @@ Please give consent for this vaccination ahead of your clinic appointment.
 
 [Give consent for the {{ session.vaccination }}]({{ session.consentUrl }})
 
-## Contact the local health team
+## Get in touch with us
 
-Speak to a member of the local health team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.

--- a/app/emails/consent/invite-reminder.njk
+++ b/app/emails/consent/invite-reminder.njk
@@ -1,4 +1,4 @@
-We wrote to you recently about a visit by a local health team to {{ session.location.name }} on {{ session.summary.dates }}.
+We wrote to you recently about a visit by our team to {{ session.location.name }} on {{ session.summary.dates }}.
 
 If you want your child to get the {{ session.vaccination }}, you need to give consent by {{ session.formatted.closeAt }}.
 
@@ -35,6 +35,6 @@ We suggest you talk to your child about the {{vaccine__n}} before you respond to
 
 If you have any trouble using the online form, you can respond over the phone using the contact details below.
 
-## Contact the local health team
+## Get in touch with us
 
-Speak to a member of the local health team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.

--- a/app/emails/consent/invite-subsequent-reminder.njk
+++ b/app/emails/consent/invite-subsequent-reminder.njk
@@ -33,6 +33,6 @@ We suggest you talk to your child about the {{vaccine__n}} before you respond to
 
 If you have any trouble using the online form, you can respond over the phone using the contact details below.
 
-## Contact the local health team
+## Get in touch with us
 
-Speak to a member of the local health team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.

--- a/app/emails/consent/invite.njk
+++ b/app/emails/consent/invite.njk
@@ -1,43 +1,52 @@
 {% if session.programmes.length == 1 %}
-Your local health team are coming to {{ session.location.name }} on {{ session.summary.dates }} to give the {{ session.programmes[0].information.title }} vaccine.
+We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to offer the {{ session.programmes[0].information.title }} vaccine to your child.
 {% else %}
-Your local health team are coming to {{ session.location.name }} on {{ session.summary.dates }} to give the following vaccines:
+We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to offer the following vaccines to your child:
 
 {% for programme in session.programmes %}
 - {{ programme.information.title }}
 {%- endfor %}
 {% endif %}
 
-## What the {{vaccine__n}} {{is__n}} for
-
-{% for programme in session.programmes %}
-{{ programme.information.description }}
-{% endfor %}
-
-## Please give or refuse consent
-
-If you want your child to get {% if session.programmes.length == 1 %}this vaccine{% else %}these vaccines{% endif %} at school, you need to give consent by {{ session.formatted.firstDate }}.
-
-[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }})
-
-Responding will take less than 5 minutes. If you do not give consent, it’s still important for you to let us know.
-
-## Your data
-
-By responding, you’re agreeing to your data being processed as set out in our [privacy notice]({{ data.organisation.privacyPolicyUrl }}).
+We would like your consent to vaccinate {{ consent.child.fullName }}. You can give this by filling in our online form (the link is below).
 
 {% for programme in session.programmes %}
 ## About the {{ programme.name | replace("Flu", "flu") }} vaccine
 
-{{ programme.information.audience }}
+{{ programme.information.description }}
 
 [Find out more about the {{ programme.name | replace("Flu", "flu") }} vaccine on NHS.UK]({{ programme.information.url }})
 
 {% if programme.information.leaflet %}
 [Read the patient information leaflet]({{ programme.information.leaflet }})
 {% endif %}
+{% endfor %}
+
+## How to respond
+
+> It’s important to let us know whether you do or do not want your child to have {% if session.programmes.length == 1 %}this vaccination{% else %}these vaccinations{% endif %}. It will take less than 5 minutes to respond using the link below.
+
+[Respond to the consent request]({{ session.consentUrl }})
+
+You need to respond by {{ session.formatted.firstDate }}.
+
+{% if programme.type != ProgrammeType.Flu %}
+## Talk to your child about what they want
+
+We suggest you talk to your child about the {{ vaccine__n }} before you respond to us.
+{% endif %}
+
+## If you cannot use the online form
+
+If you cannot use the online form, you can respond over the phone using the contact details below.
+
+## Your data
+
+By responding, you’re agreeing to your data being processed as set out in our [privacy notice]({{ data.organisation.privacyPolicyUrl }}).
 
 {% if programme.type == ProgrammeType.Flu %}
+## About the nasal spray
+
 The nasal spray contains gelatine. If your child does not use gelatine products, or the nasal spray is not suitable for medical reasons, they could have an injection instead.
 
 The nasal spray gives children the best protection against flu. However, the injected vaccine is a good alternative if the nasal spray vaccine cannot be used.
@@ -46,18 +55,7 @@ The nasal spray gives children the best protection against flu. However, the inj
 
 [Find out more about the use of gelatine in the flu vaccine (including the views of faith communities)](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1107767/UKHSA-12462-vaccines-porcine-gelatine-English.pdf)
 {% endif %}
-{% endfor %}
 
-{% if programme.type != ProgrammeType.Flu %}
-## Talk to your child about what they want
+## Get in touch with us
 
-We suggest you talk to your child about the {{ vaccine__n }} before you respond to us.
-{% endif %}
-
-## If you have trouble using the online form
-
-If you have any trouble using the online form, you can respond over the phone using the contact details below.
-
-## Contact the local health team
-
-Speak to a member of the local health team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -659,11 +659,11 @@ export const en = {
     consent: {
       invite: {
         label: 'Invitation',
-        name: '{{session.vaccinationTitle}} on {{session.summary.dates}}'
+        name: 'Vaccinations on {{session.summary.dates}}'
       },
       'invite-catch-up': {
         label: 'Invitation (catch-up)',
-        name: '{{session.vaccinationTitle}} on {{session.summary.dates}}'
+        name: 'Vaccinations on {{session.summary.dates}}'
       },
       'invite-reminder': {
         label: 'Reminder',
@@ -1689,7 +1689,7 @@ export const en = {
       'capture-could-not-vaccinate': {
         label: 'Could not vaccinate',
         name: 'Child did not get their vaccination despite having consent',
-        text: '{{consent.child.firstName}} did not have their {{session.vaccination}} at school today. This was because {{reason}}.\n\nIf you’d still like them to be vaccinated on a different date, contact the local health team by calling [{{organisation.tel}}](#), or email [{{organisation.email}}](#).'
+        text: '{{consent.child.firstName}} did not have their {{session.vaccination}} at school today. This was because {{reason}}.\n\nIf you’d still like them to be vaccinated on a different date, contact our team by calling [{{organisation.tel}}](#), or email [{{organisation.email}}](#).'
       }
     }
   },

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -41,9 +41,8 @@ export const programmeTypes = {
       title: 'Flu',
       startPage:
         'The vaccination helps to protect children against flu. It also protects others who are vulnerable to flu, such as babies and older people.',
-      description: `The vaccine protects against flu, which can cause serious health problems.`,
-      audience:
-        'By preventing the spread of flu, the vaccine also protects others who are vulnerable, such as babies and older people. The vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so it is recommended to have it again this year.',
+      description:
+        'The vaccine protects against flu, which can cause serious health problems.\n\nBy preventing the spread of flu, the vaccine also protects others who are vulnerable, such as babies and older people. The vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so it is recommended to have it again this year.',
       url: 'https://www.nhs.uk/vaccinations/child-flu-vaccine/'
     },
     term: SchoolTerm.Autumn,
@@ -59,9 +58,8 @@ export const programmeTypes = {
       title: 'Human papillomavirus (HPV)',
       startPage:
         'The HPV vaccine helps to prevent HPV related cancers from developing in boys and girls.\n\nThe number of doses you need depends on your age and how well your immune system works. Young people usually only need 1 dose.',
-      description: `The HPV vaccine helps protect boys and girls against cancers caused by HPV, including:\n- cervical cancer\n- some mouth and throat (head and neck) cancers\n- some cancers of the anal and genital areas`,
-      audience:
-        'The HPV vaccine has been given to girls since 2008. Following its success at helping prevent cervical cancers, it was introduced to boys in 2019 to help prevent HPV-related cancers that affect them.\n\nYoung people usually only need 1 dose.',
+      description:
+        'The HPV vaccine helps protect boys and girls against cancers caused by HPV, including:\n- cervical cancer\n- some mouth and throat (head and neck) cancers\n- some cancers of the anal and genital areas\n\nThe HPV vaccine has been given to girls since 2008. Following its success at helping prevent cervical cancers, it was introduced to boys in 2019 to help prevent HPV-related cancers that affect them.\n\nYoung people usually only need 1 dose.',
       url: 'https://www.nhs.uk/conditions/vaccinations/hpv-human-papillomavirus-vaccine/',
       leaflet: 'https://www.medicines.org.uk/emc/files/pil.7330.pdf'
     },
@@ -78,9 +76,7 @@ export const programmeTypes = {
       startPage:
         'The Td/IPV vaccine (3-in-1 teenage booster) protects against tetanus, diphtheria and polio.\n\nIt boosts the protection provided by the [6-in-1 vaccine](https://www.nhs.uk/vaccinations/6-in-1-vaccine/) and [4-in-1 pre-school booster vaccine](https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/).',
       description:
-        'The Td/IPV vaccine helps protect against:\n- tetanus\n - diptheria\n- polio',
-      audience:
-        'The Td/IPV vaccine (3-in-1 teenage booster) is offered at around 13 or 14 years old (school year 9 or 10). It boosts the protection provided by the [6-in-1 vaccine](https://www.nhs.uk/vaccinations/6-in-1-vaccine/) and [4-in-1 pre-school booster vaccine](https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/).',
+        'The Td/IPV vaccine (3-in-1 teenage booster) helps protect against tetanus, diphtheria and polio.\n\nIt’s offered at around 13 or 14 years old (school year 9 or 10). It boosts the protection provided by the [6-in-1 vaccine](https://www.nhs.uk/vaccinations/6-in-1-vaccine/) and [4-in-1 pre-school booster vaccine](https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/).',
       url: 'https://www.nhs.uk/vaccinations/td-ipv-vaccine-3-in-1-teenage-booster/'
     },
     term: SchoolTerm.Summer,
@@ -96,9 +92,7 @@ export const programmeTypes = {
       startPage:
         'The MenACWY vaccine is recommended for all teenagers. Most people only need one dose of the vaccine.',
       description:
-        'The MenACWY vaccine helps protect against life-threatening illnesses including:\n - meningitis\n- sepsis\n- septicaemia (blood poisoning)',
-      audience:
-        'The MenACWY vaccine is recommended for all teenagers. Most people only need 1 dose of the vaccine.',
+        'The MenACWY vaccine helps protect against life-threatening illnesses including meningitis, sepsis and septicaemia (blood poisoning).\n\nIt is recommended for all teenagers. Most people only need 1 dose of the vaccine.',
       url: 'https://www.nhs.uk/vaccinations/menacwy-vaccine/'
     },
     term: SchoolTerm.Summer,


### PR DESCRIPTION
- Update initial invitation email to:
  - Show all information about each vaccine above the request for consent link
  - Re-order later content in the email
  - Use inset text for the text block above the consent link
- Update the vaccination confirmation email to:
  - increase the number of side effects (need to confirm that this is for all vaccines administered via injection, or only MenACWY and Td/IPV)
  - Use line breaks instead of bullets for vaccination record details (matches what is already live)
- Update all emails to:
  - Change references to ‘local health team’ to ‘our team’