### PR TITLE
Show introduction to school moves, and provide a link to download records

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1996,7 +1996,9 @@ export const en = {
     list: {
       label: 'School moves',
       title: 'School moves',
-      description: 'Review children who have moved schools'
+      description: 'Review children who have moved schools',
+      introduction:
+        'When imported records or a new consent response indicates that a child has changed school, Mavis flags this as a school move.\n\nYou can then review the new information and confirm the school move or ignore it.'
     },
     show: {
       title: 'Review school move',
@@ -2012,6 +2014,9 @@ export const en = {
         clinic: 'No, keep them in the community clinic',
         school: 'Yes, move them to the upcoming school session'
       }
+    },
+    download: {
+      label: 'Download records'
     },
     ignore: {
       success: '{{move.patient.fullName}}’s school move ignored'

--- a/app/views/move/list.njk
+++ b/app/views/move/list.njk
@@ -10,6 +10,16 @@
     title: title
   }) }}
 
+  <div class="nhsuk-u-reading-width">
+    {{ __("move.list.introduction") | nhsukMarkdown }}
+
+    {{ button({
+      classes: "app-button--secondary",
+      text: __("move.download.label"),
+      href: "#"
+    }) }}
+  </div>
+
   {% set resultRows = [] %}
   {% for move in results.page %}
     {% set resultRows = resultRows | push([


### PR DESCRIPTION
Adding @rivalee’s updates to the School moves landing page (https://mavis-ops-prototype-5972b8f72f7f.herokuapp.com/school-moves) into the prototype.

We now give an introduction to this area of the service, and provide a link to download the records shown.

![Screenshot of updated school moves page.](https://github.com/user-attachments/assets/d65e54b9-2b0d-4ee6-aa09-2edff4652ebf)
