### PR TITLE
Programme session name variables

### DIFF
--- a/app/emails/consent/consent-conflicts.njk
+++ b/app/emails/consent/consent-conflicts.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-You’ve given consent for {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccination }} in school on {{ session.summary.datesDisjunction }}.
+You’ve given consent for {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccinationNames.sentenceCase }} in school on {{ session.summary.datesDisjunction }}.
 
 However, {{ placeholders.refuser }} has refused to give consent for this vaccination.
 

--- a/app/emails/consent/consent-given-changed-school.njk
+++ b/app/emails/consent/consent-given-changed-school.njk
@@ -1,4 +1,4 @@
-You’ve given consent for {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccination }}.
+You’ve given consent for {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccinationNames.sentenceCase }}.
 
 We don’t currently have any sessions scheduled at your child’s school, but this might change. We’ll be in touch again to let you know if we’re returning to the school. If we’re not, we’ll give you a chance to book into a community clinic.
 

--- a/app/emails/consent/consent-given.njk
+++ b/app/emails/consent/consent-given.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-You’ve given consent for {{ consent.child.fullAndPreferredNames }} to get their {{ session.vaccination }} at school. Please let them know what to expect. We’ll confirm once the vaccination has taken place.
+You’ve given consent for {{ consent.child.fullAndPreferredNames }} to get their {{ session.vaccinationNames.sentenceCase }} at school. Please let them know what to expect. We’ll confirm once the vaccination has taken place.
 
 If {{ consent.child.firstName }}’s health changes, or you arrange to have the vaccination elsewhere, please get in touch.
 

--- a/app/emails/consent/consent-needs-triage.njk
+++ b/app/emails/consent/consent-needs-triage.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-You’ve given consent for {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccination }} at {{ session.location.name }}.
+You’ve given consent for {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccinationNames.sentenceCase }} at {{ session.location.name }}.
 
 As you answered ‘yes’ to some of the health questions, we need to check the vaccination is suitable for {{ consent.child.firstName }}. We’ll review your answers and get in touch again soon.
 

--- a/app/emails/consent/consent-no-sessions.njk
+++ b/app/emails/consent/consent-no-sessions.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-You have told us you do not want {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccination }} at {{ session.location.name }}.
+You have told us you do not want {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccinationNames.sentenceCase }} at {{ session.location.name }}.
 
 If you change your mind, please get in touch with us.
 

--- a/app/emails/consent/consent-refused.njk
+++ b/app/emails/consent/consent-refused.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-You have told us you do not want {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccination }} at {{ session.location.name }}.
+You have told us you do not want {{ consent.child.fullAndPreferredNames }} to have their {{ session.vaccinationNames.sentenceCase }} at {{ session.location.name }}.
 
 If you change your mind, please get in touch with us.
 

--- a/app/emails/consent/invite-catch-up.njk
+++ b/app/emails/consent/invite-catch-up.njk
@@ -35,7 +35,7 @@ Both vaccines are offered to all young people aged 13 to 15 (in school Years 9 a
 
 If you want your child to get this vaccine at school, you need to give consent by {{ session.formatted.firstDate }}.
 
-[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }}/start)
+[Give or refuse consent for the {{ session.vaccinationNames.sentenceCase }}]({{ session.consentUrl }}/start)
 
 Responding will take less than 5 minutes. If you do not give consent, it’s still important for you to let us know.
 

--- a/app/emails/consent/invite-clinic-consent.njk
+++ b/app/emails/consent/invite-clinic-consent.njk
@@ -1,8 +1,8 @@
-You recently booked {{ consent.child.fullAndPreferredNames }} into a clinic so they can get their {{ session.vaccination }}.
+You recently booked {{ consent.child.fullAndPreferredNames }} into a clinic so they can get their {{ session.vaccinationNames.sentenceCase }}.
 
 Please give consent for this vaccination ahead of your clinic appointment.
 
-[Give consent for the {{ session.vaccination }}]({{ session.consentUrl }}/start)
+[Give consent for the {{ session.vaccinationNames.sentenceCase }}]({{ session.consentUrl }}/start)
 
 ## Get in touch with us
 

--- a/app/emails/consent/invite-clinic-reminder.njk
+++ b/app/emails/consent/invite-clinic-reminder.njk
@@ -1,4 +1,4 @@
-It’s not too late to book an {{ session.vaccination }} for {{ consent.child.fullAndPreferredNames }}.
+It’s not too late to book an {{ session.vaccinationNames.sentenceCase }} for {{ consent.child.fullAndPreferredNames }}.
 
 You can book a slot in a clinic by going to <https://www.swiftqueue.co.uk/userlogin.php>
 

--- a/app/emails/consent/invite-clinic.njk
+++ b/app/emails/consent/invite-clinic.njk
@@ -1,4 +1,4 @@
-Our records show that {{ consent.child.fullAndPreferredNames }} has not had their {{ session.vaccination }} yet.
+Our records show that {{ consent.child.fullAndPreferredNames }} has not had their {{ session.vaccinationNames.sentenceCase }} yet.
 
 If you’d like them to have this at a clinic, you can book a slot by going to <https://www.swiftqueue.co.uk/userlogin.php>
 

--- a/app/emails/consent/invite-reminder.njk
+++ b/app/emails/consent/invite-reminder.njk
@@ -1,11 +1,11 @@
 We wrote to you recently about a visit by our team to {{ session.location.name }} on {{ session.summary.dates }}.
 
-If you want your child to get the {{ session.vaccination }}, you need to give consent by {{ session.formatted.closeAt }}.
+If you want your child to get the {{ session.vaccinationNames.sentenceCase }}, you need to give consent by {{ session.formatted.closeAt }}.
 
 If you’ve already responded to the consent request, you can ignore this message.
 
 {% for programme in session.programmes %}
-## About the {{ programme.name | replace("Flu", "flu") }} vaccine
+## About the {{ programme.vaccineName.sentenceCase }}
 
 {{ programme.information.description }}
 
