### PR TITLE
[WIP] Patient session navigation

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,9 +4,11 @@ import '@colinaut/action-table'
 
 import Autocomplete from './autocomplete.js'
 import { AddAnotherComponent } from './custom-elements/add-another.js'
+import { IsStickyComponent } from './custom-elements/is-sticky.js'
 
 // Register custom elements
 customElements.define('add-another', AddAnotherComponent)
+customElements.define('is-sticky', IsStickyComponent)
 
 // Initiate edge detection
 const $edges = document.querySelectorAll('[data-module="edge"]')

--- a/app/assets/javascripts/custom-elements/is-sticky.js
+++ b/app/assets/javascripts/custom-elements/is-sticky.js
@@ -1,0 +1,41 @@
+export const IsStickyComponent = class extends HTMLElement {
+  constructor() {
+    super()
+    this.stickyElementStyle = null
+    this.stickyElementTop = 0
+
+    this.determineStickyState = this.determineStickyState.bind(this)
+    this.throttledStickyState = this.throttle(this.determineStickyState, 100)
+  }
+
+  connectedCallback() {
+    this.stickyElementStyle = window.getComputedStyle(this)
+    this.stickyElementTop = parseInt(this.stickyElementStyle.top, 10)
+
+    window.addEventListener('scroll', this.throttledStickyState)
+
+    this.determineStickyState()
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener('scroll', this.throttledStickyState)
+  }
+
+  determineStickyState() {
+    const currentTop = this.getBoundingClientRect().top
+    this.dataset.stuck = String(currentTop <= this.stickyElementTop)
+  }
+
+  throttle(callback, limit) {
+    let inThrottle
+    return function () {
+      const args = arguments
+      const context = this
+      if (!inThrottle) {
+        callback.apply(context, args)
+        inThrottle = true
+        setTimeout(() => (inThrottle = false), limit)
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/_grid.scss
+++ b/app/assets/stylesheets/_grid.scss
@@ -16,3 +16,10 @@
     top: 0;
   }
 }
+
+.app-grid-column--sticky-below-secondary-navigation {
+  @include mq($from: desktop) {
+    position: sticky;
+    top: #{nhsuk-spacing(9) + nhsuk-spacing(3)};
+  }
+}

--- a/app/assets/stylesheets/_is-sticky.scss
+++ b/app/assets/stylesheets/_is-sticky.scss
@@ -1,0 +1,6 @@
+is-sticky {
+  display: block;
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}

--- a/app/assets/stylesheets/_patient-banner.scss
+++ b/app/assets/stylesheets/_patient-banner.scss
@@ -25,5 +25,5 @@
 
 .app-patient-banner[data-stuck="true"] {
   border-bottom-color: $color_nhsuk-grey-3;
-  box-shadow: 0 $nhsuk-border-width 0 color.scale($color_nhsuk-grey-4, $alpha: -50%);
+  box-shadow: 0 $nhsuk-border-width 0 color.scale($color_nhsuk-grey-3, $alpha: -50%);
 }

--- a/app/assets/stylesheets/_patient-banner.scss
+++ b/app/assets/stylesheets/_patient-banner.scss
@@ -1,15 +1,5 @@
 @use "sass:color";
 
-.app-body--patient-banner {
-  .nhsuk-breadcrumb {
-    @include nhsuk-responsive-margin(5, "bottom");
-  }
-}
-
-.app-main-wrapper--patient-banner {
-  padding-top: 0;
-}
-
 .app-patient-banner {
   @include nhsuk-responsive-margin(5, "bottom");
   background: $color_nhsuk-grey-5;
@@ -36,16 +26,4 @@
 .app-patient-banner[data-stuck="true"] {
   border-bottom-color: $color_nhsuk-grey-3;
   box-shadow: 0 $nhsuk-border-width 0 color.scale($color_nhsuk-grey-4, $alpha: -50%);
-  padding-top: nhsuk-spacing(3);
-
-  .nhsuk-heading-l {
-    @include nhsuk-responsive-margin(3, "bottom");
-    @include nhsuk-font($size: 22, $weight: bold);
-  }
-
-  .app-secondary-navigation {
-    @include mq($from: tablet) {
-      margin-top: #{nhsuk-spacing(3) * -1};
-    }
-  }
 }

--- a/app/assets/stylesheets/_patient-banner.scss
+++ b/app/assets/stylesheets/_patient-banner.scss
@@ -1,0 +1,51 @@
+@use "sass:color";
+
+.app-body--patient-banner {
+  .nhsuk-breadcrumb {
+    @include nhsuk-responsive-margin(5, "bottom");
+  }
+}
+
+.app-main-wrapper--patient-banner {
+  padding-top: 0;
+}
+
+.app-patient-banner {
+  @include nhsuk-responsive-margin(5, "bottom");
+  background: $color_nhsuk-grey-5;
+  border-bottom: 1px solid $nhsuk-border-color;
+  left: 0;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  right: 0;
+  width: 100vw;
+
+  .app-secondary-navigation {
+    margin: 0;
+  }
+
+  .app-secondary-navigation__list {
+    box-shadow: none;
+
+    @include mq($until: tablet) {
+      margin-left: #{$nhsuk-gutter-half * -1};
+    }
+  }
+}
+
+.app-patient-banner[data-stuck="true"] {
+  border-bottom-color: $color_nhsuk-grey-3;
+  box-shadow: 0 $nhsuk-border-width 0 color.scale($color_nhsuk-grey-4, $alpha: -50%);
+  padding-top: nhsuk-spacing(3);
+
+  .nhsuk-heading-l {
+    @include nhsuk-responsive-margin(3, "bottom");
+    @include nhsuk-font($size: 22, $weight: bold);
+  }
+
+  .app-secondary-navigation {
+    @include mq($from: tablet) {
+      margin-top: #{nhsuk-spacing(3) * -1};
+    }
+  }
+}

--- a/app/assets/stylesheets/_secondary-navigation.scss
+++ b/app/assets/stylesheets/_secondary-navigation.scss
@@ -11,13 +11,6 @@
   }
 }
 
-.app-secondary-navigation--sticky {
-  background-color: $color_nhsuk-grey-5;
-  position: sticky;
-  top: 0;
-  z-index: 99;
-}
-
 .app-secondary-navigation__link {
   @include nhsuk-link-style-default;
   @include nhsuk-link-style-no-visited-state;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -76,6 +76,7 @@ $color_app-dark-orange: color.scale(color.mix($color_nhsuk-red, $color_nhsuk-war
 @import "header";
 @import "heading-group";
 @import "highlight";
+@import "is-sticky";
 @import "list";
 @import "message";
 @import "password-input";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -80,6 +80,7 @@ $color_app-dark-orange: color.scale(color.mix($color_nhsuk-red, $color_nhsuk-war
 @import "list";
 @import "message";
 @import "password-input";
+@import "patient-banner";
 @import "prototype";
 @import "search-input";
 @import "secondary-navigation";

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -15,7 +15,6 @@ import {
   VaccinationSite
 } from '../models/vaccination.js'
 import { today } from '../utils/date.js'
-import { formatNavigationItemWithSecondaryText } from '../utils/string.js'
 
 export const patientSessionController = {
   read(request, response, next) {
@@ -79,10 +78,7 @@ export const patientSessionController = {
     const view = request.path.split('/').at(-1)
     response.locals.navigationItems = [
       ...patientSession.siblingPatientSessions.map((patientSession) => ({
-        text: formatNavigationItemWithSecondaryText(
-          patientSession.programme.name,
-          patientSession.nextActivity
-        ),
+        text: patientSession.programme.name,
         href: activity
           ? `${patientSession.uri}?activity=${activity}`
           : patientSession.uri,
@@ -90,15 +86,7 @@ export const patientSessionController = {
       })),
       ...[
         {
-          text: formatNavigationItemWithSecondaryText(
-            __('patientSession.events.title'),
-            String(
-              __n(
-                'patientSession.events.count',
-                patientSession.auditEvents.length
-              )
-            )
-          ),
+          text: __('patientSession.events.title'),
           href: activity
             ? `${patientSession.uri}/events?activity=${activity}`
             : `${patientSession.uri}/events`,

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -91,7 +91,9 @@ export const sessionController = {
     // Only show patients ready to vaccinate
     if (view === 'record') {
       patientSessions = patientSessions.filter(
-        (patientSession) => patientSession.nextActivity === Activity.Record
+        ({ nextActivity, registration }) =>
+          nextActivity === Activity.Record &&
+          registration === RegistrationOutcome.Present
       )
     }
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1532,7 +1532,8 @@ export const en = {
       information: 'You can register attendance when a session is in progress.'
     },
     record: {
-      label: 'Record'
+      label: 'Record',
+      information: 'You can record vaccinations when a session is in progress.'
     },
     outcome: {
       label: 'Outcome'

--- a/app/middleware/navigation.js
+++ b/app/middleware/navigation.js
@@ -15,7 +15,11 @@ export const navigation = (request, response, next) => {
 
   const organisation = new Organisation(data.organisation)
   const user = new User(data.token)
-  const root = request.path.split('/')[1]
+
+  let root = request.path.split('/')[1]
+  if (root === 'programmes' && request.query.activity) {
+    root = 'sessions'
+  }
 
   const consents = Consent.readAll(data)
   const moves = Move.readAll(data)

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -19,7 +19,6 @@ import {
 import {
   formatLink,
   formatProgrammeStatus,
-  formatTag,
   formatTagWithSecondaryText
 } from '../utils/string.js'
 import { getScreenOutcome, getTriageOutcome } from '../utils/triage.js'

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -113,23 +113,6 @@ export function formatWithSecondaryText(text, secondary) {
 }
 
 /**
- * Format navigation item with optional secondary text
- *
- * @param {string} text - Hyperlink text
- * @param {string} [secondary] - Secondary text
- * @returns {string} HTML navigation text
- */
-export function formatNavigationItemWithSecondaryText(text, secondary) {
-  let html = text
-
-  if (secondary) {
-    html += `<span class="nhsuk-u-secondary-text-color nhsuk-u-font-size-16">${secondary}</span>`
-  }
-
-  return html
-}
-
-/**
  * Format tag
  *
  * @param {object} options - Tag options

--- a/app/views/_layouts/default.njk
+++ b/app/views/_layouts/default.njk
@@ -50,7 +50,7 @@
 {% endblock %}
 
 {% set bodyAttributes = {"data-module": "edge"} %}
-{% set bodyClasses = "app-signed-in" if not public %}
+{% set bodyClasses = bodyClasses + " app-signed-in" if not public %}
 
 {% block header %}
   {{ env(environment) if environment }}

--- a/app/views/patient-session/_navigation.njk
+++ b/app/views/patient-session/_navigation.njk
@@ -3,21 +3,10 @@
 {% from "_macros/secondary-navigation.njk" import secondaryNavigation %}
 
 {% macro patientSessionNavigation(params) %}
-  <is-sticky class="app-patient-banner">
-    <div class="nhsuk-width-container">
-      {{ heading({
-        title: params.patientSession.patient.fullName
-      }) }}
-
-      {{ secondaryNavigation({
-        items: navigationItems
-      }) if navigationItems }}
-    </div>
-  </is-sticky>
-
-  <h2 class="nhsuk-heading-m nhsuk-u-visually-hidden">
-    {{ __("patientSession." + params.view + ".title") }}
-  </h2>
+  {{ heading({
+    title: params.patientSession.patient.fullName,
+    summary: params.patientSession.patient.formatted.yearGroupWithRegistration
+  }) }}
 
   {{ actionList({
     items: [{
@@ -37,4 +26,16 @@
       href: params.patientSession.uri + "/new/vaccination"
     }]
   }) if not params.patientSession.session.isActive and params.patientSession.outcome != PatientOutcome.Vaccinated }}
+
+  <is-sticky class="app-patient-banner">
+    <div class="nhsuk-width-container">
+      {{ secondaryNavigation({
+        items: navigationItems
+      }) if navigationItems }}
+    </div>
+  </is-sticky>
+
+  <h2 class="nhsuk-heading-m nhsuk-u-visually-hidden">
+    {{ __("patientSession." + params.view + ".title") }}
+  </h2>
 {% endmacro %}

--- a/app/views/patient-session/_navigation.njk
+++ b/app/views/patient-session/_navigation.njk
@@ -3,10 +3,21 @@
 {% from "_macros/secondary-navigation.njk" import secondaryNavigation %}
 
 {% macro patientSessionNavigation(params) %}
-  {{ heading({
-    title: params.patientSession.patient.fullName,
-    summary: params.patientSession.patient.formatted.yearGroup
-  }) }}
+  <is-sticky class="app-patient-banner">
+    <div class="nhsuk-width-container">
+      {{ heading({
+        title: params.patientSession.patient.fullName
+      }) }}
+
+      {{ secondaryNavigation({
+        items: navigationItems
+      }) if navigationItems }}
+    </div>
+  </is-sticky>
+
+  <h2 class="nhsuk-heading-m nhsuk-u-visually-hidden">
+    {{ __("patientSession." + params.view + ".title") }}
+  </h2>
 
   {{ actionList({
     items: [{
@@ -26,13 +37,4 @@
       href: params.patientSession.uri + "/new/vaccination"
     }]
   }) if not params.patientSession.session.isActive and params.patientSession.outcome != PatientOutcome.Vaccinated }}
-
-  {{ secondaryNavigation({
-    classes: "app-secondary-navigation--sticky",
-    items: navigationItems
-  }) }}
-
-  <h2 class="nhsuk-heading-m nhsuk-u-visually-hidden">
-    {{ __("patientSession." + params.view + ".title") }}
-  </h2>
 {% endmacro %}

--- a/app/views/patient-session/events.njk
+++ b/app/views/patient-session/events.njk
@@ -2,8 +2,6 @@
 
 {% extends "_layouts/default.njk" %}
 
-{% set bodyClasses = "app-body--patient-banner" %}
-{% set mainClasses = "app-main-wrapper--patient-banner" %}
 {% set title = patient.fullName + " – " + __("patient.events.title") %}
 {% set view = "events" %}
 

--- a/app/views/patient-session/events.njk
+++ b/app/views/patient-session/events.njk
@@ -2,6 +2,8 @@
 
 {% extends "_layouts/default.njk" %}
 
+{% set bodyClasses = "app-body--patient-banner" %}
+{% set mainClasses = "app-main-wrapper--patient-banner" %}
 {% set title = patient.fullName + " – " + __("patient.events.title") %}
 {% set view = "events" %}
 

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -4,9 +4,7 @@
 
 {% extends "_layouts/form.njk" %}
 
-{% set bodyClasses = "app-body--patient-banner" %}
-{% set mainClasses = "app-main-wrapper--patient-banner" %}
-{% set gridColumns = "three-quarters" %}
+{% set gridColumns = "full" %}
 {% set hideConfirmButton = true %}
 {% set title = patient.initials + " – " + session.location.name %}
 
@@ -48,55 +46,39 @@
     view: "show"
   }) }}
 
-  {% set patientDescriptionHtml %}
-    {{ status({
-      text: patient.notice.name,
-      icon: "warning",
-      colour: "blue"
-    }) if patient.notice }}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-three-quarters">
+      {% include "patient-session/_consent.njk" %}
 
-    {{ summaryList({
-      rows: summaryRows(patient, {
-        nhsn: {
-          changeLabel: "the child’s NHS number",
-          href: patient.uri + "/edit/nhsn?referrer=" + patientSession.uri if patient.hasMissingNhsNumber
-        },
-        fullName: {},
-        preferredNames: { value: patient.preferredNames },
-        dob: { value: patient.dobWithAge },
-        gender: {},
-        address: {},
-        school: {},
-        yearGroupWithRegistration: {},
-        gpSurgery: {},
-        parents: {}
-      })
-    }) }}
+      {% if options.canTriage %}
+        {% include "patient-session/_triage.njk" %}
+      {% endif %}
 
-    {{ button({
-      classes: "app-button--secondary nhsuk-u-margin-0",
-      text: __("patient.edit.title"),
-      href: patient.uri + "/edit?referrer=" + referrer
-    }) }}
-  {% endset %}
+      {% if options.canRecord %}
+        {% include "patient-session/_record.njk" %}
+      {% endif %}
 
-  {{ card({
-    heading: __("patient.label"),
-    headingClasses: "nhsuk-heading-m",
-    descriptionHtml: patientDescriptionHtml
-  }) }}
+      {% if options.canOutcome %}
+        {% include "patient-session/_outcome.njk" %}
+      {% endif %}
+    </div>
 
-  {% include "patient-session/_consent.njk" %}
-
-  {% if options.canTriage %}
-    {% include "patient-session/_triage.njk" %}
-  {% endif %}
-
-  {% if options.canRecord %}
-    {% include "patient-session/_record.njk" %}
-  {% endif %}
-
-  {% if options.canOutcome %}
-    {% include "patient-session/_outcome.njk" %}
-  {% endif %}
+    <div class="nhsuk-grid-column-one-quarter app-grid-column--sticky-below-secondary-navigation">
+      {{ heading({
+        classes: "nhsuk-u-margin-top-1",
+        level: 3,
+        size: "s",
+        title: patientSession.patient.fullName
+      }) }}
+      {{ summaryList({
+        classes: "nhsuk-u-margin-bottom-2 nhsuk-summary-list--no-border app-summary-list--full-width",
+        rows: summaryRows(patient, {
+          dob: {},
+          yearGroupWithRegistration: {},
+          gender: {}
+        })
+      }) }}
+      {{ link(patient.uri + "?referrer=" + referrer, "View full child record") | nhsukMarkdown }}
+    </div>
+  </div>
 {% endblock %}

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -4,6 +4,8 @@
 
 {% extends "_layouts/form.njk" %}
 
+{% set bodyClasses = "app-body--patient-banner" %}
+{% set mainClasses = "app-main-wrapper--patient-banner" %}
 {% set gridColumns = "three-quarters" %}
 {% set hideConfirmButton = true %}
 {% set title = patient.initials + " – " + session.location.name %}

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -41,6 +41,8 @@
 
   {% if view == "register" and not session.isActive %}
     {{ __("session.register.information") | nhsukMarkdown }}
+  {% elif view == "record" and not session.isActive %}
+    {{ __("session.record.information") | nhsukMarkdown }}
   {% else %}
     <div class="app-grid-row">
       <div class="app-grid-column-filters">


### PR DESCRIPTION
This PR updates the existing sticky navigation design, removing superfluous content and state from the secondary navigation, while also improving it’s stuck appearance.

Minimal information about the patient is shown in the sidebar, and this also remains persistent as the page is scrolled.

### Initial appearance

<img width="1160" alt="Screenshot 2025-02-26 at 18 25 06" src="https://github.com/user-attachments/assets/f4961aee-b1c2-414a-b935-29b6bc53ac89" />

### Stuck appearance

<img width="1190" alt="Screenshot 2025-02-26 at 18 25 22" src="https://github.com/user-attachments/assets/0edb4bcf-ee99-4584-8428-9e024cdbae45" />
