### PR TITLE
Flu consent form content tweaks

### DIFF
--- a/app/datasets/health-questions.js
+++ b/app/datasets/health-questions.js
@@ -1,79 +1,96 @@
 export const healthQuestions = {
   aspirin: {
     label: 'Does the child take regular aspirin?',
-    hint: 'Also known as Salicylate therapy'
+    hint: 'Also known as Salicylate therapy',
+    detailsHint: false
   },
   allergy: {
     label: 'Does the child have any severe allergies?',
-    hint: false
+    hint: false,
+    detailsHint: false
   },
   asthma: {
     label: 'Has the child been diagnosed with asthma?',
-    hint: false
+    hint: false,
+    detailsHint: false
   },
   asthmaAdmitted: {
-    label: 'Has the child been admitted to intensive care for their asthma?',
-    hint: false
+    label:
+      'Has the child ever been admitted to intensive care because of their asthma?',
+    hint: false,
+    detailsHint: false
   },
   asthmaSteroids: {
-    label:
-      'Has the child taken any oral steroids for their asthma in the last 2 weeks?',
-    hint: 'Include the steroid name, dose and length of course'
+    label: 'Does the child take regular oral steroid tablets for their asthma?',
+    hint: false,
+    detailsHint: 'Include the steroid name, dose and length of course'
   },
   bleeding: {
     label:
       'Does the child have a bleeding disorder or another medical condition they receive treatment for?',
-    hint: false
+    hint: false,
+    detailsHint: false
   },
   eggAllergy: {
     label:
-      'Has the child ever been admitted to intensive care due an allergic reaction to egg?',
-    hint: false
+      'Has the child ever been admitted to intensive care due to an allergic reaction to egg?',
+    hint: false,
+    detailsHint: false
   },
   immunosuppressant: {
     label: 'Does the child take any immunosuppressant medication?',
-    hint: false
+    hint: false,
+    detailsHint: false
   },
   immuneSystem: {
     label:
       'Does the child have a disease or treatment that severely affects their immune system?',
-    hint: false
+    hint: false,
+    detailsHint: false
   },
   householdImmuneSystem: {
     label:
       'Is anyone in the child’s household currently having treatment that severely affects their immune system?',
-    hint: false
+    hint: false,
+    detailsHint: false
   },
   medicationAllergies: {
     label: 'Does the child have any allergies to medication?',
-    hint: false
+    hint: false,
+    detailsHint: false
   },
   medicalConditions: {
     label:
       'Does the child have any medical conditions for which they receive treatment?',
-    hint: false
+    hint: false,
+    detailsHint: false
   },
   previousReaction: {
     label:
       'Has the child ever had a severe reaction to any medicines, including vaccines?',
-    hint: false
+    hint: false,
+    detailsHint: false
   },
   recentFluVaccination: {
-    label: 'Has the child had a flu vaccination in the last 5 months?',
-    hint: false
+    label: 'Has the child had a flu vaccination in the last 3 months?',
+    hint: false,
+    detailsHint: false
   },
   recentMenAcwyVaccination: {
     label:
       'Has the child had a meningitis (MenACWY) vaccination in the last 5 years?',
-    hint: 'It’s usually given once in Year 9 or 10. Some children may have had it before travelling abroad.'
+    hint: 'It’s usually given once in Year 9 or 10. Some children may have had it before travelling abroad.',
+    detailsHint: false
   },
   recentTdIpvVaccination: {
     label:
       'Has the child had a tetanus, diphtheria and polio vaccination in the last 5 years?',
-    hint: 'Most children will not have had this vaccination since their 4-in-1 pre-school booster'
+    hint: 'Most children will not have had this vaccination since their 4-in-1 pre-school booster',
+    detailsHint: false
   },
   support: {
     label: 'Does the child need extra support during vaccination sessions?',
-    hint: 'For example, they’re autistic, or extremely anxious'
+    hint: 'For example, they’re autistic, or extremely anxious',
+    detailsHint: false
   }
 }