@@ -15,19 +15,19 @@ The vaccination is a quick and painless spray up the nose. Even if your child ha
 The nasal spray contains gelatine. If your child does not use gelatine products, they could have an injection instead.
 {% endif %}
 
-[Find out more about the {{ programme.name | replace("Flu", "flu") }} vaccine on NHS.UK]({{ programme.information.url }})
+[Find out more about the {{ programme.vaccineName.sentenceCase }} on NHS.UK]({{ programme.information.url }})
 {% endfor %}
 
 ## Please give or refuse consent
 
-[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }}/start)
+[Give or refuse consent for the {{ session.vaccinationNames.sentenceCase }}]({{ session.consentUrl }}/start)
 
 Responding will take less than 5 minutes. If you do not give consent, it’s still important for you to respond.
 
 {% if programme.type != ProgrammeType.Flu %}
 ## Talk to your child about what they want
 
-We suggest you talk to your child about the {{vaccine__n}} before you respond to us.
+We suggest you talk to your child about the {{ vaccine__n }} before you respond to us.
 
 {% endif %}
 

--- a/app/emails/consent/invite-subsequent-reminder.njk
+++ b/app/emails/consent/invite-subsequent-reminder.njk
@@ -1,9 +1,9 @@
-Our team are coming back to {{ session.location.name }} on {{ session.summary.dates }} to give the {{ session.vaccination }}.
+Our team are coming back to {{ session.location.name }} on {{ session.summary.dates }} to give the {{ session.vaccinationNames.sentenceCase }}.
 
 If you want your child to be vaccinated in school, you need to give your consent.
 
 {% for programme in session.programmes %}
-## About the {{ programme.name | replace("Flu", "flu") }} vaccine
+## About the {{ programme.vaccineName.sentenceCase }}
 
 {{ programme.information.description }}
 
@@ -13,12 +13,12 @@ The vaccination is a quick and painless spray up the nose. Even if your child ha
 The nasal spray contains gelatine. If your child does not use gelatine products, they could have an injection instead.
 {% endif %}
 
-[Find out more about the {{ programme.name | replace("Flu", "flu") }} vaccine on NHS.UK]({{ programme.information.url }})
+[Find out more about the {{ programme.vaccineName.sentenceCase }} on NHS.UK]({{ programme.information.url }})
 {% endfor %}
 
 ## Please give or refuse consent
 
-[Give or refuse consent for the {{ session.vaccination }}]({{ session.consentUrl }}/start)
+[Give or refuse consent for the {{ session.vaccinationNames.sentenceCase }}]({{ session.consentUrl }}/start)
 
 Responding will take less than 5 minutes.
 

--- a/app/emails/consent/invite.njk
+++ b/app/emails/consent/invite.njk
@@ -1,10 +1,10 @@
 {% if session.programmes.length == 1 %}
-We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to offer the {{ session.programmes[0].information.title }} vaccine to your child.
+We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to offer the {{ session.programmes[0].title }} vaccine to your child.
 {% else %}
 We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to offer the following vaccines to your child:
 
 {% for programme in session.programmes %}
-- {{ programme.information.title }}
+- {{ programme.title }}
 {%- endfor %}
 {% endif %}
 

--- a/app/emails/consent/invite.njk
+++ b/app/emails/consent/invite.njk
@@ -1,5 +1,5 @@
 {% if session.programmes.length == 1 %}
-We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to offer the {{ session.programmes[0].title }} vaccine to your child.
+We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to offer the {{ session.programmeNames.sentenceCase }} vaccine to your child.
 {% else %}
 We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to offer the following vaccines to your child:
 
@@ -11,14 +11,14 @@ We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to 
 We would like your consent to vaccinate {{ consent.child.fullName }}. You can give this by filling in our online form (the link is below).
 
 {% for programme in session.programmes %}
-## About the {{ programme.name | replace("Flu", "flu") }} vaccine
+## About the {{ programme.vaccineName.sentenceCase }}
 
 {{ programme.information.description }}
 
-[Find out more about the {{ programme.name | replace("Flu", "flu") }} vaccine on NHS.UK]({{ programme.information.url }})
+[Find out more about the {{ programme.vaccineName.sentenceCase }} on NHS.UK]({{ programme.information.url }})
 
 {% if programme.vaccine.leaflet %}
-[Read the patient information leaflet for the {{ programme.name }} vaccine (PDF, {{ programme.vaccine.leaflet.size }})]({{ programme.vaccine.leaflet.url }})
+[Read the patient information leaflet for the {{ programme.vaccineName.sentenceCase }} (PDF, {{ programme.vaccine.leaflet.size }})]({{ programme.vaccine.leaflet.url }})
 {% endif %}
 {% endfor %}
 

--- a/app/emails/consent/record-could-not-vaccinate.njk
+++ b/app/emails/consent/record-could-not-vaccinate.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-{{ consent.child.fullAndPreferredNames }} did not get their {{ session.vaccination }} at {{ session.location.name }} today. This was because {{ placeholders.reason }}.
+{{ consent.child.fullAndPreferredNames }} did not get their {{ session.vaccinationNames.sentenceCase }} at {{ session.location.name }} today. This was because {{ placeholders.reason }}.
 
 If you’d still like your child to have a vaccination, you can book a slot at a catch-up clinic by contacting our team.
 

--- a/app/emails/consent/record-reminder.njk
+++ b/app/emails/consent/record-reminder.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-This is a quick reminder that {{ consent.child.fullAndPreferredNames }} may get their {{ session.vaccination }} at {{ session.location.name }} on {{ session.summary.firstDate }}. If they’re not seen, they’ll be offered the vaccination on {{ session.summary.remainingDates }}.
+This is a quick reminder that {{ consent.child.fullAndPreferredNames }} may get their {{ session.vaccinationNames.sentenceCase }} at {{ session.location.name }} on {{ session.summary.firstDate }}. If they’re not seen, they’ll be offered the vaccination on {{ session.summary.remainingDates }}.
 
 If you haven’t already told {{ consent.child.firstName }} that they’ll be vaccinated, please let them know what to expect.
 

