### PR TITLE
Reinstate session programme filters

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -1,3 +1,4 @@
+import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 import _ from 'lodash'
 
 import { formatDate } from './utils/date.js'
@@ -167,6 +168,16 @@ export default (env) => {
    */
   filters.where = (array, key, value) => {
     return array.filter((item) => _.get(item, key) === value)
+  }
+
+  /**
+   * Filter array where array includes value
+   *
+   * @param {Array} array - Array
+   * @param {string} value - Value to check
+   */
+  filters.includes = (array, value) => {
+    return prototypeFilters.arrayOrStringIncludes(array, value)
   }
 
   /**

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -37,6 +37,18 @@
       decorate: "q"
     }) }}
 
+    {{ checkboxes({
+      fieldset: {
+        legend: {
+          classes: "nhsuk-fieldset__legend--s",
+          text: __("programme.label")
+        }
+      },
+      id: "pid",
+      name: "pid",
+      items: programmeItems
+    }) if programmeItems }}
+
     {{ radios({
       fieldset: {
         legend: {

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -82,15 +82,18 @@
 
         {% for patientSession in results.page %}
           {% set statusHtml %}
-          {% if view == "register" %}
-            {{ patientSession.formatted.status.register | safe }}
-          {% else %}
-            {% for patientSession in patientSession.siblingPatientSessions %}
-              {% if patientSession.formatted.status[view] %}
-                <p>{{ patientSession.formatted.status[view] | safe }}</p>
-              {% endif %}
-            {% endfor %}
-          {% endif %}
+            {% if view == "register" %}
+              {{ patientSession.formatted.status.register | safe }}
+            {% else %}
+              {% set pids = data.pids or session.programme_pids %}
+              {% for patientSession in patientSession.siblingPatientSessions %}
+                {% if pids | includes(patientSession.programme_pid) %}
+                  {% if patientSession.formatted.status[view] %}
+                    <p>{{ patientSession.formatted.status[view] | safe }}</p>
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
           {% endset %}
 
           {% set cardDescriptionHtml %}


### PR DESCRIPTION
Reinstate programme filter on session pages.

- Only shows when a session is running for more than one programme
- Statuses are only show for the selected programmes
- If no checkboxes are selected, all programmes are treated as being selected
- Action required on Register tab still shows action required across all programmes

## No programmes selected

<img width="870" alt="Screenshot of session with multiple programmes selected." src="https://github.com/user-attachments/assets/ac94a6c5-329a-43d6-abb2-74516c95a8df" />

## One programme selected

<img width="860" alt="Screenshot of session with one programme selected." src="https://github.com/user-attachments/assets/d1aee486-ca0c-42cd-b3ec-96a81e56937d" />
