### PR TITLE
Further refinements to parental consent flow 

### DIFF
--- a/app/generators/parent.js
+++ b/app/generators/parent.js
@@ -1,7 +1,6 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
 import {
-  ContactPreference,
   EmailStatus,
   Parent,
   ParentalRelationship,
@@ -68,9 +67,7 @@ export function generateParent(childLastName, isMum) {
     { value: EmailStatus.Technical, weight: 1 }
   ])
 
-  const contactPreference = faker.helpers.arrayElement(
-    Object.values(ContactPreference)
-  )
+  const contactPreference = faker.datatype.boolean(0.2)
 
   return new Parent({
     ...(hasName && { fullName: `${firstName} ${lastName}` }),
@@ -85,9 +82,9 @@ export function generateParent(childLastName, isMum) {
       sms,
       ...(sms && { smsStatus }),
       contactPreference,
-      ...(contactPreference === ContactPreference.Other && {
-        contactPreferenceOther:
-          'Please call 01234 567890 ext 8910 between 9am and 5pm.'
+      ...(contactPreference && {
+        contactPreferenceDetails:
+          'I sometimes have difficulty hearing phone calls, so it’s best to send me a text message.'
       })
     })
   })

--- a/app/generators/record.js
+++ b/app/generators/record.js
@@ -26,7 +26,7 @@ export function generateRecord() {
   // CHIS records provide only a subset of parent data
   delete parent1.sms
   delete parent1.contactPreference
-  delete parent1.contactPreferenceOther
+  delete parent1.contactPreferenceDetails
 
   // Pending changes
   const pendingChanges = {}

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -489,7 +489,7 @@ export const en = {
       title: 'About you',
       label: 'Parent',
       fullName: {
-        label: 'Name'
+        label: 'Full name'
       },
       relationship: {
         label: 'Relationship to child'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -432,7 +432,7 @@ export const en = {
       label: 'Child',
       summary: 'About your child',
       description:
-        'Give the name held on your child’s official school records. If their name has changed, tell us their current name.',
+        'Give the name on your child’s birth certificate. If it’s changed, give the name held by your child’s GP.',
       firstName: {
         label: 'First name'
       },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -509,14 +509,14 @@ export const en = {
         label: "Tick this box if you'd like to get updates by text message"
       },
       contactPreference: {
-        title: 'Phone contact method',
-        hint: 'Tell us if you have specific needs',
-        sms: 'I can only receive text messages',
-        voice: 'I can only receive voice calls',
-        other: 'Other',
-        none: 'I do not have specific needs'
+        title: 'If we need to contact you',
+        label: 'Do you have any communication needs?',
+        yes: 'Yes',
+        no: 'No',
+        description:
+          'Let us know if you have any communication needs you’d like us to be aware of – for example, a hearing or visual impairment.'
       },
-      contactPreferenceOther: {
+      contactPreferenceDetails: {
         label: 'Give details'
       },
       relationshipOther: {
@@ -893,7 +893,7 @@ export const en = {
       label: 'Phone number'
     },
     contactPreference: {
-      label: 'Contact preference'
+      label: 'Communication needs'
     },
     relationshipOther: {
       label: 'Give details',

--- a/app/middleware/enumeration.js
+++ b/app/middleware/enumeration.js
@@ -6,7 +6,6 @@ import { GillickCompetent } from '../models/gillick.js'
 import { MoveSource } from '../models/move.js'
 import { NoticeType } from '../models/notice.js'
 import {
-  ContactPreference,
   EmailStatus,
   ParentalRelationship,
   SmsStatus
@@ -43,7 +42,6 @@ export const enumeration = (request, response, next) => {
   response.locals.CaptureOutcome = CaptureOutcome
   response.locals.ConsentOutcome = ConsentOutcome
   response.locals.ConsentWindow = ConsentWindow
-  response.locals.ContactPreference = ContactPreference
   response.locals.DownloadFormat = DownloadFormat
   response.locals.EmailStatus = EmailStatus
   response.locals.EventType = EventType

--- a/app/models/parent.js
+++ b/app/models/parent.js
@@ -6,17 +6,6 @@ import { formatOther, formatParent, stringToBoolean } from '../utils/string.js'
  * @readonly
  * @enum {string}
  */
-export const ContactPreference = {
-  None: 'No preference',
-  Text: 'Text message',
-  Call: 'Voice call',
-  Other: 'Other'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
 export const ParentalRelationship = {
   Mum: 'Mum',
   Dad: 'Dad',
@@ -60,8 +49,8 @@ export const SmsStatus = {
  * @property {EmailStatus} emailStatus - Email status
  * @property {boolean} sms - Update via SMS
  * @property {SmsStatus} smsStatus - SMS status
- * @property {ContactPreference} [contactPreference] - Preferred contact method
- * @property {string} [contactPreferenceOther] - Other contact method
+ * @property {boolean} [contactPreference] - Preferred contact method
+ * @property {string} [contactPreferenceDetails] - Contact method details
  */
 export class Parent {
   constructor(options) {
@@ -82,11 +71,12 @@ export class Parent {
     this.emailStatus = this?.email && options?.emailStatus
     this.sms = stringToBoolean(options.sms) || false
     this.smsStatus = this?.sms && options?.smsStatus
-    this.contactPreference = options?.contactPreference
-    this.contactPreferenceOther =
-      this.contactPreference === ContactPreference.Other
-        ? options?.contactPreferenceOther
-        : undefined
+    this.contactPreference =
+      stringToBoolean(options?.contactPreference) || false
+
+    if (this.contactPreference) {
+      this.contactPreferenceDetails = options?.contactPreferenceDetails
+    }
   }
 
   /**
@@ -96,10 +86,8 @@ export class Parent {
    */
   get formatted() {
     return {
-      contactPreference: formatOther(
-        this.contactPreferenceOther,
-        this.contactPreference
-      ),
+      contactPreference:
+        this.contactPreferenceDetails || this.contactPreference,
       fullName: this.fullName || 'Name unknown',
       fullNameAndRelationship: formatParent(this, false),
       relationship: formatOther(this.relationshipOther, this.relationship)

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -320,9 +320,11 @@ export class Session {
    */
   get programmes() {
     if (this.context?.programmes && this.programme_pids) {
-      return this.programme_pids.map(
-        (pid) => new Programme(this.context?.programmes[pid], this.context)
-      )
+      return this.programme_pids
+        .sort()
+        .map(
+          (pid) => new Programme(this.context?.programmes[pid], this.context)
+        )
     }
 
     return []

--- a/app/views/parent/form/contact-preference.njk
+++ b/app/views/parent/form/contact-preference.njk
@@ -3,32 +3,28 @@
 {% set title = __("consent.parent.contactPreference.title") %}
 
 {% block form %}
+  {{ heading({
+    title: title
+  }) }}
+
+  {{ __("consent.parent.contactPreference.description") | nhsukMarkdown }}
+
   {{ radios({
     fieldset: {
       legend: {
-        html: heading({
-          classes: "nhsuk-fieldset__legend--l",
-          title: title
-        })
+        text: __("consent.parent.contactPreference.label")
       }
     },
-    hint: { text: __("consent.parent.contactPreference.hint") },
     items: [{
-      text: __("consent.parent.contactPreference.sms")
-    }, {
-      text: __("consent.parent.contactPreference.voice")
-    }, {
-      text: __("consent.parent.contactPreference.other"),
+      text: __("consent.parent.contactPreference.yes"),
       conditional: {
         html: textarea({
-          label: { text: __("consent.parent.contactPreferenceOther.label") },
-          decorate: "consent.parent.contactPreferenceOther"
+          label: { text: __("consent.parent.contactPreferenceDetails.label") },
+          decorate: "consent.parent.contactPreferenceDetails"
         })
       }
     }, {
-      divider: "or"
-    }, {
-      text: __("consent.parent.contactPreference.none")
+      text: __("consent.parent.contactPreference.no")
     }],
     decorate: "consent.parent.contactPreference"
   }) }}

--- a/app/views/parent/form/decision.njk
+++ b/app/views/parent/form/decision.njk
@@ -31,7 +31,7 @@
       {
         text: someLabelText,
         conditional: {
-          html: checkboxes({
+          html: radios({
             fieldset: {
               legend: {
                 text: "Which vaccinations do you give consent for?"

--- a/app/views/reply/show.njk
+++ b/app/views/reply/show.njk
@@ -68,8 +68,8 @@
           tel: {
             href: reply.uri + "/edit/parent"
           },
-          contactPreference: {},
-          sms: {}
+          sms: {},
+          contactPreference: {}
         })
       })
     }) if reply.parent }}


### PR DESCRIPTION
- Update patent ‘Name’ to ‘Full name’ for parent’s name
- Update description text for child’s name
- Use radios instead of checkboxes to select one of the vaccinations
- Sort vaccination programmes alphabetically (MenACWY will always come before Td/IPV)
- Replace contact preference question with options to communicate needs

## Updated question asking about communication needs (in stead of contact preference)

<img width="670" alt="Screenshot of form question asking about communication needs." src="https://github.com/user-attachments/assets/e9349648-f0fd-451b-b196-4f99d9b7646a" />