--- a/app/emails/consent/record-vaccinated-many.njk
+++ b/app/emails/consent/record-vaccinated-many.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-{{ consent.child.fullAndPreferredNames }} had their {{ session.vaccination }} at {{ session.location.name }} today.{% if data.schools[session.school_urn].phase == "Primary" %} They were very brave.{% endif %}
+{{ consent.child.fullAndPreferredNames }} had their {{ session.vaccinationNames.sentenceCase }} at {{ session.location.name }} today.{% if data.schools[session.school_urn].phase == "Primary" %} They were very brave.{% endif %}
 
 We suggest you record the following details {% if data.schools[session.school_urn].phase == "Primary" %}in their red book (also known as their personal child health record){% else %}somewhere{% endif %}:
 

--- a/app/emails/consent/triage-delay-vaccination.njk
+++ b/app/emails/consent/triage-delay-vaccination.njk
@@ -1,4 +1,4 @@
-Having looked at the answers you gave to the health questions about {{ consent.child.fullAndPreferredNames }}, our nursing team has decided it would be better for {{ consent.child.firstName }} to have the {{ session.vaccination }} in a clinic rather than at school.
+Having looked at the answers you gave to the health questions about {{ consent.child.fullAndPreferredNames }}, our nursing team has decided it would be better for {{ consent.child.firstName }} to have the {{ session.vaccinationNames.sentenceCase }} in a clinic rather than at school.
 
 You can book a slot by going to <https://www.swiftqueue.co.uk/userlogin.php>
 

