### PR TITLE
Bulk remove relationships from import

### DIFF
--- a/app/controllers/upload.js
+++ b/app/controllers/upload.js
@@ -33,11 +33,26 @@ export const uploadController = {
   },
 
   show(request, response) {
-    response.render('upload/show')
+    const view = request.params.view || 'show'
+
+    response.render(`upload/${view}`)
   },
 
   list(request, response) {
     response.render(`upload/list`)
+  },
+
+  action(type) {
+    return (request, response) => {
+      const { upload } = response.locals
+      let paths
+
+      if (type === 'bulk remove relationships') {
+        paths = { back: `${upload.uri}/bulk-remove-relationships` }
+      }
+
+      response.render('upload/action', { paths, type })
+    }
   },
 
   new(request, response) {
@@ -170,5 +185,13 @@ export const uploadController = {
     upload.update(request.body.upload, data.wizard)
 
     response.redirect(paths.next)
+  },
+
+  removeRelationships(request, response) {
+    const { __, upload } = response.locals
+
+    request.flash('success', __('upload.removeRelationships.success'))
+
+    response.redirect(upload.uri)
   }
 }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1843,6 +1843,12 @@ export const en = {
       description:
         'Import child, cohort and vaccination records and see important notices'
     },
+    action: {
+      title: 'Are you sure you want to %s?',
+      description: 'This operation cannot be undone.',
+      cancel: 'No, return to import',
+      confirm: 'Yes, %s'
+    },
     recent: {
       label: 'Recent imports',
       title: 'Recent imports'
@@ -1911,6 +1917,18 @@ export const en = {
       errors: {
         invalid: 'The selected file must be a CSV'
       }
+    },
+    removeRelationships: {
+      title: 'Bulk remove relationships',
+      label: 'Bulk remove relationships',
+      description:
+        'If there is a problem in the class list import, you can bulk remove relationships between parents and children.',
+      nonConsenting:
+        'Remove relationships where parents haven’t given consent yet',
+      all: 'Remove relationships for all parents and children',
+      confirm: 'Continue',
+      cancel: 'Cancel',
+      success: 'Relationships removed'
     },
     school: {
       label: 'School',

--- a/app/routes/upload.js
+++ b/app/routes/upload.js
@@ -16,6 +16,12 @@ router.all('/:upload_id/new/:view', upload.readForm)
 router.get('/:upload_id/new/:view', upload.showForm)
 router.post('/:upload_id/new/:view', upload.updateForm)
 
-router.get('/:upload_id', upload.show)
+router.get(
+  '/:upload_id/remove-relationships',
+  upload.action('bulk remove relationships')
+)
+router.post('/:upload_id/remove-relationships', upload.removeRelationships)
+
+router.get('/:upload_id{/:view}', upload.show)
 
 export const uploadRoutes = router

--- a/app/views/upload/action.njk
+++ b/app/views/upload/action.njk
@@ -1,0 +1,25 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("upload.action.title", type) %}
+
+{% block form %}
+  {{ heading({
+    caption: __("upload.show.title", { upload: upload }),
+    title: title
+  }) }}
+
+  {{ __("upload.action.description") | nhsukMarkdown }}
+{% endblock %}
+
+{% block afterForm %}
+  {{ buttonGroup({
+    buttons: [{
+      classes: "nhsuk-button--warning",
+      text: __("upload.action.confirm", type)
+    }],
+    links: [{
+      text: __("upload.action.cancel"),
+      href: upload.uri
+    }]
+  }) }}
+{% endblock %}

--- a/app/views/upload/bulk-remove-relationships.njk
+++ b/app/views/upload/bulk-remove-relationships.njk
@@ -1,0 +1,35 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("upload.removeRelationships.title") %}
+{% set paths = { back: upload.uri } %}
+
+{% block form %}
+  {{ heading({
+    caption: __("upload.show.title", { upload: upload }),
+    title: title
+  }) }}
+
+  {{ __("upload.removeRelationships.description") | nhsukMarkdown }}
+
+  {{ radios({
+    items: [{
+      text: __("upload.removeRelationships.nonConsenting")
+    }, {
+      text: __("upload.removeRelationships.all")
+    }],
+    decorate: "removeRelationships.type"
+  }) }}
+{% endblock %}
+
+{% block afterForm %}
+  {{ buttonGroup({
+    buttons: [{
+      text: __("upload.removeRelationships.confirm"),
+      href: upload.uri + "/remove-relationships"
+    }],
+    links: [{
+      text: __("upload.removeRelationships.cancel"),
+      href: upload.uri
+    }]
+  }) }}
+{% endblock %}

--- a/app/views/upload/show.njk
+++ b/app/views/upload/show.njk
@@ -39,10 +39,8 @@
     {%- endif %}
   </p>
 
-  {{ card({
-    heading: __("upload.show.summary"),
-    headingClasses: "nhsuk-heading-m",
-    descriptionHtml: summaryList({
+  {% set cardDescriptionHtml %}
+    {{ summaryList({
       rows: summaryRows(upload, {
         createdAt: {},
         createdBy: {},
@@ -53,7 +51,15 @@
         devoid: {},
         duplicates: {}
       })
-    })
+    }) }}
+
+    {{ link(upload.uri + "/bulk-remove-relationships", __("upload.removeRelationships.label")) | nhsukMarkdown }}
+  {% endset %}
+
+  {{ card({
+    heading: __("upload.show.summary"),
+    headingClasses: "nhsuk-heading-m",
+    descriptionHtml: cardDescriptionHtml
   }) }}
 
   {% set duplicateRecordRows = [] %}


### PR DESCRIPTION
Adding the journey for bulk removing relationships between parents and children as designed by @rivalee (https://mavis-ops-prototype-5972b8f72f7f.herokuapp.com/import-records) into the prototype. A few changes:

- Moves link to ‘Remove bulk relationships’ to below the summary list on the import page, making this action slightly less prominent
- Adds a standard confirmation page after selecting the type of relationships you want to remove – maybe we need an additional warning here?
- We’ll only enable this for super admins

![Screenshot of import page/](https://github.com/user-attachments/assets/14f38f3b-81f7-4ab4-8182-efa88fed02bc)

![Screenshot showing bulk remove relationship options.](https://github.com/user-attachments/assets/cd5ad593-4194-4aab-82f5-9eb41048c79a)

![Screenshot showing final confirmation.](https://github.com/user-attachments/assets/dce7e479-67e5-4100-a81e-6e00949d562f)

![Screenshot showing success banner on import page.](https://github.com/user-attachments/assets/753ddad5-965c-498b-b72d-096203618dae)
