### PR TITLE
Flu consent journey

### DIFF
--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -123,7 +123,7 @@ export const parentController = {
       },
       [`/${session_id}/${consent_uuid}/new/contact-preference`]: {},
       [`/${session_id}/${consent_uuid}/new/decision`]: {
-        [`/${session_id}/${consent_uuid}/new/consultation`]: {
+        [`/${session_id}/${consent_uuid}/new/refusal-reason`]: {
           data: 'consent.decision',
           value: ReplyDecision.Refused
         }
@@ -136,13 +136,15 @@ export const parentController = {
       ),
       [`/${session_id}/${consent_uuid}/new/check-answers`]: {},
       [`/${session_id}/${consent_uuid}/new/confirmation`]: {},
-      [`/${session_id}/${consent_uuid}/new/consultation`]: {
-        [`/${session_id}/${consent_uuid}/new/refusal-reason`]: {
-          data: 'consent.decision',
-          value: ReplyDecision.Refused
-        }
-      },
       [`/${session_id}/${consent_uuid}/new/refusal-reason`]: {
+        [`/${session_id}/${consent_uuid}/new/method`]: {
+          data: 'consent.refusalReason',
+          value: ReplyRefusal.Gelatine
+        },
+        [`/${session_id}/${consent_uuid}/new/consultation`]: {
+          data: 'consent.refusalReason',
+          value: ReplyRefusal.OutsideSchool
+        },
         [`/${session_id}/${consent_uuid}/new/refusal-reason-details`]: {
           data: 'consent.refusalReason',
           values: [

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -147,7 +147,9 @@ export const replyController = {
 
       const replyNeedsTriage = (reply) => {
         return reply?.healthAnswers
-          ? Object.values(reply.healthAnswers).find((answer) => answer !== '')
+          ? Object.values(reply.healthAnswers).find(
+              (healthAnswer) => healthAnswer.answer !== 'No'
+            )
           : false
       }
 

--- a/app/datasets/health-conditions.js
+++ b/app/datasets/health-conditions.js
@@ -1,213 +1,208 @@
-import { HealthQuestion } from '../models/vaccine.js'
-
 export const healthConditions = {
   adhd: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child was diagnosed with ADHD and has difficulty focusing and paying attention.',
     triageNote:
       'Spoke with parent, child diagnosed with ADHD and takes medication. Vaccinator should be aware of child’s condition and accommodate by allowing extra time for the child to settle, using clear communication and providing a calm environment. Monitor for any adverse reactions during and after vaccine administration.'
   },
   anaemia: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child was diagnosed with anaemia and has low iron levels.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child takes iron supplements to manage their anaemia.',
     triageNote:
       'Spoke with parent, child diagnosed with anaemia and takes iron supplements. Vaccinator needs to be aware and ensure iron levels are monitored during and after vaccine administration.'
   },
   anxietyDisorder: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has an anxiety disorder and experiences excessive worry and fear on a regular basis.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child takes medication to manage their anxiety and prevent panic attacks.',
-    [HealthQuestion.Support]:
+    support:
       'My child becomes extremely anxious in public settings. I’d like for them to be vaccinated in a private space and not rushed through the vaccination.',
     triageNote:
       'Spoke with parent. Child has an anxiety disorder, takes medication to manage it. No medical issues that would impact vaccine administration. It is safe to vaccinate.'
   },
-  asthma: {
-    [HealthQuestion.Asthma]:
-      'My child was diagnosed with asthma a few months ago and it has been quite challenging for them. They have struggled with breathing difficulties and have needed to use their inhaler several times a day.',
-    [HealthQuestion.AsthmaSteroids]:
-      'My child takes medication every day to manage their asthma',
+  asthmaMild: {
+    asthmaSteroids: 'They need to use their inhaler several times a day.',
     triageNote:
       'Spoke with parent. Child has asthma, takes daily medication. Safe to give vaccine'
   },
-  asthmaAndAllergies: {
-    [HealthQuestion.Asthma]:
-      'My child has asthma and multiple allergies, including environmental and food allergies.',
-    [HealthQuestion.AsthmaSteroids]:
-      'My child takes medication to manage their asthma and prevent breathing difficulties. They also carry an EpiPen in case of anaphylactic reactions.',
-    [HealthQuestion.Support]:
+  asthmaSerious: {
+    asthmaSteroids:
+      'Prednisolone 30mg daily for 7 days, prescribed by our GP on last week following an acute exacerbation.',
+    asthmaAdmitted:
+      'Admitted for 3 days in March 2025 due to severe asthma attack. Required high-flow oxygen therapy and was under the care of the respiratory team. Previously admitted to hospital in November 2024 for 5 days',
+    support:
       'My child has a history of anaphylactic reactions and must avoid certain foods and environments to prevent reactions.',
     triageNote:
       'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
   autism: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has autism spectrum disorder and has difficulty with social interactions and communication.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child does not take medication, but receives therapy to help with their autism.',
-    [HealthQuestion.Support]:
+    support:
       'My child becomes extremely anxious in public settings. I’d like for them to be vaccinated in a private space and not rushed through the vaccination.',
     triageNote:
       'Spoke with parent, child has autism spectrum disorder and sensory processing disorder. Child does not take medication but receives therapy. Vaccinator should be aware of child’s conditions, especially the sensory processing disorder, and take extra care during vaccine administration to minimize any discomfort. Monitor for any adverse reactions during and after vaccine administration.'
   },
   badExperience: {
-    [HealthQuestion.PreviousReaction]:
+    previousReaction:
       'My child recently had a bad reaction to a different vaccine.',
-    [HealthQuestion.Support]:
+    support:
       'My child had a bad experience with a vaccine before, I just want to make sure they are comfortable and safe',
     triageNote:
       'I have spoken to the parent and they mentioned that the child had a bad experience with a vaccine before. It is important to ensure the child is comfortable and at ease during the vaccine process. I suggest discussing any concerns with the child and addressing them before proceeding with the vaccine. It is safe to give the vaccine with these measures in place.'
   },
   badReaction: {
-    [HealthQuestion.PreviousReaction]:
+    previousReaction:
       'My child recently had a bad reaction to a different vaccine.',
-    [HealthQuestion.Support]:
+    support:
       'My child recently had a bad reaction to a different vaccine. I just want to make sure we are extra cautious with this.',
     triageNote:
       'Spoke with parent, confirmed bad reaction from previous vaccine. Vaccine was a COVID-19 vaccination and the reaction was swelling at the site of vaccination. Safe to vaccinate with caution. Monitor for adverse reactions post-vaccination.'
   },
   bleedingDisorder: {
-    [HealthQuestion.Bleeding]:
+    bleeding:
       'My child has frequent nose bleeds, but our doctor says its nothing to be worried about.',
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has a bleeding disorder and can easily bruise or bleed.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child takes medication to manage their bleeding disorder and prevent excessive bleeding.',
     triageNote:
       'Spoke with parent, child has bleeding disorder and takes medication to manage. Vaccinator needs to be aware and cautious when administering vaccine to prevent excessive bleeding.'
   },
   chronicIllness: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has a chronic illness and requires ongoing medical treatment.',
-    [HealthQuestion.Immunosuppressant]:
+    immunosuppressant:
       'My child takes immunosuppressant medication to manage their chronic illness and prevent complications.',
-    [HealthQuestion.Support]:
+    support:
       'My child also has a history of hospitalizations due to their chronic illness.',
     triageNote:
       'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
   chronicPain: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has chronic pain due to a previous injury and struggles with discomfort daily.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child takes pain medication to manage their chronic pain and improve their quality of life.',
     triageNote:
       'Spoke with parent, child has chronic pain due to previous injury and takes medication. Vaccinator should be aware of child’s condition and take extra care during vaccine administration to minimize any discomfort. Monitor for any adverse reactions during and after vaccine administration.'
   },
   coeliacDisease: {
-    [HealthQuestion.EggAllergy]:
+    eggAllergy:
       'My child has coeliac disease and must follow a strict gluten-free diet.',
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has coeliac disease and must follow a strict gluten-free diet.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child does not take medication, but follows a strict gluten-free diet to manage their coeliac disease.',
     triageNote:
       'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
   covid19: {
-    [HealthQuestion.HouseholdImmuneSystem]:
+    householdImmuneSystem:
       'Their grandmother lives with us, and has recently got covid.',
     triageNote:
       'Spoke with parent. Child has sufficiently recovered. It is safe to vaccinate'
   },
   depression: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has depression and experiences feelings of sadness and hopelessness on a regular basis.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child takes medication to manage their depression and improve their mood.',
     triageNote:
       'Spoke with parent. Child has depression, takes medication to manage it, has made progress with therapy. No medical issues that would impact vaccine administration. It is safe to vaccinate.'
   },
   diabetes: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has type 1 diabetes and requires daily insulin injections.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child takes insulin injections multiple times a day to manage their diabetes.',
     triageNote: 'Spoke with parent, it is safe to vaccinate'
   },
   dogBite: {
-    [HealthQuestion.RecentTdIpvVaccination]:
+    recentTdIpvVaccination:
       'My child was bitten by a dog last summer and got a Tetanus jab when we visited A&E.'
   },
   dyslexia: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has dyslexia and has difficulty with reading and writing.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child does not take medication, but receives extra support in school to help with their dyslexia.',
     triageNote:
       'Spoke with parent. Child has dyslexia, does not take medication for it, receives extra support in school. No medical issues that would impact vaccine administration. It is safe to vaccinate.'
   },
   eczema: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has eczema and has skin irritation and redness on a regular basis.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child uses topical ointments to manage their eczema and prevent skin irritation.',
     triageNote:
       'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
   epilepsy: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has epilepsy and has seizures on a regular basis.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child takes anti-seizure medication twice a day to manage their epilepsy.',
     triageNote: 'Spoke with parent, it is safe to vaccinate'
   },
   fainting: {
-    [HealthQuestion.PreviousReaction]:
+    previousReaction:
       'My child has a history of fainting after receiving injections.',
-    [HealthQuestion.Support]:
+    support:
       'My child has a history of fainting after receiving injections. I’d like for them to be vaccinated in a private space and not rushed through the vaccination.',
     triageNote:
       'I have spoken to the parent and gathered that the child has a history of fainting after receiving injections. It is recommended to observe the child for 15 minutes after the vaccine is given, to monitor for any adverse reactions. The vaccine can be safely given with this precaution in place.'
   },
   foodAllergy: {
-    [HealthQuestion.Allergy]:
+    allergy:
       'My child has a food allergy to dairy products and had an anaphylactic reaction in the past.',
-    [HealthQuestion.EggAllergy]:
+    eggAllergy:
       'My child has an allergy to dairy products and had an anaphylactic reaction in the past.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child carries an EpiPen with them at all times in case of another reaction.',
     triageNote:
       'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
   heartCondition: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child was born with a heart condition and has had several surgeries to repair it.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child takes medication to manage their heart condition and prevent further issues.',
     triageNote: 'Spoke with parent, it is safe to vaccinate'
   },
   learningDisability: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has a learning disability and has difficulty with reading, writing, and other academic skills.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child does not take medication, but receives extra support in school to help with their learning disability.',
-    [HealthQuestion.Support]:
+    support:
       'My child becomes extremely anxious in public settings. I’d like for them to be vaccinated in a private space and not rushed through the vaccination.',
     triageNote:
       'Vaccinator should be aware of the child’s learning disability and provide appropriate support to ensure a smooth vaccination experience'
   },
   migraines: {
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child suffers from migraines and has severe headaches on a regular basis.',
-    [HealthQuestion.MedicationAllergies]:
+    medicationAllergies:
       'My child takes medication to manage their migraines and prevent headaches.',
     triageNote:
       'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
   nutAllergy: {
-    [HealthQuestion.Allergy]:
+    allergy:
       'My child has a severe nut allergy and has had an anaphylactic reaction in the past. This is something that is extremely important to me and my husband. We make sure to always have an EpiPen on hand and have educated our child about their allergy.',
-    [HealthQuestion.MedicalConditions]:
+    medicalConditions:
       'My child has a severe nut allergy, which is their only existing medical condition that we are aware of.',
     triageNote:
       'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
   surgery: {
-    [HealthQuestion.Support]:
+    support:
       'Our child recently had surgery and is still recovering. We want to make sure it’s safe for them to get the vaccine.',
     triageNote:
       'Spoke with parent. Child has sufficiently recovered. It is safe to vaccinate'

--- a/app/datasets/health-questions.js
+++ b/app/datasets/health-questions.js
@@ -1,0 +1,79 @@
+export const healthQuestions = {
+  aspirin: {
+    label: 'Does the child take regular aspirin?',
+    hint: 'Also known as Salicylate therapy'
+  },
+  allergy: {
+    label: 'Does the child have any severe allergies?',
+    hint: false
+  },
+  asthma: {
+    label: 'Has the child been diagnosed with asthma?',
+    hint: false
+  },
+  asthmaAdmitted: {
+    label: 'Has the child been admitted to intensive care for their asthma?',
+    hint: false
+  },
+  asthmaSteroids: {
+    label:
+      'Has the child taken any oral steroids for their asthma in the last 2 weeks?',
+    hint: 'Include the steroid name, dose and length of course'
+  },
+  bleeding: {
+    label:
+      'Does the child have a bleeding disorder or another medical condition they receive treatment for?',
+    hint: false
+  },
+  eggAllergy: {
+    label:
+      'Has the child ever been admitted to intensive care due an allergic reaction to egg?',
+    hint: false
+  },
+  immunosuppressant: {
+    label: 'Does the child take any immunosuppressant medication?',
+    hint: false
+  },
+  immuneSystem: {
+    label:
+      'Does the child have a disease or treatment that severely affects their immune system?',
+    hint: false
+  },
+  householdImmuneSystem: {
+    label:
+      'Is anyone in the child’s household currently having treatment that severely affects their immune system?',
+    hint: false
+  },
+  medicationAllergies: {
+    label: 'Does the child have any allergies to medication?',
+    hint: false
+  },
+  medicalConditions: {
+    label:
+      'Does the child have any medical conditions for which they receive treatment?',
+    hint: false
+  },
+  previousReaction: {
+    label:
+      'Has the child ever had a severe reaction to any medicines, including vaccines?',
+    hint: false
+  },
+  recentFluVaccination: {
+    label: 'Has the child had a flu vaccination in the last 5 months?',
+    hint: false
+  },
+  recentMenAcwyVaccination: {
+    label:
+      'Has the child had a meningitis (MenACWY) vaccination in the last 5 years?',
+    hint: 'It’s usually given once in Year 9 or 10. Some children may have had it before travelling abroad.'
+  },
+  recentTdIpvVaccination: {
+    label:
+      'Has the child had a tetanus, diphtheria and polio vaccination in the last 5 years?',
+    hint: 'Most children will not have had this vaccination since their 4-in-1 pre-school booster'
+  },
+  support: {
+    label: 'Does the child need extra support during vaccination sessions?',
+    hint: 'For example, they’re autistic, or extremely anxious'
+  }
+}

--- a/app/datasets/vaccines.js
+++ b/app/datasets/vaccines.js
@@ -1,5 +1,4 @@
 import {
-  HealthQuestion,
   PreScreenQuestion,
   VaccineMethod,
   VaccineSideEffect
@@ -25,17 +24,20 @@ export default {
       VaccineSideEffect.Tiredness,
       VaccineSideEffect.AppetiteLoss
     ],
-    healthQuestions: [
-      HealthQuestion.Asthma,
-      HealthQuestion.AsthmaSteroids,
-      HealthQuestion.AsthmaAdmitted,
-      HealthQuestion.RecentFluVaccination,
-      HealthQuestion.ImmuneSystem,
-      HealthQuestion.HouseholdImmuneSystem,
-      HealthQuestion.EggAllergy,
-      HealthQuestion.MedicationAllergies,
-      HealthQuestion.Aspirin
-    ],
+    healthQuestions: {
+      'asthma': {
+        conditional: {
+          'asthmaSteroids': {},
+          'asthmaAdmitted': {}
+        }
+      },
+      'recentFluVaccination': {},
+      'immuneSystem': {},
+      'householdImmuneSystem': {},
+      'eggAllergy': {},
+      'medicationAllergies': {},
+      'aspirin': {}
+    },
     preScreenQuestions: [
       PreScreenQuestion.IsWell,
       PreScreenQuestion.IsMedicated,
@@ -67,11 +69,11 @@ export default {
       VaccineSideEffect.Temperature,
       VaccineSideEffect.Unwell
     ],
-    healthQuestions: [
-      HealthQuestion.Allergy,
-      HealthQuestion.MedicalConditions,
-      HealthQuestion.PreviousReaction
-    ],
+    healthQuestions: {
+      'allergy': {},
+      'medicalConditions': {},
+      'previousReaction': {}
+    },
     preScreenQuestions: [
       PreScreenQuestion.IsWell,
       PreScreenQuestion.IsMedicated,
@@ -100,11 +102,11 @@ export default {
       VaccineSideEffect.SickFeeling,
       VaccineSideEffect.PainArms
     ],
-    healthQuestions: [
-      HealthQuestion.Allergy,
-      HealthQuestion.MedicalConditions,
-      HealthQuestion.PreviousReaction
-    ],
+    healthQuestions: {
+      'allergy': {},
+      'medicalConditions': {},
+      'previousReaction': {}
+    },
     preScreenQuestions: [
       PreScreenQuestion.IsWell,
       PreScreenQuestion.IsPregnant,
@@ -134,12 +136,12 @@ export default {
       VaccineSideEffect.Temperature,
       VaccineSideEffect.Headache
     ],
-    healthQuestions: [
-      HealthQuestion.Bleeding,
-      HealthQuestion.Allergy,
-      HealthQuestion.PreviousReaction,
-      HealthQuestion.RecentTdIpvVaccination
-    ],
+    healthQuestions: {
+      'bleeding': {},
+      'allergy': {},
+      'previousReaction': {},
+      'recentTdIpvVaccination': {}
+    },
     preScreenQuestions: [
       PreScreenQuestion.IsWell,
       PreScreenQuestion.IsPregnant,
@@ -173,12 +175,12 @@ export default {
       VaccineSideEffect.AppetiteLoss,
       VaccineSideEffect.Unwell
     ],
-    healthQuestions: [
-      HealthQuestion.Bleeding,
-      HealthQuestion.Allergy,
-      HealthQuestion.PreviousReaction,
-      HealthQuestion.RecentMenAcwyVaccination
-    ],
+    healthQuestions: {
+      'bleeding': {},
+      'allergy': {},
+      'previousReaction': {},
+      'recentMenAcwyVaccination': {}
+    },
     preScreenQuestions: [
       PreScreenQuestion.IsWell,
       PreScreenQuestion.IsMedicated,

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -550,6 +550,16 @@ export const en = {
       yes: 'Yes, I’m happy for someone to contact me',
       no: 'No'
     },
+    method: {
+      title: 'Your child may be able to have an injection instead',
+      description:
+        'If the nasal spray is not suitable, your child may be able to have an injection instead. This vaccine does not contain gelatine.',
+      label: 'Method',
+      legend: 'Do you agree to them having an injected flu vaccine?',
+      yes: 'Yes, I agree',
+      no: 'No',
+      details: 'Give details'
+    },
     refusalReason: {
       title: 'Please tell us why you do not agree to your child having the %s',
       label: 'Refusal reason',
@@ -560,6 +570,10 @@ export const en = {
       gettingElsewhere: {
         one: ReplyRefusal.GettingElsewhere,
         other: ReplyRefusal.GettingElsewhere.replace('Vaccine', 'Vaccines')
+      },
+      outsideSchool: {
+        one: ReplyRefusal.OutsideSchool,
+        other: ReplyRefusal.OutsideSchool.replace('vaccination', 'vaccinations')
       }
     },
     refusalReasonDetails: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1,3 +1,4 @@
+import { healthQuestions } from '../datasets/health-questions.js'
 import {
   Activity,
   ConsentOutcome,
@@ -591,28 +592,7 @@ export const en = {
       label: 'Answers to health questions',
       yes: 'Yes',
       no: 'No',
-      details: 'Give details',
-      hint: {
-        Allergy: false,
-        Aspirin: 'Also known as Salicylate therapy',
-        Asthma: false,
-        AsthmaSteroids: 'Include the steroid name, dose and length of course',
-        AsthmaAdmitted: false,
-        Bleeding: false,
-        EggAllergy: false,
-        ImmuneSystem: false,
-        Immunosuppressant: false,
-        HouseholdImmuneSystem: false,
-        PreviousReaction: false,
-        MedicalConditions: false,
-        MedicationAllergies: false,
-        RecentFluVaccination: false,
-        RecentMenAcwyVaccination:
-          'It’s usually given once in Year 9 or 10. Some children may have had it before travelling abroad.',
-        RecentTdIpvVaccination:
-          'Most children will not have had this vaccination since their 4-in-1 pre-school booster',
-        Support: 'For example, they’re autistic, or extremely anxious'
-      }
+      details: 'Give details'
     },
     note: {
       label: 'Notes'
@@ -789,6 +769,7 @@ export const en = {
   healthAnswers: {
     label: 'All answers to health questions'
   },
+  healthQuestions,
   home: {
     show: {
       title: 'Home'

--- a/app/models/cohort.js
+++ b/app/models/cohort.js
@@ -9,7 +9,8 @@ import { Programme, ProgrammeType } from './programme.js'
  * @enum {string}
  */
 export const AcademicYear = {
-  Y2024: '2024/25'
+  Y2024: '2024/25',
+  Y2025: '2025/26'
 }
 
 /**

--- a/app/models/consent.js
+++ b/app/models/consent.js
@@ -13,7 +13,9 @@ export class Consent extends Reply {
    * @returns {boolean} - Answers need triage
    */
   get hasAnswersNeedingTriage() {
-    return Object.values(this.healthAnswers).find((answer) => answer)
+    return Object.values(this.healthAnswers).find(
+      (healthAnswer) => healthAnswer.answer === 'Yes'
+    )
   }
 
   /**

--- a/app/models/consent.js
+++ b/app/models/consent.js
@@ -1,3 +1,4 @@
+import { hasAnswersNeedingTriage } from '../utils/reply.js'
 import { formatLinkWithSecondaryText } from '../utils/string.js'
 
 import { Reply } from './reply.js'
@@ -13,9 +14,7 @@ export class Consent extends Reply {
    * @returns {boolean} - Answers need triage
    */
   get hasAnswersNeedingTriage() {
-    return Object.values(this.healthAnswers).find(
-      (healthAnswer) => healthAnswer.answer === 'Yes'
-    )
+    return hasAnswersNeedingTriage(this.healthAnswers)
   }
 
   /**

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -36,7 +36,7 @@ export const programmeTypes = {
   [ProgrammeType.Flu]: {
     id: 'flu',
     name: 'Flu',
-    active: false,
+    active: true,
     information: {
       title: 'Flu',
       startPage:
@@ -53,7 +53,7 @@ export const programmeTypes = {
   [ProgrammeType.HPV]: {
     id: 'hpv',
     name: 'HPV',
-    active: true,
+    active: false,
     information: {
       title: 'Human papillomavirus (HPV)',
       startPage:

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -51,6 +51,7 @@ export const ReplyRefusal = {
   AlreadyGiven: 'Vaccine already received',
   GettingElsewhere: 'Vaccine will be given elsewhere',
   Medical: 'Medical reasons',
+  OutsideSchool: 'Don’t want vaccination in school',
   Personal: 'Personal choice',
   Other: 'Other'
 }

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -35,9 +35,9 @@ export const SchoolYear = {
 }
 
 export const schoolTerms = {
-  [SchoolTerm.Autumn]: { from: '2024-09-03', to: '2024-12-13' },
   [SchoolTerm.Spring]: { from: '2025-01-06', to: '2025-04-11' },
-  [SchoolTerm.Summer]: { from: '2025-04-28', to: '2025-07-21' }
+  [SchoolTerm.Summer]: { from: '2025-04-28', to: '2025-07-21' },
+  [SchoolTerm.Autumn]: { from: '2025-09-03', to: '2025-12-13' }
 }
 
 /**

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -3,7 +3,6 @@ import { default as filters } from '@x-govuk/govuk-prototype-filters'
 import { isAfter } from 'date-fns'
 import _ from 'lodash'
 
-import { HealthQuestion } from '../models/vaccine.js'
 import {
   removeDays,
   convertIsoDateToObject,
@@ -504,20 +503,20 @@ export class Session {
   /**
    * Get health questions for all programme vaccines
    *
-   * @returns {Array<string>} - Health questions
+   * @returns {object} - Health questions
    */
   get healthQuestions() {
-    const healthQuestions = new Set()
+    const healthQuestions = new Map()
     for (const vaccine of this.vaccines) {
-      for (const question of vaccine.healthQuestions) {
-        healthQuestions.add(question)
+      for (const [key, value] of Object.entries(vaccine.healthQuestions)) {
+        healthQuestions.set(key, value)
       }
     }
 
     // Always ask support question last
-    healthQuestions.add(HealthQuestion.Support)
+    healthQuestions.set('support', {})
 
-    return [...healthQuestions]
+    return healthQuestions
   }
 
   /**

--- a/app/models/vaccine.js
+++ b/app/models/vaccine.js
@@ -1,6 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
 import {
+  formatHealthQuestions,
   formatList,
   formatMillilitres,
   formatMonospace
@@ -29,41 +30,6 @@ export const VaccineSideEffect = {
   Temperature: 'a high temperature',
   TemperatureShiver: 'a high temperature, or feeling hot and shivery',
   Unwell: 'generally feeling unwell'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const HealthQuestion = {
-  Aspirin: 'Does the child take regular aspirin?',
-  Allergy: 'Does the child have any severe allergies?',
-  Asthma: 'Has the child been diagnosed with asthma?',
-  AsthmaAdmitted:
-    'Has the child been admitted to intensive care for their asthma?',
-  AsthmaSteroids:
-    'Has the child taken any oral steroids for their asthma in the last 2 weeks?',
-  Bleeding:
-    'Does the child have a bleeding disorder or another medical condition they receive treatment for?',
-  EggAllergy:
-    'Has the child ever been admitted to intensive care due an allergic reaction to egg?',
-  Immunosuppressant: 'Does the child take any immunosuppressant medication?',
-  ImmuneSystem:
-    'Does the child have a disease or treatment that severely affects their immune system?',
-  HouseholdImmuneSystem:
-    'Is anyone in the child’s household currently having treatment that severely affects their immune system?',
-  MedicationAllergies: 'Does the child have any allergies to medication?',
-  MedicalConditions:
-    'Does the child have any medical conditions for which they receive treatment?',
-  PreviousReaction:
-    'Has the child ever had a severe reaction to any medicines, including vaccines?',
-  RecentFluVaccination:
-    'Has the child had a flu vaccination in the last 5 months?',
-  RecentMenAcwyVaccination:
-    'Has the child had a meningitis (MenACWY) vaccination in the last 5 years?',
-  RecentTdIpvVaccination:
-    'Has the child had a tetanus, diphtheria and polio vaccination in the last 5 years?',
-  Support: 'Does the child need extra support during vaccination sessions?'
 }
 
 /**
@@ -101,7 +67,7 @@ export const VaccineMethod = {
  * @property {number} dose - Dosage
  * @property {VaccineMethod} method - Method
  * @property {Array<VaccineSideEffect>} sideEffects - Side effects
- * @property {Array<HealthQuestion>} healthQuestions - Health questions
+ * @property {object} healthQuestions - Health questions
  * @property {Array<PreScreenQuestion>} preScreenQuestions - Pre-screening questions
  */
 export class Vaccine {
@@ -144,6 +110,23 @@ export class Vaccine {
   }
 
   /**
+   * Get flattened health questions (moves sub-questions to top-level)
+   *
+   * @returns {object} - Health questions
+   */
+  get flatHealthQuestions() {
+    return Object.fromEntries(
+      Object.entries(this.healthQuestions).flatMap(([key, value]) => {
+        if (value.conditional) {
+          return [[key, {}], ...Object.entries(value.conditional)]
+        }
+
+        return [[key, value]]
+      })
+    )
+  }
+
+  /**
    * Get formatted values
    *
    * @returns {object} - Formatted values
@@ -151,7 +134,7 @@ export class Vaccine {
   get formatted() {
     return {
       snomed: formatMonospace(this.snomed),
-      healthQuestions: formatList(this.healthQuestions),
+      healthQuestions: formatHealthQuestions(this.healthQuestions),
       preScreenQuestions: formatList(this.preScreenQuestions),
       sideEffects: formatList(this.sideEffects),
       dose: formatMillilitres(this.dose)

--- a/app/utils/reply.js
+++ b/app/utils/reply.js
@@ -242,11 +242,7 @@ export const getHealthAnswers = (vaccine, healthCondition) => {
  * @returns {string} Triage note
  */
 export const getTriageNote = (healthAnswers, healthCondition) => {
-  const hasAnswersNeedingTriage = Object.values(healthAnswers).find(
-    (answer) => answer
-  )
-
-  if (hasAnswersNeedingTriage) {
+  if (hasAnswersNeedingTriage(healthAnswers)) {
     return healthConditions[healthCondition].triageNote
   }
 }
@@ -283,4 +279,21 @@ export const getRefusalReason = (type) => {
   )
 
   return faker.helpers.arrayElement(refusalReasons)
+}
+
+/**
+ * Has health answers needing triage
+ *
+ * @param {object} healthAnswers - Health answers
+ * @returns {boolean} Has health answers needing triage
+ */
+export const hasAnswersNeedingTriage = (healthAnswers) => {
+  // Ignore answer to asthma question, as only its sub-questions get triaged
+  const nonConditionalAnswers = Object.fromEntries(
+    Object.entries(healthAnswers).filter(([key]) => key !== 'asthma')
+  )
+
+  return Object.values(nonConditionalAnswers).find(
+    (answer) => answer.answer === 'Yes'
+  )
 }

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -1,25 +1,27 @@
 import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
+import { healthQuestions } from '../datasets/health-questions.js'
+
 /**
- * kebab-case to PascalCase
+ * kebab-case to camelCase
  *
  * @param {string} string - String to convert
- * @returns {string} PascalCase string
+ * @returns {string} camelCase string
  */
-export function kebabToPascalCase(string) {
-  return string.replace(/(^\w|-\w)/g, (string) =>
-    string.replace(/-/, '').toUpperCase()
-  )
+export function kebabToCamelCase(string) {
+  return string
+    .replace(/(^\w|-\w)/g, (match) => match.replace(/-/, '').toUpperCase())
+    .replace(/^./, (match) => match.toLowerCase())
 }
 
 /**
- * PascalCase to kebab-case
+ * camelCase to kebab-case
  *
  * @param {string} string - String to convert
  * @returns {string} kebab-case string
  */
-export function pascalToKebabCase(string) {
-  return string.replace(/([a-z0–9])([A-Z])/g, '$1-$2').toLowerCase()
+export function camelToKebabCase(string) {
+  return string.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
 }
 
 /**
@@ -35,6 +37,29 @@ export function stringToBoolean(value) {
   }
 
   return typeof value === 'string' ? value === 'true' : value
+}
+
+/**
+ * Format highlight
+ *
+ * @param {object} healthAnswer - Health answer
+ * @param {string} healthAnswer.answer - Yes/No
+ * @param {string} healthAnswer.details - Details for yes answer
+ * @param {string} [healthAnswer.relationship] - Relationship of respondent
+ * @returns {string|Promise<string>} Formatted HTML
+ */
+export function formatHealthAnswer({ answer = 'No', details, relationship }) {
+  let html = relationship
+    ? prototypeFilters.govukMarkdown(
+        [relationship, answer].join(' responded: ')
+      )
+    : prototypeFilters.govukMarkdown(answer)
+
+  if (answer === 'Yes' && details) {
+    html += `\n<blockquote>${String(prototypeFilters.govukMarkdown(details)).replaceAll('govuk-', 'nhsuk-')}</blockquote>`
+  }
+
+  return html
 }
 
 /**
@@ -171,6 +196,21 @@ export function formatProgrammeStatus(programme, status, note) {
   }
 
   return html
+}
+
+export function formatHealthQuestions(questions) {
+  const items = Object.entries(questions).map(([key, question]) => {
+    if (!question.conditional) {
+      return `- ${healthQuestions[key].label}`
+    }
+
+    const subList = Object.keys(question.conditional)
+      .map((conditionalKey) => `  - ${healthQuestions[conditionalKey].label}`)
+      .join('\n')
+    return `- ${healthQuestions[key].label}\n${subList}`
+  })
+
+  return formatMarkdown(items.join('\n'))
 }
 
 /**

--- a/app/views/parent/form/decision.njk
+++ b/app/views/parent/form/decision.njk
@@ -1,6 +1,6 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("consent.decision.title", { session: session }) %}
+{% set title = __("consent.decision.title", { session: session }) | replace("the Flu", "a nasal flu") %}
 
 {% if programmeItems | length == 1 %}
   {% set yesLabelText = __("consent.decision.yes.single") %}

--- a/app/views/parent/form/health-question.njk
+++ b/app/views/parent/form/health-question.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = healthQuestion %}
-{% set hint = __("consent.healthAnswers.hint." + key) %}
+{% set title = __("healthQuestions." + key + ".label") %}
+{% set hint = __("healthQuestions." + key + ".hint") %}
 
 {% block form %}
   {{ radios({
@@ -9,7 +9,7 @@
       legend: {
         html: heading({
           classes: "nhsuk-fieldset__legend--l",
-          title: title
+          title: title | replace('the child', 'your child')
         })
       }
     },
@@ -19,13 +19,13 @@
       conditional: {
         html: textarea({
           label: { text: __("consent.healthAnswers.details") },
-          decorate: ["consent", "healthAnswers", key]
+          decorate: ["consent", "healthAnswers", key, "details"]
         })
-      }
+      } if not hasSubQuestions
     },
     {
       text: __("consent.healthAnswers.no")
     }],
-    decorate: ["healthAnswers", key]
+    decorate: ["consent", "healthAnswers", key, "answer"]
   }) }}
 {% endblock %}

--- a/app/views/parent/form/method.njk
+++ b/app/views/parent/form/method.njk
@@ -1,0 +1,37 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("consent.method.title") %}
+
+{% block form %}
+  {{ heading({
+    title: title
+  }) }}
+
+  {{ __("consent.method.description") | nhsukMarkdown }}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        html: heading({
+          classes: "nhsuk-fieldset__legend--s",
+          title: __("consent.method.legend")
+        })
+      }
+    },
+    items: [{
+      text: __("consent.method.yes"),
+      value: true
+    },
+    {
+      text: __("consent.method.no"),
+      value: false,
+      conditional: {
+        html: input({
+          label: { text: __("consent.method.details") },
+          decorate: "consent.methodOther"
+        })
+      }
+    }],
+    decorate: "consent.method"
+  }) }}
+{% endblock %}

--- a/app/views/parent/form/refusal-reason.njk
+++ b/app/views/parent/form/refusal-reason.njk
@@ -34,6 +34,10 @@
         value: ReplyRefusal.GettingElsewhere
       },
       {
+        text: __n("consent.refusalReason.outsideSchool", vaccinations),
+        value: ReplyRefusal.OutsideSchool
+      },
+      {
         text: ReplyRefusal.Medical
       },
       {

--- a/app/views/reply/form/health-answers.njk
+++ b/app/views/reply/form/health-answers.njk
@@ -2,17 +2,11 @@
 
 {% set title = __("reply.healthAnswers.title") %}
 
-{% block form %}
-  {{ heading({
-    caption: patient.fullName,
-    title: title
-  }) }}
-
-  {% for key, healthQuestion in healthQuestions(programme) %}
+{% macro questions(healthQuestions) %}
+  {% for key, thing in healthQuestions %}
     {{ radios({
-      classes: "nhsuk-radios--inline",
       fieldset: {
-        legend: { text: healthQuestion }
+        legend: { text: __("healthQuestions." + key + ".label") }
       },
       items: [
         {
@@ -20,15 +14,26 @@
           conditional: {
             html: textarea({
               label: { text: __("reply.healthAnswers.details") },
-              decorate: ["reply", "healthAnswers", key]
+              decorate: ["reply", "healthAnswers", key, "details"]
             })
+          } if not programme.vaccine.healthQuestions[key].conditional else {
+            html: questions(programme.vaccine.healthQuestions[key].conditional)
           }
         },
         {
           text: __("reply.healthAnswers.no")
         }
       ],
-      decorate: ["healthAnswers", key]
+      decorate: ["reply", "healthAnswers", key, "answer"]
     }) }}
   {% endfor %}
+{% endmacro %}
+
+{% block form %}
+  {{ heading({
+    caption: patient.fullName,
+    title: title
+  }) }}
+
+  {{ questions(programme.vaccine.healthQuestions) }}
 {% endblock %}

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -21,7 +21,7 @@ import { generateUpload } from '../app/generators/upload.js'
 import { generateUser } from '../app/generators/user.js'
 import { generateVaccination } from '../app/generators/vaccination.js'
 import { Clinic } from '../app/models/clinic.js'
-import { Cohort } from '../app/models/cohort.js'
+import { AcademicYear, Cohort } from '../app/models/cohort.js'
 import { Move, MoveSource } from '../app/models/move.js'
 import { NoticeType } from '../app/models/notice.js'
 import { Organisation } from '../app/models/organisation.js'
@@ -31,7 +31,7 @@ import {
   PatientSession,
   ScreenOutcome
 } from '../app/models/patient-session.js'
-import { programmeTypes } from '../app/models/programme.js'
+import { ProgrammeType, programmeTypes } from '../app/models/programme.js'
 import { SchoolPhase, schoolTerms } from '../app/models/school.js'
 import {
   ConsentWindow,
@@ -131,6 +131,12 @@ const patients = new Map()
 for (const programme of programmes.values()) {
   for (const yearGroup of programme.yearGroups) {
     let cohort = generateCohort(programme, yearGroup, nurse)
+
+    // Flu programme runs in the next academic year
+    if (programme.type === ProgrammeType.Flu) {
+      cohort.year = AcademicYear.Y2025
+    }
+
     cohort = new Cohort(cohort, {
       programmes: Object.fromEntries(programmes),
       records: Object.fromEntries(records)
@@ -236,7 +242,7 @@ const earliestPlannedSchoolSession = [...sessions.values()]
   .sort((a, b) => getDateValueDifference(a.openAt, b.openAt))
   .find((session) => session.isPlanned)
 
-const hasSessionToday = earliestPlannedSchoolSession.dates.find((date) =>
+const hasSessionToday = earliestPlannedSchoolSession?.dates.find((date) =>
   isSameDay(date, today())
 )
 


### PR DESCRIPTION
This PR:

- Rolls over to the 2025/26 academic year
- Reactivates the flu programme
- Deactivates the HPV programme (for reasons of session data size!)
- Changes the refusal consent journey so that a parent is asked if they want to consider a clinic appointment if they select the new ‘Don’t want vaccination in school’ refusal reason
- Adds option to have an injection if the refusal reason is ‘Vaccine contains gelatine’ 

It also:

- Refactors health questions to support those with sub questions
- Answers to sub questions only show if the answer to the parent question is ‘Yes’ 
- Use answers to these sub questions to determine if a child needs triage, but ignore answer to parent question