--- a/app/emails/consent/triage-do-not-vaccinate.njk
+++ b/app/emails/consent/triage-do-not-vaccinate.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-Having looked at the answers you gave to the health questions about {{ consent.child.fullAndPreferredNames }}, our nursing team has decided that {{ consent.child.firstName }} cannot have the {{ session.vaccination }} at school.
+Having looked at the answers you gave to the health questions about {{ consent.child.fullAndPreferredNames }}, our nursing team has decided that {{ consent.child.firstName }} cannot have the {{ session.vaccinationNames.sentenceCase }} at school.
 
 Please get in touch with our team to discuss what {{ consent.child.firstName }} might be able to have instead. You can call {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
 

--- a/app/emails/consent/triage-vaccinate.njk
+++ b/app/emails/consent/triage-vaccinate.njk
@@ -1,6 +1,6 @@
 Dear {{ consent.parent.fullName }},
 
-Thanks for answering the health questions about {{ consent.child.fullAndPreferredNames }}. Our nurses have confirmed it’s safe for Jamie to have the {{ session.vaccination }}.
+Thanks for answering the health questions about {{ consent.child.fullAndPreferredNames }}. Our nurses have confirmed it’s safe for Jamie to have the {{ session.vaccinationNames.sentenceCase }}.
 
 This will take place at {{ session.location.name }} on {{ session.summary.datesDisjunction }}.
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -208,7 +208,8 @@ export const en = {
     },
     unselect: {
       confirm: 'Remove from cohort',
-      success: '{{patient.fullName}} removed from {{cohort.name}} cohort'
+      success:
+        '{{patient.fullName}} removed from {{cohort.name.sentenceCase}} cohort'
     },
     patients: {
       count: {
@@ -381,10 +382,12 @@ export const en = {
     },
     start: {
       title: {
-        single: 'Give or refuse consent for a %s',
-        multiple: 'Give or refuse consent for the %s'
+        single:
+          'Give or refuse consent for a {{session.vaccinationNames.sentenceCase}}',
+        multiple:
+          'Give or refuse consent for the {{session.vaccinationNames.sentenceCase}}'
       },
-      more: `Find out more about the {{programme.name}} vaccine`,
+      more: `Find out more about the {{programme.vaccineName.sentenceCase}}`,
       confirm: {
         title: 'Give or refuse consent',
         buttonText: 'Start now'
@@ -516,9 +519,9 @@ export const en = {
       label: 'Programme'
     },
     decision: {
-      summary: 'Consent for the {{session.vaccination}}',
+      summary: 'Consent for the {{session.vaccinationNames.sentenceCase}}',
       title:
-        'Do you agree to your child having the {{session.vaccinationTitle}}?',
+        'Do you agree to your child having the {{session.vaccinationNames.sentenceCase}}?',
       label: 'Decision',
       hint: {
         Flu: 'The nasal flu spray contains gelatine which comes from pigs.'
@@ -562,7 +565,8 @@ export const en = {
       details: 'Give details'
     },
     refusalReason: {
-      title: 'Please tell us why you do not agree to your child having the %s',
+      title:
+        'Please tell us why you do not agree to your child having the {{session.vaccinationNames.sentenceCase}}',
       label: 'Refusal reason',
       alreadyGiven: {
         one: ReplyRefusal.AlreadyGiven,
@@ -611,19 +615,19 @@ export const en = {
       },
       text: {
         [ReplyDecision.Given]:
-          '{{consent.child.fullName}} is due to get the {{session.vaccination}} at school on {{session.summary.datesDisjunction}}',
+          '{{consent.child.fullName}} is due to get the {{session.vaccinationNames.sentenceCase}} at school on {{session.summary.datesDisjunction}}',
         [ReplyDecision.OnlyMenACWY]:
           '{{consent.child.fullName}} is due to get the MenACWY vaccination at school on {{session.summary.datesDisjunction}}',
         [ReplyDecision.OnlyTdIPV]:
           '{{consent.child.fullName}} is due to get the Td/IPV vaccination at school on {{session.summary.datesDisjunction}}',
         [ReplyDecision.Refused]:
-          'You’ve told us that you do not want {{consent.child.fullName}} to get the {{session.vaccination}} at school'
+          'You’ve told us that you do not want {{consent.child.fullName}} to get the {{session.vaccinationNames.sentenceCase}} at school'
       },
       triage: {
         // TODO: Parent may have given consent for two vaccinations for doubles
         // so text should say either ‘vaccination is’ or ‘vaccinations are’
         [ReplyDecision.Given]:
-          'As you answered ‘yes’ to one or more of the health questions, we need to check the {{session.vaccination}} is suitable for {{consent.child.fullName}}. We’ll review your answers and get in touch again soon.',
+          'As you answered ‘yes’ to one or more of the health questions, we need to check the {{session.vaccinationNames.sentenceCase}} is suitable for {{consent.child.fullName}}. We’ll review your answers and get in touch again soon.',
         [ReplyDecision.OnlyMenACWY]:
           'As you answered ‘yes’ to one or more of the health questions, we need to check the MenACWY vaccination is suitable for {{consent.child.fullName}}. We’ll review your answers and get in touch again soon.',
         [ReplyDecision.OnlyTdIPV]:
@@ -683,75 +687,75 @@ export const en = {
       },
       'invite-subsequent-reminder': {
         label: 'Subsequent reminder',
-        name: 'There’s still time for your child to be vaccinated against {{session.immunisation}}'
+        name: 'There’s still time for your child to be vaccinated against {{session.programmeNames.sentenceCase}}'
       },
       'invite-clinic': {
         label: 'Clinic booking',
-        name: 'Booking a clinic appointment for your child’s {{session.vaccination}}'
+        name: 'Booking a clinic appointment for your child’s {{session.vaccinationNames.sentenceCase}}'
       },
       'invite-clinic-reminder': {
         label: 'Clinic booking reminder',
-        name: 'Your child can still get their {{session.vaccination}} at a clinic'
+        name: 'Your child can still get their {{session.vaccinationNames.sentenceCase}} at a clinic'
       },
       'invite-clinic-consent': {
         label: 'Clinic invitation',
-        name: 'We still need consent for your child’s {{session.vaccination}}'
+        name: 'We still need consent for your child’s {{session.vaccinationNames.sentenceCase}}'
       },
       'consent-given': {
         label: 'Consent given',
-        name: '{{session.vaccinationTitle}} on {{session.summary.dates}}'
+        name: '{{session.vaccinationNames.titleCase}} on {{session.summary.dates}}'
       },
       'consent-given-changed-school': {
         label: 'Consent given (changed school)',
-        name: 'Your child’s {{session.vaccination}}'
+        name: 'Your child’s {{session.vaccinationNames.sentenceCase}}'
       },
       'consent-conflicts': {
         label: 'Consent conflicts',
-        name: 'Your child will not have their {{session.vaccination}}'
+        name: 'Your child will not have their {{session.vaccinationNames.sentenceCase}}'
       },
       'consent-refused': {
         label: 'Consent refused',
-        name: '{{session.vaccinationTitle}} on {{session.summary.dates}}'
+        name: '{{session.vaccinationNames.titleCase}} on {{session.summary.dates}}'
       },
       'consent-refused-injection': {
         label: 'Consent refused (flu injection)',
-        name: '{{session.vaccinationTitle}} on {{session.summary.dates}}'
+        name: '{{session.vaccinationNames.titleCase}} on {{session.summary.dates}}'
       },
       'consent-needs-triage': {
         label: 'Consent needs triage',
-        name: '{{session.vaccinationTitle}} on {{session.summary.dates}}'
+        name: '{{session.vaccinationNames.titleCase}} on {{session.summary.dates}}'
       },
       'triage-vaccinate': {
         label: 'Vaccinate',
-        name: 'Your child can have the {{session.vaccination}} on {{session.summary.dates}}'
+        name: 'Your child can have the {{session.vaccinationNames.sentenceCase}} on {{session.summary.dates}}'
       },
       'triage-delay-vaccination': {
         label: 'Delay vaccination',
-        name: 'Please book a clinic appointment for your child’s {{session.vaccination}}'
+        name: 'Please book a clinic appointment for your child’s {{session.vaccinationNames.sentenceCase}}'
       },
       'triage-do-not-vaccinate': {
         label: 'Do not vaccinate',
-        name: 'Your child will not have the {{session.vaccination}} in school'
+        name: 'Your child will not have the {{session.vaccinationNames.sentenceCase}} in school'
       },
       'record-reminder': {
         label: 'Reminder',
-        name: '{{consent.child.fullName}} will get their {{session.vaccination}} on {{session.summary.dates}}'
+        name: '{{consent.child.fullName}} will get their {{session.vaccinationNames.sentenceCase}} on {{session.summary.dates}}'
       },
       'record-vaccinated': {
         label: 'Vaccinated',
-        name: 'Your child had their {{programme.name}} vaccination today'
+        name: 'Your child had their {{session.vaccinationNames.sentenceCase}} today'
       },
       'record-vaccinated-many': {
         label: 'Vaccinated (many)',
-        name: 'Your child had their {{session.vaccination}} today'
+        name: 'Your child had their {{session.vaccinationNames.sentenceCase}} today'
       },
       'record-could-not-vaccinate': {
         label: 'Could not vaccinate',
-        name: 'Your child did not have their {{session.vaccination}} today'
+        name: 'Your child did not have their {{session.vaccinationNames.sentenceCase}} today'
       },
       'information-child': {
         label: 'Information for students',
-        name: 'You can get an {{session.vaccination}} on {{session.summary.dates}}'
+        name: 'You can get an {{session.vaccinationNames.sentenceCase}} on {{session.summary.dates}}'
       }
     }
   },
@@ -1387,9 +1391,10 @@ export const en = {
     decision: {
       label: 'Decision',
       title: {
-        Child: 'Does the child agree to having the {{programme.name}} vaccine?',
+        Child:
+          'Does the child agree to having the {{programme.programme.vaccineName.sentenceCase}}?',
         Parent:
-          'Do they agree to {{patient.firstName}} having the {{programme.name}} vaccine?'
+          'Do they agree to {{patient.firstName}} having the {{programme.programme.vaccineName.sentenceCase}}?'
       }
     },
     invalid: {
@@ -1724,62 +1729,62 @@ export const en = {
       invite: {
         label: 'Invitation',
         name: 'Inviting parent to give or refuse consent',
-        text: 'Give or refuse consent for {{consent.child.fullName}} to have their {{session.vaccination}}:\n\n[https://give-or-refuse-consent.nhs.uk/{{session.id}}]({{session.consentUrl}}/start)\n\nYou need to do this by {{session.formatted.openAt}}.\n\nResponding will take less than 5 minutes.'
+        text: 'Give or refuse consent for {{consent.child.fullName}} to have their {{session.vaccinationNames.sentenceCase}}:\n\n[https://give-or-refuse-consent.nhs.uk/{{session.id}}]({{session.consentUrl}}/start)\n\nYou need to do this by {{session.formatted.openAt}}.\n\nResponding will take less than 5 minutes.'
       },
       'invite-clinic': {
         label: 'Clinic booking',
         name: 'Inviting parent to book a clinic appointment',
-        text: 'Our records show that {{consent.child.fullAndPreferredNames}} has not been vaccinated against {{session.immunisation}}.\n\nTo book this vaccination in a clinic, go to https://www.swiftqueue.co.uk/userlogin.php\n\nYou’ll need to register for a Swiftqueue account first.'
+        text: 'Our records show that {{consent.child.fullAndPreferredNames}} has not been vaccinated against {{session.programmeNames.sentenceCase}}.\n\nTo book this vaccination in a clinic, go to https://www.swiftqueue.co.uk/userlogin.php\n\nYou’ll need to register for a Swiftqueue account first.'
       },
       'invite-clinic-reminder': {
         label: 'Clinic booking reminder',
         name: 'Reminding parent to book a clinic appointment',
-        text: "It’s not too late for {{consent.child.fullAndPreferredNames}} to get their {{session.vaccination}}.\n\nBook a clinic slot by going to https://www.swiftqueue.co.uk/userlogin.php\n\nYou'll need to register for a Swiftqueue account first."
+        text: "It’s not too late for {{consent.child.fullAndPreferredNames}} to get their {{session.vaccinationNames.sentenceCase}}.\n\nBook a clinic slot by going to https://www.swiftqueue.co.uk/userlogin.php\n\nYou'll need to register for a Swiftqueue account first."
       },
       'invite-clinic-consent': {
         label: 'Clinic invitation',
         name: 'Inviting parent to give consent for a clinic appointment',
-        text: 'You recently booked a clinic appointment for {{consent.child.fullAndPreferredNames}}.\n\nPlease give consent for them to get the {{session.vaccination}} by going to https://give-or-refuse-consent.nhs.uk/{{session.id}}.'
+        text: 'You recently booked a clinic appointment for {{consent.child.fullAndPreferredNames}}.\n\nPlease give consent for them to get the {{session.vaccinationNames.sentenceCase}} by going to https://give-or-refuse-consent.nhs.uk/{{session.id}}.'
       },
       'invite-reminder': {
         label: 'Reminder',
         name: 'Reminding parent to give or refuse consent',
-        text: 'We recently asked for your consent to vaccinate your child against {{session.immunisation}}.\n\nGo to [https://give-or-refuse-consent.nhs.uk/{{session.id}}]({{session.consentUrl}}/start) to submit a response. This will take less than 5 minutes.'
+        text: 'We recently asked for your consent to vaccinate your child against {{session.programmeNames.sentenceCase}}.\n\nGo to [https://give-or-refuse-consent.nhs.uk/{{session.id}}]({{session.consentUrl}}/start) to submit a response. This will take less than 5 minutes.'
       },
       'consent-given': {
         label: 'Consent given',
         name: 'Confirmation that consent has been given',
-        text: 'You’ve given consent for {{consent.child.firstName}} to get their {{session.vaccination}} at school on {{session.summary.remainingDates}}. Please let them know what to expect.\n\nIf anything changes, phone {{organisation.tel}}.'
+        text: 'You’ve given consent for {{consent.child.firstName}} to get their {{session.vaccinationNames.sentenceCase}} at school on {{session.summary.remainingDates}}. Please let them know what to expect.\n\nIf anything changes, phone {{organisation.tel}}.'
       },
       'consent-given-child': {
         label: 'Consent given (child)',
         name: 'Confirmation that consent has been given',
-        text: 'Your parent or guardian has agreed for you to have the {{session.vaccination}} at school on {{session.summary.remainingDates}}.'
+        text: 'Your parent or guardian has agreed for you to have the {{session.vaccinationNames.sentenceCase}} at school on {{session.summary.remainingDates}}.'
       },
       'consent-refused': {
         label: 'Consent refused',
         name: 'Confirmation that consent has been refused',
-        text: 'You’ve refused to give consent for {{consent.child.fullName}} to have their {{session.vaccination}}.\n\nYou can give feedback about the ‘Give or refuse consent’ service by completing our short survey:\n\n<https://feedback.digital.nhs.uk/jfe/form/SV_3fICo6frMvUZX1k>\n\nYour feedback will help us improve the service.'
+        text: 'You’ve refused to give consent for {{consent.child.fullName}} to have their {{session.vaccinationNames.sentenceCase}}.\n\nYou can give feedback about the ‘Give or refuse consent’ service by completing our short survey:\n\n<https://feedback.digital.nhs.uk/jfe/form/SV_3fICo6frMvUZX1k>\n\nYour feedback will help us improve the service.'
       },
       'record-reminder': {
         label: 'Reminder',
         name: 'Reminder (to go out the day before the vaccination)',
-        text: '{{consent.child.firstName}} will get their {{session.vaccination}} at school tomorrow ({{session.formatted.nextDate}}). Please make sure they have breakfast and encourage them to wear a short-sleeved shirt.'
+        text: '{{consent.child.firstName}} will get their {{session.vaccinationNames.sentenceCase}} at school tomorrow ({{session.formatted.nextDate}}). Please make sure they have breakfast and encourage them to wear a short-sleeved shirt.'
       },
       'record-reminder-child': {
         label: 'Reminder (child)',
         name: 'Reminder (to go out the day before the vaccination)',
-        text: 'You’re due to get your {{session.vaccination}} at school tomorrow ({{session.formatted.nextDate}}). Please wear a short-sleeved shirt and make sure you eat something before the session.'
+        text: 'You’re due to get your {{session.vaccinationNames.sentenceCase}} at school tomorrow ({{session.formatted.nextDate}}). Please wear a short-sleeved shirt and make sure you eat something before the session.'
       },
       'record-vaccinated': {
         label: 'Vaccinated',
         name: 'Child has been vaccinated',
-        text: '{{consent.child.firstName}} had their {{session.vaccination}} at school today. They might have some side effects, including bruising or itching at the injection site, a high temperature, nausea, or pain in the arms, hands, or fingers.\n\nIf you’re concerned, contact your GP in the usual way.'
+        text: '{{consent.child.firstName}} had their {{session.vaccinationNames.sentenceCase}} at school today. They might have some side effects, including bruising or itching at the injection site, a high temperature, nausea, or pain in the arms, hands, or fingers.\n\nIf you’re concerned, contact your GP in the usual way.'
       },
       'record-could-not-vaccinate': {
         label: 'Could not vaccinate',
         name: 'Child did not get their vaccination despite having consent',
-        text: '{{consent.child.firstName}} did not have their {{session.vaccination}} at school today. This was because {{reason}}.\n\nIf you’d still like them to be vaccinated on a different date, contact our team by calling [{{organisation.tel}}](#), or email [{{organisation.email}}](#).'
+        text: '{{consent.child.firstName}} did not have their {{session.vaccinationNames.sentenceCase}} at school today. This was because {{reason}}.\n\nIf you’d still like them to be vaccinated on a different date, contact our team by calling [{{organisation.tel}}](#), or email [{{organisation.email}}](#).'
       }
     }
   },

--- a/app/models/cohort.js
+++ b/app/models/cohort.js
@@ -1,8 +1,12 @@
 import { createMap } from '../utils/object.js'
-import { formatLink, formatYearGroup } from '../utils/string.js'
+import {
+  formatLink,
+  formatYearGroup,
+  sentenceCaseProgrammeName
+} from '../utils/string.js'
 
 import { Patient } from './patient.js'
-import { Programme, ProgrammeType } from './programme.js'
+import { Programme } from './programme.js'
 
 /**
  * @readonly
@@ -86,12 +90,13 @@ export class Cohort {
   /**
    * Get name
    *
-   * @returns {string} - Name
+   * @returns {object} - Name
    */
   get name() {
-    const type = ProgrammeType[this.programme.type]
-
-    return `${type} ${this.formatted.yearGroup} (${this.year})`
+    return {
+      sentenceCase: `${sentenceCaseProgrammeName(this.programme.name)} ${this.formatted.yearGroup} (${this.year})`,
+      titleCase: `${this.programme.name} ${this.formatted.yearGroup} (${this.year})`
+    }
   }
 
   /**
@@ -112,7 +117,7 @@ export class Cohort {
    */
   get link() {
     return {
-      name: formatLink(this.uri, this.name)
+      name: formatLink(this.uri, this.name.titleCase)
     }
   }
 

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -7,7 +7,8 @@ import { getPreferredNames } from '../utils/reply.js'
 import {
   formatLink,
   formatLinkWithSecondaryText,
-  formatParent
+  formatParent,
+  sentenceCaseProgrammeName
 } from '../utils/string.js'
 
 import { AuditEvent, EventType } from './audit-event.js'
@@ -369,7 +370,7 @@ export class Patient extends Record {
     this.cohort_uids.push(cohort.uid)
     this.addEvent({
       type: EventType.Select,
-      name: `Selected for the ${cohort.name.replace('Flu', 'flu')} cohort`,
+      name: `Selected for the ${cohort.name.sentenceCase} cohort`,
       createdAt: cohort.createdAt,
       createdBy_uid: cohort.createdBy_uid,
       programme_ids: [cohort.programme_id]
@@ -388,7 +389,7 @@ export class Patient extends Record {
 
     this.addEvent({
       type: EventType.Select,
-      name: `Removed from the ${cohort.name.replace('Flu', 'flu')} cohort`,
+      name: `Removed from the ${cohort.name.sentenceCase} cohort`,
       createdBy_uid: cohort.createdBy_uid,
       programme_ids: [cohort.programme_id]
     })
@@ -411,7 +412,7 @@ export class Patient extends Record {
   inviteToSession(patientSession) {
     this.addEvent({
       type: EventType.Invite,
-      name: `Invited to the ${patientSession.session.name}`,
+      name: `Invited to the ${sentenceCaseProgrammeName(patientSession.session.name)}`,
       createdAt: patientSession.session.openAt,
       createdBy_uid: patientSession.createdBy_uid,
       programme_ids: patientSession.session.programme_ids

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -2,7 +2,11 @@ import { isAfter } from 'date-fns'
 
 import vaccines from '../datasets/vaccines.js'
 import { isBetweenDates, today } from '../utils/date.js'
-import { formatLink, formatTag } from '../utils/string.js'
+import {
+  formatLink,
+  formatTag,
+  sentenceCaseProgrammeName
+} from '../utils/string.js'
 
 import { Cohort } from './cohort.js'
 import { PatientSession } from './patient-session.js'
@@ -37,6 +41,7 @@ export const programmeTypes = {
     id: 'flu',
     name: 'Flu',
     title: 'Children’s flu',
+    vaccineName: 'Children’s flu vaccine',
     active: true,
     information: {
       startPage:
@@ -54,6 +59,7 @@ export const programmeTypes = {
     id: 'hpv',
     name: 'HPV',
     title: 'Human papillomavirus (HPV)',
+    vaccineName: 'HPV vaccine',
     active: false,
     information: {
       startPage:
@@ -76,6 +82,7 @@ export const programmeTypes = {
     id: 'td-ipv',
     name: 'Td/IPV',
     title: 'Td/IPV (3-in-1 teenage booster)',
+    vaccineName: 'Td/IPV vaccine',
     active: true,
     information: {
       startPage:
@@ -98,6 +105,7 @@ export const programmeTypes = {
     id: 'menacwy',
     name: 'MenACWY',
     title: 'MenACWY',
+    vaccineName: 'MenACWY vaccine',
     active: true,
     information: {
       startPage:
@@ -219,6 +227,22 @@ export class Programme {
    */
   get vaccine() {
     return new Vaccine(vaccines[this.vaccine_smomeds[0]])
+  }
+
+  /**
+   * Get vaccine name
+   *
+   * @returns {object} - Vaccine name
+   * @example Children’s flu vaccine
+   * @example Td/IPV vaccine (3-in-1 teenage booster)
+   */
+  get vaccineName() {
+    const vaccineName = programmeTypes[this.type].vaccineName
+
+    return {
+      sentenceCase: sentenceCaseProgrammeName(vaccineName),
+      titleCase: vaccineName
+    }
   }
 
   /**

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -36,9 +36,9 @@ export const programmeTypes = {
   [ProgrammeType.Flu]: {
     id: 'flu',
     name: 'Flu',
+    title: 'Children’s flu',
     active: true,
     information: {
-      title: 'Flu',
       startPage:
         'The vaccination helps to protect children against flu. It also protects others who are vulnerable to flu, such as babies and older people.',
       description:
@@ -53,9 +53,9 @@ export const programmeTypes = {
   [ProgrammeType.HPV]: {
     id: 'hpv',
     name: 'HPV',
+    title: 'Human papillomavirus (HPV)',
     active: false,
     information: {
-      title: 'Human papillomavirus (HPV)',
       startPage:
         'The HPV vaccine helps to prevent HPV related cancers from developing in boys and girls.\n\nThe number of doses you need depends on your age and how well your immune system works. Young people usually only need 1 dose.',
       description:
@@ -75,9 +75,9 @@ export const programmeTypes = {
   [ProgrammeType.TdIPV]: {
     id: 'td-ipv',
     name: 'Td/IPV',
+    title: 'Td/IPV (3-in-1 teenage booster)',
     active: true,
     information: {
-      title: 'Td/IPV (3-in-1 teenage booster)',
       startPage:
         'The Td/IPV vaccine (also called the 3-in-1 teenage booster) helps protect against tetanus, diphtheria and polio.\n\nIt boosts the protection provided by the [6-in-1 vaccine](https://www.nhs.uk/vaccinations/6-in-1-vaccine/) and [4-in-1 pre-school booster vaccine](https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/).',
       description:
@@ -97,9 +97,9 @@ export const programmeTypes = {
   [ProgrammeType.MenACWY]: {
     id: 'menacwy',
     name: 'MenACWY',
+    title: 'MenACWY',
     active: true,
     information: {
-      title: 'MenACWY',
       startPage:
         'The MenACWY vaccine helps protect against meningitis and sepsis. It is recommended for all teenagers. Most people only need one dose of the vaccine.',
       description:
@@ -122,6 +122,7 @@ export const programmeTypes = {
  * @param {object} [context] - Context
  * @property {object} [context] - Context
  * @property {string} name - Name
+ * @property {string} title - Title
  * @property {object} information - NHS.UK programme information
  * @property {object} leaflet - UKHSA programme information leaflets
  * @property {boolean} active - Active programme
@@ -142,6 +143,7 @@ export class Programme {
   constructor(options, context) {
     this.context = context
     this.name = options?.type && programmeTypes[options.type]?.name
+    this.title = options?.type && programmeTypes[options.type]?.title
     this.information =
       options?.type && programmeTypes[options.type]?.information
     this.leaflet = options?.type && programmeTypes[options.type]?.leaflet

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -600,9 +600,7 @@ export class Session {
    * @returns {string} - Programme title
    */
   get programmeTitle() {
-    return filters.formatList(
-      this.programmes.map(({ information }) => information.title)
-    )
+    return filters.formatList(this.programmes.map(({ title }) => title))
   }
 
   /**

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -19,7 +19,8 @@ import {
   formatList,
   formatTag,
   formatWithSecondaryText,
-  lowerCaseFirst
+  lowerCaseFirst,
+  sentenceCaseProgrammeName
 } from '../utils/string.js'
 
 import { Batch } from './batch.js'
@@ -554,53 +555,39 @@ export class Session {
   }
 
   /**
-   * Get vaccination name (sentence case)
+   * Get programme name(s)
    *
-   * @returns {string} - Vaccination name
-   * @example flu vaccination
-   * @example flu and HPV vaccinations
+   * @returns {object} - Programme name(s)
+   * @example Flu
+   * @example Td/IPV and MenACWY
    */
-  get vaccination() {
-    const pluralisation =
-      this.programmes.length === 1 ? 'vaccination' : 'vaccinations'
-
-    return `${this.immunisation} ${pluralisation}`
+  get programmeNames() {
+    return {
+      sentenceCase: filters.formatList(
+        this.programmes.map(({ name }) => sentenceCaseProgrammeName(name))
+      ),
+      titleCase: filters.formatList(this.programmes.map(({ name }) => name))
+    }
   }
 
   /**
-   * Get vaccination title (Title case)
+   * Get vaccination name(s)
    *
-   * @returns {string} - Vaccination title
+   * @returns {object} - Vaccination name(s)
    * @example Flu vaccination
-   * @example Flu and HPV vaccinations
+   * @example Td/IPV and MenACWY vaccinations
    */
-  get vaccinationTitle() {
+  get vaccinationNames() {
     const pluralisation =
       this.programmes.length === 1 ? 'vaccination' : 'vaccinations'
 
-    return `${this.programmeTitle.replace('flu', 'Flu')} ${pluralisation}`
-  }
-
-  /**
-   * Get programme immunisation
-   *
-   * @returns {string} - Programme immunisation
-   * @example flu
-   * @example flu and HPV
-   */
-  get immunisation() {
-    return filters.formatList(
-      this.programmes.map(({ name }) => name.replace('Flu', 'flu'))
-    )
-  }
-
-  /**
-   * Get programme title
-   *
-   * @returns {string} - Programme title
-   */
-  get programmeTitle() {
-    return filters.formatList(this.programmes.map(({ title }) => title))
+    return {
+      sentenceCase: `${filters.formatList(
+        this.programmes.map(({ name }) => sentenceCaseProgrammeName(name))
+      )} ${pluralisation}`,
+      titleCase: `${filters.formatList(this.programmes.map(({ name }) => name))}
+        ${pluralisation}`
+    }
   }
 
   /**
@@ -643,7 +630,7 @@ export class Session {
    */
   get name() {
     if (this.location) {
-      return `${this.immunisation} session at ${this.location.name}`
+      return `${this.programmeNames.titleCase} session at ${this.location.name}`
     }
   }
 

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -381,3 +381,16 @@ export function formatYearGroup(yearGroup) {
 export function lowerCaseFirst(string) {
   return string.charAt(0).toLowerCase() + string.slice(1)
 }
+
+/**
+ * Get programme names that can be used in a sentence
+ *
+ * @param {string} string - String to change
+ * @returns {string} Sentence cased programme names
+ */
+export function sentenceCaseProgrammeName(string) {
+  return string
+    .replace('Children', 'children') // Children’s flu vaccine
+    .replace('Flu', 'flu') // Flu vaccination
+    .replace('Human', 'human') // Human papillomavirus
+}

--- a/app/views/parent/emails.njk
+++ b/app/views/parent/emails.njk
@@ -1,11 +1,11 @@
 {% extends "_layouts/emails.njk" %}
 
 {% if session.programmes.length == 1 %}
-  {% set caption = __("consent.start.title.single", session.vaccination) %}
+  {% set caption = __("consent.start.title.single", { session: session }) | safe %}
   {% set vaccine__n = "vaccine" %}
   {% set is__n = "is" %}
 {% else %}
-  {% set caption = __("consent.start.title.multiple", session.vaccination) %}
+  {% set caption = __("consent.start.title.multiple", { session: session }) | safe %}
   {% set vaccine__n = "vaccines" %}
   {% set is__n = "are" %}
 {% endif %}

--- a/app/views/parent/form/refusal-reason.njk
+++ b/app/views/parent/form/refusal-reason.njk
@@ -7,7 +7,7 @@
   {% set title = __("consent.refusalReason.title", "MenACWY vaccination") %}
   {% set vaccinations = 1 %}
 {% else %}
-  {% set title = __("consent.refusalReason.title", session.vaccination) %}
+  {% set title = __("consent.refusalReason.title", { session: session }) %}
   {% set vaccinations = session.programmes.length %}
 {% endif %}
 

--- a/app/views/parent/start.njk
+++ b/app/views/parent/start.njk
@@ -12,7 +12,7 @@
 
       {% for programme in session.programmes %}
         {% if session.programmes.length != 1 %}
-          <h2 class="nhsuk-heading-m">{{ programme.information.title }}</h2>
+          <h2 class="nhsuk-heading-m">{{ programme.title }}</h2>
         {% endif %}
 
         {{ programme.information.startPage | nhsukMarkdown }}

--- a/app/views/parent/texts.njk
+++ b/app/views/parent/texts.njk
@@ -1,9 +1,9 @@
 {% extends "_layouts/texts.njk" %}
 
 {% if session.programmes.length == 1 %}
-  {% set caption = __("consent.start.title.single", session.vaccination) %}
+  {% set caption = __("consent.start.title.single", { session: session }) | safe %}
 {% else %}
-  {% set caption = __("consent.start.title.multiple", session.vaccination) %}
+  {% set caption = __("consent.start.title.multiple", { session: session }) | safe %}
 {% endif %}
 
 {% set placeholders = {

--- a/app/views/session/_navigation.njk
+++ b/app/views/session/_navigation.njk
@@ -5,7 +5,7 @@
 {% macro sessionNavigation(params) %}
   {{ heading({
     title: params.session.location.name,
-    summary: params.session.immunisation
+    summary: params.session.programmeNames.titleCase
   }) }}
 
   {{ secondaryNavigation({


### PR DESCRIPTION
Renames properties to programmes and sessions for referring to their name in different use cases.

Ensures all values have title case and sentence case variants, to account for the following scenarios:

* About the **children’s flu vaccination**
* **Children’s flu vaccination** for 2025

| Programme.type | Flu | HPV | TdIPV | MenACWY |
| -------------- | --- | --- | ----- | ------- |
| `Programme.name` | Flu | HPV | Td/IPV | MenACWY |
| `Programme.title` | Children’s flu | Human papillomavirus (HPV) | Td/IPV (3-in-1 teenage booster) | MenACWY |
| `Programme.vaccineName.titleCase` | Children’s flu vaccine | HPV vaccine | Td/IPV vaccine                  | MenACWY vaccine |
| `Programme.vaccineName.sentenceCase` | children’s flu vaccine | HPV vaccine | Td/IPV vaccine                  | MenACWY vaccine |                          
| `Session.programmeNames.titleCase` | Flu | HPV | MenACWY and Td/IPV |
| `Session.programmeNames.sentenceCase` | flu | HPV | MenACWY and Td/IPV |
| `Session.vaccinationNames.titleCase` | Flu vaccination | HPV vaccination | MenACWY and Td/IPV vaccinations |
| `Session.vaccinationNames.sentenceCase` | flu vaccination  | HPV vaccination | MenACWY and Td/IPV vaccinations |