### PR TITLE
Refactor pre-screening checks so they can be answered with one question

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1154,13 +1154,18 @@ export const en = {
       label: 'Consent responses'
     },
     preScreen: {
-      label: 'Session pre-screen',
-      questions: {
-        label: '{{patient.firstName}} has confirmed that they:'
+      label: 'Pre-screening checks',
+      description: '{{patient.firstName}} has confirmed that they:',
+      check: {
+        error:
+          'Select if the child has confirmed all pre-screening statements are true',
+        label:
+          '{{patient.firstName}} has confirmed the above statements are true'
       },
       ready: {
         label:
           'Is {{patient.firstName}} ready for their {{programme.name}} vaccination?',
+        hint: 'Pre-screening checks must be completed for vaccination to go ahead',
         yes: 'Yes',
         no: 'No'
       },

--- a/app/models/vaccine.js
+++ b/app/models/vaccine.js
@@ -71,7 +71,7 @@ export const HealthQuestion = {
  * @enum {string}
  */
 export const PreScreenQuestion = {
-  IsWell: 'are feeling well',
+  IsWell: 'are not acutely unwell',
   IsPregnant: 'are not pregnant',
   IsMedicated: 'are not taking any medication which prevents vaccination',
   IsAllergic: 'have no allergies which would prevent vaccination',

--- a/app/views/_layouts/form.njk
+++ b/app/views/_layouts/form.njk
@@ -5,7 +5,7 @@
 {% block content %}
   {{ super() }}
 
-  <form class="nhsuk-grid-row" method="post" novalidate>
+  <form class="nhsuk-grid-row" method="post" novalidate data-validate>
     <div class="nhsuk-grid-column-{{ gridColumns }}">
       {% block form %}
       {% endblock %}

--- a/app/views/patient-session/_record.njk
+++ b/app/views/patient-session/_record.njk
@@ -5,9 +5,24 @@
 }) }}
 
 {% set preScreenDescriptionHtml %}
+{% filter nhsukMarkdown %}
+{{ __("patientSession.preScreen.description", { patient: patient }) }}
+{% for question in programme.vaccine.preScreenQuestions %}
+- {{ question }}
+{%- endfor %}
+{% endfilter %}
+
   {{ checkboxes({
-    items: preScreenQuestionItems,
-    decorate: ["patientSession", "preScreen", "questions"]
+    items: [{
+      text: __("patientSession.preScreen.check.label", { patient: patient })
+    }],
+    decorate: ["patientSession", "preScreen", "check"],
+    validate: {
+      presence: {
+        name: "dave",
+        message: __("patientSession.preScreen.check.error")
+      }
+    }
   }) }}
 
   {{ textarea({
@@ -32,6 +47,9 @@
       {
         text: __("patientSession.preScreen.ready.yes"),
         value: true,
+        hint: {
+          text: __("patientSession.preScreen.ready.hint")
+        },
         conditional: {
           html: radios({
             fieldset: {
@@ -59,7 +77,7 @@
 {% endset %}
 
 {{ card({
-  heading: __("patientSession.preScreen.questions.label", {
+  heading: __("patientSession.preScreen.label", {
     patient: patient
   }),
   headingClasses: "nhsuk-heading-m",


### PR DESCRIPTION
Update pre-screening questions to show a list of questions the nurse should ask (updating ‘unwell’ to be ‘acutely unwell’ to match Green Book guidance). This means that the error state should be easier to understand, and asking only one question will also help during high-volume vaccination campaigns such as seasonal flu.

Includes an example of the error message shown if a vaccination is to be recorded but the checks have not been confirmed.

![Screenshot of updated pre-screening check.](https://github.com/user-attachments/assets/1371590e-ac5b-4c4e-b49d-38c16d32be82)

![Screenshot of error messages for pre-screening-check.](https://github.com/user-attachments/assets/89d9d961-3035-42cb-a447-9e9eccea5a60)

![Screenshot of error summary shown at the top of the page when there are errors for the pre-screening check.](https://github.com/user-attachments/assets/5b2a5ba8-25be-4c34-bb77-87e8eb7cc8a3)

