### PR TITLE
Update initial invitation email to include information about Gillick competence

### DIFF
--- a/app/emails/consent/invite-catch-up.njk
+++ b/app/emails/consent/invite-catch-up.njk
@@ -35,7 +35,7 @@ Both vaccines are offered to all young people aged 13 to 15 (in school Years 9 a
 
 If you want your child to get this vaccine at school, you need to give consent by {{ session.formatted.firstDate }}.
 
-[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }})
+[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }}/start)
 
 Responding will take less than 5 minutes. If you do not give consent, it’s still important for you to let us know.
 

--- a/app/emails/consent/invite-clinic-consent.njk
+++ b/app/emails/consent/invite-clinic-consent.njk
@@ -2,7 +2,7 @@ You recently booked {{ consent.child.fullAndPreferredNames }} into a clinic so t
 
 Please give consent for this vaccination ahead of your clinic appointment.
 
-[Give consent for the {{ session.vaccination }}]({{ session.consentUrl }})
+[Give consent for the {{ session.vaccination }}]({{ session.consentUrl }}/start)
 
 ## Get in touch with us
 

--- a/app/emails/consent/invite-reminder.njk
+++ b/app/emails/consent/invite-reminder.njk
@@ -20,7 +20,7 @@ The nasal spray contains gelatine. If your child does not use gelatine products,
 
 ## Please give or refuse consent
 
-[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }})
+[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }}/start)
 
 Responding will take less than 5 minutes. If you do not give consent, it’s still important for you to respond.
 

--- a/app/emails/consent/invite-subsequent-reminder.njk
+++ b/app/emails/consent/invite-subsequent-reminder.njk
@@ -18,7 +18,7 @@ The nasal spray contains gelatine. If your child does not use gelatine products,
 
 ## Please give or refuse consent
 
-[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }})
+[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }}/start)
 
 Responding will take less than 5 minutes.
 

--- a/app/emails/consent/invite.njk
+++ b/app/emails/consent/invite.njk
@@ -26,7 +26,7 @@ We would like your consent to vaccinate {{ consent.child.fullName }}. You can gi
 
 > It’s important to let us know whether you do or do not want your child to have {% if session.programmes.length == 1 %}this vaccination{% else %}these vaccinations{% endif %}. It will take less than 5 minutes to respond using the link below.
 
-[Respond to the consent request]({{ session.consentUrl }})
+[Respond to the consent request]({{ session.consentUrl }}/start)
 
 You need to respond by {{ session.formatted.firstDate }}.
 

--- a/app/emails/consent/invite.njk
+++ b/app/emails/consent/invite.njk
@@ -34,6 +34,11 @@ You need to respond by {{ session.formatted.firstDate }}.
 ## Talk to your child about what they want
 
 We suggest you talk to your child about the {{ vaccine__n }} before you respond to us.
+
+{% if programme.type != ProgrammeType.Flu %}
+Young people who show ‘[Gillick competence](https://www.nhs.uk/conditions/consent-to-treatment/children)’ have a legal right to consent to vaccinations themselves. They also have the right to refuse vaccinations which their parents want them to have. Our team may assess Gillick competence during vaccination sessions.
+{% endif %}
+
 {% endif %}
 
 ## If you cannot use the online form

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1663,7 +1663,7 @@ export const en = {
       invite: {
         label: 'Invitation',
         name: 'Inviting parent to give or refuse consent',
-        text: 'Give or refuse consent for your child’s {{session.vaccination}} by going to [https://give-or-refuse-consent.nhs.uk/{{session.id}}]({{session.consentUrl}}). You need to do this by {{session.formatted.openAt}}.\n\nResponding will take less than 5 minutes.'
+        text: 'Give or refuse consent for your child’s {{session.vaccination}} by going to [https://give-or-refuse-consent.nhs.uk/{{session.id}}]({{session.consentUrl}}/start). You need to do this by {{session.formatted.openAt}}.\n\nResponding will take less than 5 minutes.'
       },
       'invite-clinic': {
         label: 'Clinic booking',
@@ -1683,7 +1683,7 @@ export const en = {
       'invite-reminder': {
         label: 'Reminder',
         name: 'Reminding parent to give or refuse consent',
-        text: 'We recently asked for your consent to vaccinate your child against {{session.immunisation}}.\n\nGo to [https://give-or-refuse-consent.nhs.uk/{{session.id}}]({{session.consentUrl}}) to submit a response. This will take less than 5 minutes.'
+        text: 'We recently asked for your consent to vaccinate your child against {{session.immunisation}}.\n\nGo to [https://give-or-refuse-consent.nhs.uk/{{session.id}}]({{session.consentUrl}}/start) to submit a response. This will take less than 5 minutes.'
       },
       'consent-given': {
         label: 'Consent given',


### PR DESCRIPTION
…and also make sure email and text messages always like to a ‘live’ consent form.