### PR TITLE
Concurrent programme statuses on session activity views

### DIFF
--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -70,6 +70,25 @@
   }
 }
 
+.app-card--patient {
+  @include nhsuk-responsive-margin(3, "bottom");
+
+  .app-button-group {
+    gap: nhsuk-spacing(2);
+    margin-bottom: nhsuk-spacing(1);
+    margin-top: #{nhsuk-spacing(4) * -1};
+  }
+
+  .nhsuk-card__heading {
+    @include nhsuk-responsive-margin(1, "bottom");
+  }
+
+  .nhsuk-card__content {
+    @include nhsuk-responsive-padding(4);
+    @include nhsuk-responsive-padding(3, "bottom");
+  }
+}
+
 // Card title and actions (borrowed from GOV.UK Summary Card component)
 .app-card__title-wrapper {
   @include nhsuk-responsive-padding(5);

--- a/app/assets/stylesheets/_grid.scss
+++ b/app/assets/stylesheets/_grid.scss
@@ -1,6 +1,8 @@
 // Search filters and results
-.app-grid-row {
-  margin-top: #{nhsuk-spacing(5) * -1};
+.app-grid-column-filters > .nhsuk-card--feature,
+.app-grid-column-results > .nhsuk-card--feature,
+.app-grid-column-results > .nhsuk-warning-callout {
+  margin-top: nhsuk-spacing(3);
 }
 
 @include govuk-grid-row($class: "app-grid-row");

--- a/app/assets/stylesheets/_tag.scss
+++ b/app/assets/stylesheets/_tag.scss
@@ -13,8 +13,11 @@
 }
 
 .nhsuk-tag + .nhsuk-u-secondary-text-color {
-  @include nhsuk-font(16, $line-height: 1.2);
+  @include nhsuk-font(16);
 
-  display: block;
-  margin-top: 12px;
+  margin-left: nhsuk-spacing(2);
+}
+
+.app-tag--attached {
+  margin-right: -1px;
 }

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -111,14 +111,6 @@ export const sessionController = {
     }
 
     // Filters
-    if (session.programmes.length > 1) {
-      response.locals.programmeItems = session.programmes.map((programme) => ({
-        text: programme.name,
-        value: programme.pid,
-        checked: programme.pid === filters.pid
-      }))
-    }
-
     const statusItems = {
       consent: ConsentOutcome,
       triage: TriageOutcome,

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -16,6 +16,7 @@ export const en = {
     label: 'Actions',
     change: 'Change',
     review: 'Review',
+    update: 'Update',
     archive: 'Archive'
   },
   address: {

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -18,7 +18,7 @@ import {
 } from '../utils/reply.js'
 import {
   formatLink,
-  formatLinkWithSecondaryText,
+  formatProgrammeStatus,
   formatTag,
   formatTagWithSecondaryText
 } from '../utils/string.js'
@@ -29,7 +29,6 @@ import { Gillick } from './gillick.js'
 import { Patient } from './patient.js'
 import { Programme } from './programme.js'
 import { Session } from './session.js'
-import { VaccinationOutcome } from './vaccination.js'
 
 /**
  * @readonly
@@ -445,14 +444,7 @@ export class PatientSession {
    */
   get link() {
     return {
-      fullName: formatLink(this.uri, this.patient.fullName),
-      fullAndPreferredName: this.patient.preferredName
-        ? formatLinkWithSecondaryText(
-            this.uri,
-            this.patient.fullName,
-            this.patient.preferredName
-          )
-        : formatLink(this.uri, this.patient.fullName)
+      fullName: formatLink(this.uri, this.patient.fullName)
     }
   }
 
@@ -504,33 +496,38 @@ export class PatientSession {
     return {
       programme: this.programme.nameTag,
       status: {
-        consent: this.reason.consent
-          ? formatTagWithSecondaryText(this.status.consent, this.reason.consent)
-          : formatTag(this.status.consent),
-        triage: this.reason.triage
-          ? formatTagWithSecondaryText(this.status.triage, this.reason.triage)
-          : formatTag(this.status.triage),
-        screen: this.reason.screen
-          ? formatTagWithSecondaryText(this.status.screen, this.reason.screen)
-          : formatTag(this.status.screen),
+        consent: formatProgrammeStatus(
+          this.programme,
+          this.status.consent,
+          this.reason.consent
+        ),
+        screen:
+          this.screen &&
+          formatProgrammeStatus(
+            this.programme,
+            this.status.screen,
+            this.reason.screen
+          ),
         register: formatTagWithSecondaryText(
           this.status.register,
           this.nextActivity
         ),
-        record: this.reason.record
-          ? formatTagWithSecondaryText(this.status.outcome, this.reason.record)
-          : formatTag(this.status.record),
-        outcome: this.reason.outcome
-          ? formatTagWithSecondaryText(
-              this.status.outcome,
-              this.status.record.text
-            )
-          : formatTag(this.status.outcome)
+        record: formatProgrammeStatus(
+          this.programme,
+          this.status.outcome,
+          this.reason.record
+        ),
+        outcome: formatProgrammeStatus(
+          this.programme,
+          this.status.outcome,
+          this.status.record.text
+        )
       },
-      outcome:
-        !this.record || this.record === VaccinationOutcome.Vaccinated
-          ? formatTag(this.outcomeStatus)
-          : formatTagWithSecondaryText(this.outcomeStatus, this.record)
+      outcome: formatProgrammeStatus(
+        this.programme,
+        this.outcomeStatus,
+        this.record
+      )
     }
   }
 

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -136,16 +136,18 @@ export function formatNavigationItemWithSecondaryText(text, secondary) {
  * @param {string} [options.text] - Text
  * @param {string} [options.html] - Text
  * @param {string} [options.colour] - Colour
+ * @param {string} [options.classes] - Classes
  * @returns {string} Formatted HTML
  */
-export function formatTag({ text, html, colour }) {
+export function formatTag({ text, html, colour, classes }) {
   text = html || text
+  classes = ['nhsuk-tag', classes].join(' ')
 
   if (colour) {
-    return `<strong class="nhsuk-tag nhsuk-tag--${colour}">${text}</strong>`
+    return `<strong class="${classes} nhsuk-tag--${colour}">${text}</strong>`
   }
 
-  return `<strong class="nhsuk-tag">${text}</strong>`
+  return `<strong class="${classes}">${text}</strong>`
 }
 
 /**
@@ -163,6 +165,24 @@ export function formatTagWithSecondaryText(tag, secondary) {
   }
 
   return `<span>${html}</span>`
+}
+
+export function formatProgrammeStatus(programme, status, note) {
+  let html = formatTag({
+    classes: 'app-tag--attached',
+    text: programme.name,
+    colour: 'white'
+  })
+
+  if (status) {
+    html += formatTag(status)
+  }
+
+  if (note) {
+    html += `<span class="nhsuk-u-secondary-text-color">${note}</span>`
+  }
+
+  return html
 }
 
 /**

--- a/app/views/_macros/button-group.njk
+++ b/app/views/_macros/button-group.njk
@@ -1,4 +1,4 @@
-{%- from "components/button/macro.njk" import button -%}
+{%- from "x-nhsuk/decorated/button/macro.njk" import button with context %}
 
 {% macro buttonGroup(params) -%}
 {% if params.buttons | removeEmpty | length %}

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -41,17 +41,6 @@
       fieldset: {
         legend: {
           classes: "nhsuk-fieldset__legend--s",
-          text: __("programme.label")
-        }
-      },
-      items: programmeItems,
-      decorate: "pid"
-    }) if programmeItems }}
-
-    {{ radios({
-      fieldset: {
-        legend: {
-          classes: "nhsuk-fieldset__legend--s",
           text: __("patientSession." + params.outcome + ".label")
         }
       },
@@ -70,6 +59,17 @@
       decorate: params.status
     }) if params.status }}
 
+    {{ checkboxes({
+      fieldset: {
+        legend: {
+          classes: "nhsuk-fieldset__legend--s",
+          text: __("patient.yearGroup.label")
+        }
+      },
+      items: yearGroupItems,
+      decorate: "yearGroup"
+    }) if yearGroupItems }}
+
     {% set searchDetailsHtml %}
       {{ dateInput({
         fieldset: {
@@ -80,17 +80,6 @@
         },
         decorate: "dob"
       }) }}
-
-      {{ checkboxes({
-        fieldset: {
-          legend: {
-            classes: "nhsuk-fieldset__legend--s",
-            text: __("patient.yearGroup.label")
-          }
-        },
-        items: yearGroupItems,
-        decorate: "yearGroup"
-      }) if yearGroupItems }}
 
       {{ checkboxes({
         fieldset: {

--- a/app/views/consent/match.njk
+++ b/app/views/consent/match.njk
@@ -55,7 +55,7 @@
 
         {% for patient in results.page %}
           {{ card({
-            classes: "nhsuk-u-margin-bottom-3",
+            classes: "app-card--patient",
             heading: patient.fullName | highlightQuery(data.q),
             headingClasses: "nhsuk-heading-s",
             clickable: true,

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -39,66 +39,6 @@
     html: defaultBatchHtml
   }) if view == "record" and session.defaultBatch.length }}
 
-  {% set patientRows = [] %}
-  {% for patientSession in results.page %}
-    {% set registrationButtonHtml %}
-      <div>
-        {{ button({
-          classes: "app-button--secondary app-button--icon app-button--small",
-          html: icon({
-            icon: "tick",
-            title: __("patientSession.registration.actions.present.title", { patient: patientSession.patient })
-          }),
-          decorate: "patientSession.registration",
-          value: RegistrationOutcome.Present,
-          attributes: {
-            formaction: patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view,
-            formmethod: "post"
-          }
-        }) if patientSession.registration != RegistrationOutcome.Present }}
-        {{ button({
-          classes: "app-button--secondary-warning app-button--icon app-button--small",
-          html: icon({
-            icon: "cross",
-            title: __("patientSession.registration.actions.absent.title", { patient: patientSession.patient })
-          }),
-          decorate: "patientSession.registration",
-          value: RegistrationOutcome.Absent,
-          attributes: {
-            formaction: patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view,
-            formmethod: "post"
-          }
-        }) if patientSession.registration != RegistrationOutcome.Absent }}
-      </div>
-    {% endset %}
-    {% set patientRows = patientRows | push([
-      {
-        header: __("patient.fullName.label"),
-        html: patientSession.link.fullAndPreferredName | replace(patientSession.uri, patientSession.uri + "?activity=" + view) | highlightQuery(data.q),
-        attributes: {
-          "data-filter": patientSession.patient.fullName,
-          "data-sort": patientSession.patient.fullName
-        }
-      },
-      {
-        header: __("patient.yearGroup.label"),
-        html: patientSession.patient.formatted.yearGroupWithRegistration,
-        attributes: {
-          "data-filter": patientSession.patient.yearGroup,
-          "data-sort": patientSession.patient.yearGroup
-        }
-      },
-      {
-        header: __("patientSession." + view + ".label"),
-        html: patientSession.formatted.status[view]
-      },
-      {
-        header: __("patientSession.registration.actions.label"),
-        html: registrationButtonHtml
-      } if view == "register"
-    ]) %}
-  {% endfor %}
-
   {% if view == "register" and not session.isActive %}
     {{ __("session.register.information") | nhsukMarkdown }}
   {% else %}
@@ -118,49 +58,75 @@
           }) | nhsukMarkdown
         }) if session.consents.length }}
 
+        <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-2">Search results</h2>
         {% if patientSessions.length %}
-          {{ actionTable({
-            id: "patient-sessions",
-            sort: "name",
-            heading: __n("patient.count", results.count),
-            responsive: true,
-            panel: true,
-            head: [
-              {
-                text: __("patient.fullName.label"),
-                attributes: {
-                  "data-col": "name"
-                }
-              },
-              {
-                text: __("patient.yearGroup.label"),
-                attributes: {
-                  "data-col": "yearGroup"
-                }
-              },
-              {
-                text: __("patientSession." + view + ".label")
-              },
-              {
-                text: __("patientSession.registration.actions.label"),
-                attributes: {
-                  "no-sort": "no-sort"
-                }
-              } if view == "register"
-            ],
-            rows: patientRows
-          }) }}
+          {{ __("patient.results", { results: results }) | nhsukMarkdown }}
+
+          {% for patientSession in results.page %}
+            {% set statusHtml %}
+            {% if view == "register" %}
+              {{ patientSession.formatted.status.register | safe }}
+            {% else %}
+              {% for patientSession in patientSession.siblingPatientSessions %}
+                {% if patientSession.formatted.status[view] %}
+                  <p>{{ patientSession.formatted.status[view] | safe }}</p>
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+            {% endset %}
+
+            {% set cardDescriptionHtml %}
+              {{ summaryList({
+                rows: summaryRows(patientSession.patient, {
+                  dob: {},
+                  yearGroupWithRegistration: {},
+                  status: {
+                    value: statusHtml,
+                    href: (patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view) if view == "register" and patientSession.registration != RegistrationOutcome.Pending
+                  },
+                  registration: {
+                    label: __("patientSession.registration.actions.label"),
+                    value: registrationButtonHtml
+                  } if view == "register" and patientSession.registration == RegistrationOutcome.Pending
+                })
+              }) }}
+
+              {{ buttonGroup({
+                buttons: [{
+                  classes: "app-button--secondary app-button--small",
+                  text: __("patientSession.registration.actions.present.label"),
+                  decorate: "patientSession.registration",
+                  value: RegistrationOutcome.Present,
+                  attributes: {
+                    "aria-label": __("patientSession.registration.actions.present.title", { patient: patientSession.patient }),
+                    formaction: patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view,
+                    formmethod: "post"
+                  }
+                }, {
+                  classes: "app-button--secondary-warning app-button--small",
+                  text: __("patientSession.registration.actions.absent.label"),
+                  decorate: "patientSession.registration",
+                  value: RegistrationOutcome.Absent,
+                  attributes: {
+                    "aria-label": __("patientSession.registration.actions.absent.title", { patient: patientSession.patient }),
+                    formaction: patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view,
+                    formmethod: "post"
+                  }
+                }]
+              }) if view == "register" and patientSession.registration == RegistrationOutcome.Pending }}
+            {% endset %}
+            {{ card({
+              classes: "app-card--patient",
+              heading: patientSession.patient.fullAndPreferredNames | highlightQuery(data.q),
+              headingClasses: "nhsuk-heading-s",
+              href: patientSession.uri + "?activity=" + activity,
+              descriptionHtml: cardDescriptionHtml
+            }) }}
+          {% endfor %}
 
           {{ govukPagination(pages) }}
-
-          {{ __("patient.results", { results: results }) | nhsukMarkdown }}
         {% else %}
-          {{ card({
-            heading: __n("patient.count", patientSessions.length),
-            headingClasses: "nhsuk-heading-s",
-            feature: true,
-            description: __("patient.search.empty")
-          }) }}
+          {{ __("patient.search.empty") | nhsukMarkdown }}
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
Changes:

- Use cards for patient records
- Show statuses per programme (except for registration)
- Remove programme filter
- Always show year group filter 

## Consent

Where separate statuses may be present, show both:

<img width="1150" alt="Screenshot 2025-02-26 at 15 43 45" src="https://github.com/user-attachments/assets/96f9dfae-09cd-457a-99b2-cb0e41ec7568" />

## Register

For registration, status is for the session so show only one registration status is shown, without a programme name. Additionally:

- Show registration buttons for patients who haven’t registered yet
- When registered, show change link to change the registration status for a child

<img width="1140" alt="Screenshot 2025-02-26 at 15 46 51" src="https://github.com/user-attachments/assets/2044a4a5-4f37-46ca-9946-e3c6e67fbe52" />

