### PR TITLE
Give refusal reason if only consenting for one vaccination

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -550,7 +550,8 @@ export const en = {
       no: 'No'
     },
     refusalReason: {
-      title: 'Please tell us why you do not agree',
+      title:
+        'Please tell us why you do not agree to your child having the %s vaccination',
       label: 'Refusal reason'
     },
     refusalReasonDetails: {
@@ -611,7 +612,7 @@ export const en = {
       description: {
         [ReplyDecision.Given]:
           'We’ll send a confirmation once the vaccination has been given.\n\nIf the vaccination does not take place due to illness or absence, we’ll contact you about a catch-up session.',
-        [ReplyDecision.OnlyTdIPV]:
+        [ReplyDecision.OnlyMenACWY]:
           'We’ll send a confirmation once the vaccination has been given.\n\nIf the vaccination does not take place due to illness or absence, we’ll contact you about a catch-up session.',
         [ReplyDecision.OnlyTdIPV]:
           'We’ll send a confirmation once the vaccination has been given.\n\nIf the vaccination does not take place due to illness or absence, we’ll contact you about a catch-up session.',

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -3,6 +3,7 @@ import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 import { isAfter } from 'date-fns'
 import _ from 'lodash'
 
+import { getHealthQuestionKeys } from '../utils/consent.js'
 import {
   removeDays,
   convertIsoDateToObject,
@@ -336,14 +337,7 @@ export class Session {
    * @returns {Array} - Programmes
    */
   get healthQuestionKeys() {
-    const healthQuestionKeys = new Set()
-    for (const vaccine of this.vaccines) {
-      for (const key of vaccine.healthQuestionKeys) {
-        healthQuestionKeys.add(key)
-      }
-    }
-
-    return [...healthQuestionKeys].sort()
+    return getHealthQuestionKeys(this.vaccines)
   }
 
   /**

--- a/app/utils/consent.js
+++ b/app/utils/consent.js
@@ -1,4 +1,24 @@
+import { ProgrammeType } from '../models/programme.js'
+import { ReplyDecision } from '../models/reply.js'
+
 import { kebabToPascalCase, pascalToKebabCase } from './string.js'
+
+/**
+ * Get health question keys
+ *
+ * @param {Array<import('../models/vaccine.js').Vaccine>} vaccines - Vaccine
+ * @returns {Array<string>}
+ */
+export const getHealthQuestionKeys = (vaccines) => {
+  const healthQuestionKeys = new Set()
+  for (const vaccine of vaccines) {
+    for (const key of vaccine.healthQuestionKeys) {
+      healthQuestionKeys.add(key)
+    }
+  }
+
+  return [...healthQuestionKeys].sort()
+}
 
 /**
  * Get health question key from view name
@@ -15,13 +35,38 @@ export const getHealthQuestionKey = (view) => {
  *
  * @param {string} pathPrefix - Path prefix
  * @param {import('../models/session.js').Session} session - Session
+ * @param {ReplyDecision} decision - Reply decision
  * @returns {object} Health question paths
  */
-export const getHealthQuestionPaths = (pathPrefix, session) => {
+export const getHealthQuestionPaths = (pathPrefix, session, decision) => {
   const paths = {}
-  for (const key of session.healthQuestionKeys) {
+
+  // Only get health question paths for vaccines with consent
+  let vaccines
+  switch (decision) {
+    case ReplyDecision.OnlyMenACWY:
+      vaccines = session.vaccines.filter(
+        (vaccine) => vaccine.type !== ProgrammeType.TdIPV
+      )
+      break
+    case ReplyDecision.OnlyTdIPV:
+      vaccines = session.vaccines.filter(
+        (vaccine) => vaccine.type !== ProgrammeType.MenACWY
+      )
+      break
+    default:
+      vaccines = session.vaccines
+  }
+
+  const healthQuestionKeys = getHealthQuestionKeys(vaccines)
+  for (const key of healthQuestionKeys) {
     const slug = pascalToKebabCase(key)
     paths[`${pathPrefix}health-question-${slug}`] = {}
+  }
+
+  // Ask for refusal reason if consent only given for one vaccination
+  if ([ReplyDecision.OnlyMenACWY, ReplyDecision.OnlyTdIPV].includes(decision)) {
+    paths[`${pathPrefix}refusal-reason`] = {}
   }
 
   return paths

--- a/app/views/parent/form/check-answers.njk
+++ b/app/views/parent/form/check-answers.njk
@@ -10,23 +10,89 @@
     title: title
   }) }}
 
-  {{ card({
-    heading: __("consent.decision.summary", { session: session }) | safe,
-    headingClasses: "nhsuk-heading-m",
-    descriptionHtml: summaryList({
-      rows: summaryRows(consent, {
-        decision: {
-          href: editPath + "decision"
-        },
-        refusalReason: {
-          href: editPath + "refusal-reason"
-        },
-        refusalReasonDetails: {
-          href: editPath + "refusal-reason-details"
-        }
+  {% if consent.decision == ReplyDecision.OnlyMenACWY %}
+    {{ card({
+      heading: "Consent for the MenACWY vaccination",
+      headingClasses: "nhsuk-heading-m",
+      descriptionHtml: summaryList({
+        rows: summaryRows(consent, {
+          decision: {
+            value: ReplyDecision.Given,
+            href: editPath + "decision"
+          }
+        })
       })
-    })
-  }) }}
+    }) }}
+
+    {{ card({
+      heading: "Consent for the Td/IPV vaccination",
+      headingClasses: "nhsuk-heading-m",
+      descriptionHtml: summaryList({
+        rows: summaryRows(consent, {
+          decision: {
+            value: ReplyDecision.Refused,
+            href: editPath + "decision"
+          },
+          refusalReason: {
+            href: editPath + "refusal-reason"
+          },
+          refusalReasonDetails: {
+            href: editPath + "refusal-reason-details"
+          }
+        })
+      })
+    }) }}
+  {% elif consent.decision == ReplyDecision.OnlyTdIPV %}
+    {{ card({
+      heading: "Consent for the MenACWY vaccination",
+      headingClasses: "nhsuk-heading-m",
+      descriptionHtml: summaryList({
+        rows: summaryRows(consent, {
+          decision: {
+            value: ReplyDecision.Refused,
+            href: editPath + "decision"
+          },
+          refusalReason: {
+            href: editPath + "refusal-reason"
+          },
+          refusalReasonDetails: {
+            href: editPath + "refusal-reason-details"
+          }
+        })
+      })
+    }) }}
+
+    {{ card({
+      heading: "Consent for the Td/IPV vaccination",
+      headingClasses: "nhsuk-heading-m",
+      descriptionHtml: summaryList({
+        rows: summaryRows(consent, {
+          decision: {
+            value: ReplyDecision.Given,
+            href: editPath + "decision"
+          }
+        })
+      })
+    }) }}
+  {% else %}
+    {{ card({
+      heading: __("consent.decision.summary", { session: session }) | safe,
+      headingClasses: "nhsuk-heading-m",
+      descriptionHtml: summaryList({
+        rows: summaryRows(consent, {
+          decision: {
+            href: editPath + "decision"
+          },
+          refusalReason: {
+            href: editPath + "refusal-reason"
+          },
+          refusalReasonDetails: {
+            href: editPath + "refusal-reason-details"
+          }
+        })
+      })
+    }) }}
+  {% endif %}
 
   {{ card({
     heading: __("consent.child.summary"),
@@ -93,7 +159,7 @@
     descriptionHtml: summaryList({
       classes: "app-summary-list--full-width",
       rows: healthAnswerRows(
-        consent.healthAnswers,
+        consent.healthAnswersForDecision,
         editPath + "health-question-{{key}}"
       )
     })

--- a/app/views/parent/form/decision.njk
+++ b/app/views/parent/form/decision.njk
@@ -38,7 +38,7 @@
               }
             },
             items: programmeItems,
-            decorate: "decisions"
+            decorate: "decision"
           })
         }
       } if programmeItems | length > 1,

--- a/app/views/parent/form/refusal-reason.njk
+++ b/app/views/parent/form/refusal-reason.njk
@@ -1,6 +1,12 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("consent.refusalReason.title") %}
+{% if consent.decision == ReplyDecision.OnlyMenACWY %}
+  {% set title = __("consent.refusalReason.title", "Td/IPV") %}
+{% elif consent.decision == ReplyDecision.OnlyTdIPV %}
+  {% set title = __("consent.refusalReason.title", "MenACWY") %}
+{% else %}
+  {% set title = __("consent.refusalReason.title", programme.name) %}
+{% endif %}
 
 {% block form %}
   {{ radios({


### PR DESCRIPTION
Update parental consent flow so that:
- only ask health questions related to vaccination(s) consent being given for
- ask for refusal reason if only giving consent for one vaccination
- check answers page accounts for mixed consent outcomes
- title for refusal question includes name of vaccination being refused

Fixes
- confirmation screen message for `OnlyMenACWY` decision

## Updated refusal question

Question shown after health questions if giving mixed consent. 

<img width="660" alt="Screenshot 2025-02-05 at 21 00 08" src="https://github.com/user-attachments/assets/adb0f743-8b94-491f-a72f-711b2ae29d20" />

## Check and confirm

Shared decision for both vaccinations:

<img width="670" alt="Screenshot 2025-02-05 at 21 01 23" src="https://github.com/user-attachments/assets/90b4143c-dec5-497f-8f74-c8e576e3e257" />

Refusal for MenACWY:

<img width="670" alt="Screenshot 2025-02-05 at 21 02 14" src="https://github.com/user-attachments/assets/0b819db4-edc6-4965-8c2b-059695c3db59" />

Refusal for Td/IPV:

<img width="670" alt="Screenshot 2025-02-05 at 21 01 08" src="https://github.com/user-attachments/assets/11d7e18b-a0c3-42c0-bb81-ba3821939fb2" />


