### PR TITLE
Further content refinements for doubles

### DIFF
--- a/app/datasets/vaccines.js
+++ b/app/datasets/vaccines.js
@@ -76,7 +76,7 @@ export default {
       'isPregnant'
     ]
   },
-  // 3-in-1 and MenACWY vaccines
+  // 3-in-1 vaccines
   // Possible others: Pediacel, Repevax, Infanrix IPV
   // https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/147952/Green-Book-Chapter-15.pdf
   3664798042948: {
@@ -101,14 +101,15 @@ export default {
       'isMedicated'
     ]
   },
-  // Menveo, Nimenrix and MenQuadfi
+  // MenACWY vaccines
+  // Possible others: Menveo, Nimenrix
   // https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1076053/Meningococcal-greenbook-chapter-22_17May2022.pdf
-  5415062370568: {
-    gtin: '5415062370568',
+  5000283662365: {
+    gtin: '5000283662365',
     type: 'MenACWY',
-    brand: 'Nimenrix',
-    manufacturer: 'Pfizer Ltd',
-    leaflet: 'https://www.medicines.org.uk/emc/files/pil.4118.pdf',
+    brand: 'MenQuadfi',
+    manufacturer: 'Sanofi',
+    leaflet: 'https://www.medicines.org.uk/emc/files/pil.12818.pdf',
     method: 'Injection',
     dose: 0.5,
     healthQuestionKeys: [

--- a/app/datasets/vaccines.js
+++ b/app/datasets/vaccines.js
@@ -6,7 +6,10 @@ export default {
     type: 'Flu',
     brand: 'Fluenz Tetra',
     manufacturer: 'AstraZeneca UK Ltd',
-    leaflet: 'https://www.medicines.org.uk/emc/files/pil.15790.pdf',
+    leaflet: {
+      url: 'https://www.medicines.org.uk/emc/files/pil.15790.pdf',
+      size: '197KB'
+    },
     method: 'Nasal spray',
     dose: 0.2,
     healthQuestionKeys: [
@@ -58,7 +61,10 @@ export default {
     type: 'HPV',
     brand: 'Gardasil 9',
     manufacturer: 'Merck Sharp & Dohme (UK) Ltd',
-    leaflet: 'https://www.medicines.org.uk/emc/files/pil.7330.pdf',
+    leaflet: {
+      url: 'https://www.medicines.org.uk/emc/files/pil.7330.pdf',
+      size: '110KB'
+    },
     method: 'Injection',
     dose: 0.5,
     sequenceLimit: 3,
@@ -84,7 +90,10 @@ export default {
     type: 'TdIPV',
     brand: 'Revaxis',
     manufacturer: 'Sanofi',
-    leaflet: 'https://www.medicines.org.uk/emc/files/pil.5581.pdf',
+    leaflet: {
+      url: 'https://www.medicines.org.uk/emc/files/pil.5581.pdf',
+      size: '2.64MB'
+    },
     method: 'Injection',
     dose: 0.5,
     healthQuestionKeys: [
@@ -109,7 +118,10 @@ export default {
     type: 'MenACWY',
     brand: 'MenQuadfi',
     manufacturer: 'Sanofi',
-    leaflet: 'https://www.medicines.org.uk/emc/files/pil.12818.pdf',
+    leaflet: {
+      url: 'https://www.medicines.org.uk/emc/files/pil.12818.pdf',
+      size: '177KB'
+    },
     method: 'Injection',
     dose: 0.5,
     healthQuestionKeys: [

--- a/app/emails/consent/invite.njk
+++ b/app/emails/consent/invite.njk
@@ -18,7 +18,7 @@ We would like your consent to vaccinate {{ consent.child.fullName }}. You can gi
 [Find out more about the {{ programme.name | replace("Flu", "flu") }} vaccine on NHS.UK]({{ programme.information.url }})
 
 {% if programme.vaccine.leaflet %}
-[Read the patient information leaflet]({{ programme.vaccine.leaflet }})
+[Read the patient information leaflet for the {{ programme.name }} vaccine (PDF, {{ programme.vaccine.leaflet.size }})]({{ programme.vaccine.leaflet.url }})
 {% endif %}
 {% endfor %}
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -434,10 +434,12 @@ export const en = {
       description:
         'Give the name on your child’s birth certificate. If it’s changed, give the name held by your child’s GP.',
       firstName: {
-        label: 'First name'
+        label: 'First name',
+        hint: 'Or given name'
       },
       lastName: {
-        label: 'Last name'
+        label: 'Last name',
+        hint: 'Or family name'
       },
       hasPreferredName: {
         label: 'Do they use a different name in school?',

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -96,7 +96,7 @@ export const programmeTypes = {
     },
     term: SchoolTerm.Summer,
     yearGroups: [9, 10, 11],
-    vaccines: ['5415062370568']
+    vaccines: ['5000283662365']
   }
 }
 

--- a/app/models/vaccine.js
+++ b/app/models/vaccine.js
@@ -79,7 +79,7 @@ export const VaccineMethod = {
  * @property {string} type - Type
  * @property {string} brand - Brand
  * @property {string} manufacturer - Manufacturer
- * @property {string} [leaflet] - Leaflet
+ * @property {object} [leaflet] - Leaflet
  * @property {number} dose - Dosage
  * @property {number} sequenceLimit - Maximum doses in sequence
  * @property {VaccineMethod} method - Method

--- a/app/views/parent/form/child.njk
+++ b/app/views/parent/form/child.njk
@@ -11,11 +11,13 @@
 
   {{ input({
     label: { text: __("consent.child.firstName.label") },
+    hint: { text: __("consent.child.firstName.hint") },
     decorate: "consent.child.firstName"
   }) }}
 
   {{ input({
     label: { text: __("consent.child.lastName.label") },
+    hint: { text: __("consent.child.lastName.hint") },
     decorate: "consent.child.lastName"
   }) }}
 


### PR DESCRIPTION
- Use MenQuadfi vaccine for MenACWY, not Nimenrix
- Include file size when linking to patient information leaflets
- Add hint text for child’s name in parental consent journey