### PR TITLE
Callout important notices on dashboard

### DIFF
--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -1,3 +1,4 @@
+import { Notice } from '../models/notice.js'
 import { UserRole } from '../models/user.js'
 
 export const homeController = {
@@ -9,5 +10,15 @@ export const homeController = {
     } else {
       response.redirect('/dashboard')
     }
+  },
+
+  dashboard(request, response) {
+    const { data } = request.session
+
+    if (data.token?.role === UserRole.ClinicalAdmin) {
+      response.locals.notices = Notice.readAll(data)
+    }
+
+    response.render('views/dashboard')
   }
 }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -751,6 +751,10 @@ export const en = {
       one: '%s notice',
       other: '[0] No notices|%s notices'
     },
+    warning: {
+      one: '%s important notice needs attention',
+      other: '%s important notices need attention'
+    },
     createdAt: {
       label: 'Date'
     },

--- a/app/routes.js
+++ b/app/routes.js
@@ -37,7 +37,7 @@ router.use(internationalisation)
 router.use(flash(), navigation, notification, users)
 router.use(referrer)
 
-router.use('/home', homeRoutes)
+router.use('/', homeRoutes)
 router.use('/account', accountRoutes)
 router.use('/cohorts', cohortRoutes)
 router.use('/consents', consentRoutes)

--- a/app/routes/home.js
+++ b/app/routes/home.js
@@ -4,6 +4,7 @@ import { homeController } from '../controllers/home.js'
 
 const router = express.Router({ strict: true })
 
-router.get('/', homeController.redirect)
+router.get('/home', homeController.redirect)
+router.get('/dashboard', homeController.dashboard)
 
 export const homeRoutes = router

--- a/app/views/dashboard.njk
+++ b/app/views/dashboard.njk
@@ -10,6 +10,13 @@
     title: title
   }) }}
 
+  {{ warningCallout({
+    heading: __("notice.list.title"),
+    HTML: link("/uploads/notices", __n("notice.warning", notices.length), {
+      classes: "nhsuk-link--no-visited-state"
+    }) | nhsukMarkdown
+  }) if notices.length }}
+
   <ul class="nhsuk-grid-row nhsuk-card-group">
     <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
       {{ card({

--- a/app/views/upload/_navigation.njk
+++ b/app/views/upload/_navigation.njk
@@ -28,7 +28,7 @@
       text: (__("upload.notices.label") + " " + count(notices.length)) | safe,
       href: "/uploads/notices",
       current: params.view == "notices"
-    }]
+    } if data.token.role == UserRole.ClinicalAdmin]
   }) }}
 
   <h2 class="nhsuk-heading-m nhsuk-u-visually-hidden">


### PR DESCRIPTION
- Show important notices on dashboard (if there are any, if the user is a nurse)
- Only show important notices in Import section if the user is a nurse

<img width="1160" alt="Screenshot of dashboard with warning callout showing number of important notices that need attention." src="https://github.com/user-attachments/assets/4fad6a66-5abe-4219-a066-0834ec5367a8" />