--- a/app/globals.js
+++ b/app/globals.js
@@ -99,9 +99,10 @@ export default () => {
    *
    * @param {object} healthAnswers - Health answers
    * @param {string} edit - Edit link
+   * @param {string} [parentFacing] - Use parent-facing questions (‘your child’)
    * @returns {Array|undefined} Parameters for summary list component
    */
-  globals.healthAnswerRows = function (healthAnswers, edit) {
+  globals.healthAnswerRows = function (healthAnswers, edit, parentFacing) {
     if (healthAnswers.length === 0) {
       return
     }
@@ -120,8 +121,12 @@ export default () => {
         html += formatHealthAnswer(healthAnswer)
       }
 
+      const keyText = parentFacing
+        ? healthQuestions[key].label.replace('the child', 'your child')
+        : healthQuestions[key].label
+
       rows.push({
-        key: { text: healthQuestions[key].label },
+        key: { text: keyText },
         value: { html },
         ...(edit && {
           actions: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -533,12 +533,12 @@ export const en = {
         label: 'I agree to them having one of the vaccinations'
       },
       nasal: {
-        label: 'Yes, I agree',
-        hint: 'The nasal spray gives children the best protection against flu'
+        label: 'Yes, I agree to them having the nasal spray vaccine',
+        hint: 'This is the recommended option and gives the best protection against flu'
       },
       injection: {
         label: 'Yes, I agree to the alternative flu injection',
-        hint: 'The injection is suitable for children who don’t use gelatine products, or the nasal spray is not suitable for medical reasons'
+        hint: 'This is suitable for children who do not use gelatine products, or if they cannot have the nasal spray vaccine for medical reasons'
       },
       no: {
         label: 'No'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -555,11 +555,7 @@ export const en = {
         other:
           'Your child may be able to have the vaccinations outside of school'
       },
-      description: {
-        one: 'For example, they may be able to have the vaccination in a clinic.',
-        other:
-          'For example, they may be able to have the vaccinations in a clinic.'
-      },
+      description: 'For example, in a community clinic.',
       label: 'Discuss options',
       legend:
         'Would you like a member of the team to contact you to discuss your options?',

--- a/app/views/parent/form/check-answers.njk
+++ b/app/views/parent/form/check-answers.njk
@@ -162,7 +162,8 @@
       classes: "app-summary-list--full-width",
       rows: healthAnswerRows(
         consent.healthAnswers,
-        editPath("health-question-{{key}}")
+        editPath("health-question-{{key}}"),
+        true
       )
     })
   }) if consent.given }}

--- a/app/views/parent/form/consultation.njk
+++ b/app/views/parent/form/consultation.njk
@@ -7,7 +7,7 @@
     title: title
   }) }}
 
-  {{ __n("consent.consultation.description", session.programmes.length) | nhsukMarkdown }}
+  {{ __n("consent.consultation.description") | nhsukMarkdown }}
 
   {{ radios({
     fieldset: {

--- a/app/views/parent/form/consultation.njk
+++ b/app/views/parent/form/consultation.njk
@@ -1,13 +1,13 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __n("consent.consultation.title", programmeItems.length) %}
+{% set title = __n("consent.consultation.title", session.programmes.length) %}
 
 {% block form %}
   {{ heading({
     title: title
   }) }}
 
-  {{ __n("consent.consultation.description", programmeItems.length) | nhsukMarkdown }}
+  {{ __n("consent.consultation.description", session.programmes.length) | nhsukMarkdown }}
 
   {{ radios({
     fieldset: {

--- a/app/views/parent/form/decision.njk
+++ b/app/views/parent/form/decision.njk
@@ -1,6 +1,6 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("consent.decision.title", { session: session }) | replace("the flu", "a nasal flu") %}
+{% set title = __("consent.decision.title", { session: session }) %}
 
 {% block form %}
   {%- set programmeRadiosHtml = radios({

--- a/app/views/parent/form/health-question.njk
+++ b/app/views/parent/form/health-question.njk
@@ -2,6 +2,7 @@
 
 {% set title = __("healthQuestions." + key + ".label") %}
 {% set hint = __("healthQuestions." + key + ".hint") %}
+{% set detailsHint = __("healthQuestions." + key + ".detailsHint") %}
 
 {% block form %}
   {{ radios({
@@ -19,6 +20,7 @@
       conditional: {
         html: textarea({
           label: { text: __("consent.healthAnswers.details") },
+          hint: { text: detailsHint } if detailsHint,
           decorate: ["consent", "healthAnswers", key, "details"]
         })
       } if not hasSubQuestions


### PR DESCRIPTION
## Changes

- Update flu consent decision page
  - Remove ‘nasal spray’ from opening question
  - Update hint text for each vaccination option
- First pass update to flu consent health questions for the nasal spray (more to come)
- Show hint text under ‘Give details’ for asthma oral steroid tablets health question
  - And allow all questions to provide optional hint text under ‘Give details’

<img width="720" alt="Screenshot of flue programme decision question." src="https://github.com/user-attachments/assets/6c76bf6d-f2c2-45fe-971f-ea083ef3a39d" />

## Fixes

- Fix pluralisation of ‘vaccination’ on consultation question
- Correctly show ‘your child’ not ‘the child’ on check answers page