### PR TITLE
Sync emails with production, add note about multiple session dates

### DIFF
--- a/app/emails/consent/_about-the-nasal-spray.njk
+++ b/app/emails/consent/_about-the-nasal-spray.njk
@@ -1,0 +1,7 @@
+## About the nasal spray
+
+The nasal spray contains gelatine. If your child does not use gelatine products, or the nasal spray is not suitable for medical reasons, they could have an injection instead.
+
+The nasal spray gives children the best protection against flu. However, the injected vaccine is a good alternative if the nasal spray vaccine cannot be used.
+
+[Find out more about the use of gelatine in the flu vaccine (including the views of faith communities)](https://www.gov.uk/government/publications/vaccines-and-porcine-gelatine/vaccines-and-porcine-gelatine)

--- a/app/emails/consent/_get-in-touch.njk
+++ b/app/emails/consent/_get-in-touch.njk
@@ -1,0 +1,3 @@
+## Get in touch with us
+
+Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.

--- a/app/emails/consent/_how-to-respond.njk
+++ b/app/emails/consent/_how-to-respond.njk
@@ -1,0 +1,5 @@
+## How to respond
+
+> It’s important to let us know whether you do or do not want your child to have {% if session.programmes.length == 1 %}this vaccination{% else %}these vaccinations{% endif %}. It will take less than 5 minutes to respond using the link below.
+
+[Respond to the consent request]({{ session.consentUrl }}/start)

--- a/app/emails/consent/_talk-to-your-child.njk
+++ b/app/emails/consent/_talk-to-your-child.njk
@@ -1,0 +1,7 @@
+## Talk to your child about what they want
+
+We suggest you talk to your child about the {{ vaccine__n }} before you respond to us.
+
+{% if consent.child.school.phase == SchoolPhase.Secondary %}
+Young people have the right to refuse vaccinations. Those who show ‘[Gillick competence](https://www.nhs.uk/conditions/consent-to-treatment/children)’ have the right to consent to vaccinations themselves. Our team may assess Gillick competence during vaccination sessions.
+{% endif %}

--- a/app/emails/consent/_trouble-using-online-form.njk
+++ b/app/emails/consent/_trouble-using-online-form.njk
@@ -1,0 +1,3 @@
+## If you have trouble using the online form
+
+If you have any trouble using the online form, you can respond over the phone using the contact details below.

--- a/app/emails/consent/_your-data.njk
+++ b/app/emails/consent/_your-data.njk
@@ -1,0 +1,3 @@
+## Your data
+
+By responding, you’re agreeing to your data being processed as set out in our [privacy notice]({{ data.organisation.privacyPolicyUrl }}).

--- a/app/emails/consent/invite-catch-up.njk
+++ b/app/emails/consent/invite-catch-up.njk
@@ -1,77 +1,27 @@
-We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to give {% if programme.type == ProgrammeType.Flu %} this year’s flu vaccine{% elif programme.type == ProgrammeType.HPV %}the human papillomavirus (HPV) vaccine{% elif programme.type == ProgrammeType.TdIPV %}the Td/IPV (3-in-1 teenage booster) vaccines{% endif %}.
+We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to give the human papillomavirus (HPV) vaccine.
 
 Our records show your child has not had their HPV vaccination. Pupils usually have this when they’re in Year 8.
 
-## What the vaccine is for
+{% for programme in session.programmes %}
+## About the {{ programme.vaccineName.sentenceCase }}
 
-{% if programme.type == ProgrammeType.Flu %}
-The vaccine protects against flu, which can cause serious health problems.
+{{ programme.information.description }}
 
-By preventing the spread of flu, the vaccine also protects others who are vulnerable, such as babies and older people.
+[Find out more about the {{ programme.vaccineName.sentenceCase }} on NHS.UK]({{ programme.information.url }})
 
-The vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so it is recommended to have it again this year.
+[Learn more about the {{ programme.vaccineName.sentenceCase }} on GOV.UK]({{ programme.guidance.url }}) ({{ programme.guidance.hint }})
+{% endfor %}
 
-{% elif programme.type == ProgrammeType.HPV %}
-The HPV vaccine helps protect boys and girls against cancers caused by HPV, including:
+{% include "emails/consent/_how-to-respond.njk" %}
 
-- cervical cancer
-- some mouth and throat (head and neck) cancers
-- some cancers of the anal and genital areas
+You need to respond by {{ session.formatted.firstDate }}.
 
-It also helps protect against genital warts.
+If you do not respond, you’ll be sent automatic reminders. Responding will stop reminders.
 
-The HPV vaccine works best if it’s given before young people become sexually active.
+{% include "emails/consent/_talk-to-your-child.njk" %}
 
-{% elif programme.type == ProgrammeType.TdIPV %}
-The 3-in-1 teenage booster, also known as the Td/IPV vaccine, boosts protection against 3 diseases: tetanus, diptheria and polio.
+{% include "emails/consent/_trouble-using-online-form.njk" %}
 
-The MenACWY vaccine, which helps to prevent meningitis and septicaemia, is normally given at the same time as the 3-in-1.
+{% include "emails/consent/_your-data.njk" %}
 
-Both vaccines are offered to all young people aged 13 to 15 (in school Years 9 and 10). They’re given as injections into the upper arm.
-
-{% endif %}
-
-## Please give or refuse consent
-
-If you want your child to get this vaccine at school, you need to give consent by {{ session.formatted.firstDate }}.
-
-[Give or refuse consent for the {{ session.vaccinationNames.sentenceCase }}]({{ session.consentUrl }}/start)
-
-Responding will take less than 5 minutes. If you do not give consent, it’s still important for you to let us know.
-
-{% if programme.type == ProgrammeType.Flu %}
-## About the flu vaccine
-
-The nasal spray contains gelatine. If your child does not use gelatine products, or the nasal spray is not suitable for medical reasons, they could have an injection instead.
-
-The nasal spray gives children the best protection against flu. However, the injected vaccine is a good alternative if the nasal spray vaccine cannot be used.
-
-[Find out more about protecting your child against flu](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1165161/UKHSA-12652-protecting-your-child-against-flu-information-for-parents-and-carers.pdf)
-
-[Find out more about the use of gelatine in the flu vaccine (including the views of faith communities)](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1107767/UKHSA-12462-vaccines-porcine-gelatine-English.pdf)
-
-{% elif programme.type == ProgrammeType.HPV %}
-## About the HPV vaccine
-
-Girls and boys in England are offered the HPV vaccination when they’re in Year 8.
-
-The HPV vaccine has been given to girls since 2008. Following its success at helping prevent cervical cancers, it was introduced to boys in 2019 to help prevent HPV-related cancers that affect them – including head and neck, anal and genital cancers.
-
-The number of doses you need depends on your age and how well your immune system works. Young people usually only need 1 dose.
-
-[Find out more about the HPV vaccine on NHS.UK](https://www.nhs.uk/conditions/vaccinations/hpv-human-papillomavirus-vaccine/)
-{% endif %}
-
-{% if programme.type != ProgrammeType.Flu %}
-## Talk to your child about what they want
-
-We suggest you talk to your child about the vaccine before you respond to us.
-{% endif %}
-
-## If you have trouble using the online form
-
-If you have any trouble using the online form, you can respond over the phone using the contact details below.
-
-## Get in touch with us
-
-Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+{% include "emails/consent/_get-in-touch.njk" %}

--- a/app/emails/consent/invite-clinic-consent.njk
+++ b/app/emails/consent/invite-clinic-consent.njk
@@ -4,6 +4,4 @@ Please give consent for this vaccination ahead of your clinic appointment.
 
 [Give consent for the {{ session.vaccinationNames.sentenceCase }}]({{ session.consentUrl }}/start)
 
-## Get in touch with us
-
-Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+{% include "emails/consent/_get-in-touch.njk" %}

--- a/app/emails/consent/invite-clinic-reminder.njk
+++ b/app/emails/consent/invite-clinic-reminder.njk
@@ -1,26 +1,6 @@
 It’s not too late to book an {{ session.vaccinationNames.sentenceCase }} for {{ consent.child.fullAndPreferredNames }}.
 
-You can book a slot in a clinic by going to <https://www.swiftqueue.co.uk/userlogin.php>
-
-Slots are normally for 10 minutes. If your child needs more time, please contact the office using the details below.
-
-## How to use Swiftqueue
-
-If you haven’t used Swiftqueue before, you’ll need to register for an account before you can make a booking.
-
-Once you have an account, click on ‘Book an appointment’ and search for ‘CWP’.
-
-You can then select:
-
-- Jepson House for Nuneaton clinics
-- Locke House for Rugby clinics
-- Woodloes House for South Warwickshire clinic
-- Alcester Clinic for Alcester clinics
-- City of Coventry Health Centre or Central Library for Coventry clinics
-
-Click on the green ‘School questionnaire tab’ and type in your child’s school. Once you’ve chosen ‘{{ programme.name }}’ as the vaccination type, select your preferred time and date.
-
-If you have any questions or difficulties, feel free to contact us.
+If you’d like to book a clinic appointment, please contact us using the details below.
 
 {{ data.organisation.name }}<br>
 {{ data.organisation.email }}<br>

--- a/app/emails/consent/invite-clinic.njk
+++ b/app/emails/consent/invite-clinic.njk
@@ -1,26 +1,6 @@
 Our records show that {{ consent.child.fullAndPreferredNames }} has not had their {{ session.vaccinationNames.sentenceCase }} yet.
 
-If you’d like them to have this at a clinic, you can book a slot by going to <https://www.swiftqueue.co.uk/userlogin.php>
-
-Slots are normally for 10 minutes. If your child needs more time, please contact the office using the details below.
-
-## How to use Swiftqueue
-
-If you haven’t used Swiftqueue before, you’ll need to register for an account before you can make a booking.
-
-Once you have an account, click on ‘Book an appointment’ and search for ‘CWP’.
-
-You can then select:
-
-- Jepson House for Nuneaton clinics
-- Locke House for Rugby clinics
-- Woodloes House for South Warwickshire clinic
-- Alcester Clinic for Alcester clinics
-- City of Coventry Health Centre or Central Library for Coventry clinics
-
-Click on the green ‘School questionnaire tab’ and type in your child’s school. Once you’ve chosen ‘{{ programme.name }}’ as the vaccination type, select your preferred time and date.
-
-If you have any questions or difficulties, feel free to contact us.
+They can have this vaccination at a community clinic. If you’d like to book a clinic appointment, please contact us using the details below.
 
 {{ data.organisation.name }}<br>
 {{ data.organisation.email }}<br>

--- a/app/emails/consent/invite-reminder.njk
+++ b/app/emails/consent/invite-reminder.njk
@@ -9,32 +9,19 @@ If you’ve already responded to the consent request, you can ignore this messag
 
 {{ programme.information.description }}
 
-{% if programme.type == ProgrammeType.Flu %}
-The vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so we recommend they have it again this year.
-
-The nasal spray contains gelatine. If your child does not use gelatine products, they could have an injection instead.
-{% endif %}
-
 [Find out more about the {{ programme.vaccineName.sentenceCase }} on NHS.UK]({{ programme.information.url }})
 {% endfor %}
 
-## Please give or refuse consent
-
-[Give or refuse consent for the {{ session.vaccinationNames.sentenceCase }}]({{ session.consentUrl }}/start)
-
-Responding will take less than 5 minutes. If you do not give consent, it’s still important for you to respond.
-
-{% if programme.type != ProgrammeType.Flu %}
-## Talk to your child about what they want
-
-We suggest you talk to your child about the {{ vaccine__n }} before you respond to us.
-
+{% if programme.type == ProgrammeType.Flu %}
+{% include "emails/consent/_about-the-nasal-spray.njk" %}
 {% endif %}
 
-## If you have trouble using the online form
+{% include "emails/consent/_how-to-respond.njk" %}
 
-If you have any trouble using the online form, you can respond over the phone using the contact details below.
+{% include "emails/consent/_talk-to-your-child.njk" %}
 
-## Get in touch with us
+{% include "emails/consent/_trouble-using-online-form.njk" %}
 
-Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+{% include "emails/consent/_your-data.njk" %}
+
+{% include "emails/consent/_get-in-touch.njk" %}

--- a/app/emails/consent/invite-subsequent-reminder.njk
+++ b/app/emails/consent/invite-subsequent-reminder.njk
@@ -7,32 +7,19 @@ If you want your child to be vaccinated in school, you need to give your consent
 
 {{ programme.information.description }}
 
-{% if programme.type == ProgrammeType.Flu %}
-The vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so we recommend they have it again this year.
-
-The nasal spray contains gelatine. If your child does not use gelatine products, they could have an injection instead.
-{% endif %}
-
 [Find out more about the {{ programme.vaccineName.sentenceCase }} on NHS.UK]({{ programme.information.url }})
 {% endfor %}
 
-## Please give or refuse consent
-
-[Give or refuse consent for the {{ session.vaccinationNames.sentenceCase }}]({{ session.consentUrl }}/start)
-
-Responding will take less than 5 minutes.
-
-{% if programme.type != ProgrammeType.Flu %}
-## Talk to your child about what they want
-
-We suggest you talk to your child about the {{vaccine__n}} before you respond to us.
-
+{% if programme.type == ProgrammeType.Flu %}
+{% include "emails/consent/_about-the-nasal-spray.njk" %}
 {% endif %}
 
-## If you have trouble using the online form
+{% include "emails/consent/_how-to-respond.njk" %}
 
-If you have any trouble using the online form, you can respond over the phone using the contact details below.
+{% include "emails/consent/_talk-to-your-child.njk" %}
 
-## Get in touch with us
+{% include "emails/consent/_trouble-using-online-form.njk" %}
 
-Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+{% include "emails/consent/_your-data.njk" %}
+
+{% include "emails/consent/_get-in-touch.njk" %}

--- a/app/emails/consent/invite.njk
+++ b/app/emails/consent/invite.njk
@@ -12,6 +12,8 @@ We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to 
 
 We would like your consent to vaccinate {{ consent.child.firstName }}. You can give this by filling in our online form (the link is below).
 
+Note that we’re unable to say on which of the above dates individual pupils will have the vaccination, due to the large number of children being vaccinated.
+
 {% for programme in session.programmes %}
 ## About the {{ programme.vaccineName.sentenceCase }}
 
@@ -19,47 +21,23 @@ We would like your consent to vaccinate {{ consent.child.firstName }}. You can g
 
 [Find out more about the {{ programme.vaccineName.sentenceCase }} on NHS.UK]({{ programme.information.url }})
 
-[Read the patient information leaflet for the {{ programme.vaccineName.sentenceCase }} (PDF, {{ programme.vaccine.leaflet.size }})]({{ programme.vaccine.leaflet.url }})
+[Learn more about the {{ programme.vaccineName.sentenceCase }} on GOV.UK]({{ programme.guidance.url }}) ({{ programme.guidance.hint }})
 {% endfor %}
 
 {% if programme.type == ProgrammeType.Flu %}
-## About the nasal spray
-
-The nasal spray contains gelatine. If your child does not use gelatine products, or the nasal spray is not suitable for medical reasons, they could have an injection instead.
-
-The nasal spray gives children the best protection against flu. However, the injected vaccine is a good alternative if the nasal spray vaccine cannot be used.
-
-[Find out more about protecting your child against flu](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1165161/UKHSA-12652-protecting-your-child-against-flu-information-for-parents-and-carers.pdf)
-
-[Find out more about the use of gelatine in the flu vaccine (including the views of faith communities)](https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1107767/UKHSA-12462-vaccines-porcine-gelatine-English.pdf)
+{% include "emails/consent/_about-the-nasal-spray.njk" %}
 {% endif %}
 
-## How to respond
-
-> It’s important to let us know whether you do or do not want your child to have {% if session.programmes.length == 1 %}this vaccination{% else %}these vaccinations{% endif %}. It will take less than 5 minutes to respond using the link below.
-
-[Respond to the consent request]({{ session.consentUrl }}/start)
+{% include "emails/consent/_how-to-respond.njk" %}
 
 You need to respond by {{ session.formatted.firstDate }}.
 
 If you do not respond, you’ll be sent automatic reminders. Responding will stop reminders.
 
-## Talk to your child about what they want
+{% include "emails/consent/_talk-to-your-child.njk" %}
 
-We suggest you talk to your child about the {{ vaccine__n }} before you respond to us.
+{% include "emails/consent/_trouble-using-online-form.njk" %}
 
-{% if consent.child.school.phase == SchoolPhase.Secondary %}
-Young people have the right to refuse vaccinations. Those who show ‘[Gillick competence](https://www.nhs.uk/conditions/consent-to-treatment/children)’ have the right to consent to vaccinations themselves. Our team may assess Gillick competence during vaccination sessions.
-{% endif %}
+{% include "emails/consent/_your-data.njk" %}
 
-## If you cannot use the online form
-
-If you cannot use the online form, you can respond over the phone using the contact details below.
-
-## Your data
-
-By responding, you’re agreeing to your data being processed as set out in our [privacy notice]({{ data.organisation.privacyPolicyUrl }}).
-
-## Get in touch with us
-
-Speak to a member of our team by calling {{ data.organisation.tel }}, or email {{ data.organisation.email }}.
+{% include "emails/consent/_get-in-touch.njk" %}

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -679,11 +679,11 @@ export const en = {
     consent: {
       invite: {
         label: 'Invitation',
-        name: 'Vaccinations on {{session.summary.dates}}'
+        name: '{{session.vaccinationNames.titleCase}} on {{session.summary.dates}}'
       },
       'invite-catch-up': {
         label: 'Invitation (catch-up)',
-        name: 'Vaccinations on {{session.summary.dates}}'
+        name: '{{session.vaccinationNames.titleCase}} on {{session.summary.dates}}'
       },
       'invite-reminder': {
         label: 'Reminder',
@@ -691,7 +691,7 @@ export const en = {
       },
       'invite-subsequent-reminder': {
         label: 'Subsequent reminder',
-        name: 'There’s still time for your child to be vaccinated against {{session.programmeNames.sentenceCase}}'
+        name: 'There’s still time for your child to get their {{session.vaccinationNames.sentenceCase}}'
       },
       'invite-clinic': {
         label: 'Clinic booking',

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -50,6 +50,10 @@ export const programmeTypes = {
         'The vaccine protects against flu, which can cause serious health problems such as bronchitis and pneumonia.\n\nBy preventing the spread of flu, the vaccine also protects others who are vulnerable, such as babies and older people.\n\nThe vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so we recommend they have it again this year.',
       url: 'https://www.nhs.uk/vaccinations/child-flu-vaccine/'
     },
+    guidance: {
+      url: 'https://www.gov.uk/government/publications/flu-vaccination-leaflets-and-posters',
+      hint: 'with information available in different languages and alternative formats, including BSL and Braille'
+    },
     term: SchoolTerm.Autumn,
     seasonal: true,
     yearGroups: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
@@ -68,9 +72,9 @@ export const programmeTypes = {
         'The HPV vaccine helps protect boys and girls against cancers caused by HPV, including:\n- cervical cancer\n- some mouth and throat (head and neck) cancers\n- some cancers of the anal and genital areas\n\nThe HPV vaccine has been given to girls since 2008. Following its success at helping prevent cervical cancers, it was introduced to boys in 2019 to help prevent HPV-related cancers that affect them.\n\nYoung people usually only need 1 dose.',
       url: 'https://www.nhs.uk/conditions/vaccinations/hpv-human-papillomavirus-vaccine/'
     },
-    leaflet: {
-      html: 'https://www.gov.uk/government/publications/hpv-vaccine-vaccination-guide-leaflet/information-on-the-hpv-vaccination-from-september-2023',
-      pdf: 'https://assets.publishing.service.gov.uk/media/64919b26103ca6000c03a212/HPV_Vaccination_For_All_-_English_Leaflet_from_September_2023.pdf'
+    guidance: {
+      url: 'https://www.gov.uk/government/publications/hpv-vaccine-vaccination-guide-leaflet',
+      hint: 'with information available in different languages and alternative formats, including BSL and Braille'
     },
     term: SchoolTerm.Spring,
     sequence: ['1P', '2P', '3P'],
@@ -91,9 +95,9 @@ export const programmeTypes = {
         'The Td/IPV vaccine (also called the 3-in-1 teenage booster) helps protect against tetanus, diphtheria and polio.\n\nIt’s offered at around 13 or 14 years old (school year 9 or 10). It boosts the protection provided by the [6-in-1 vaccine](https://www.nhs.uk/vaccinations/6-in-1-vaccine/) and [4-in-1 pre-school booster vaccine](https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/).',
       url: 'https://www.nhs.uk/vaccinations/td-ipv-vaccine-3-in-1-teenage-booster/'
     },
-    leaflet: {
-      html: 'https://www.gov.uk/government/publications/a-guide-to-the-3-in-1-teenage-booster-tdipv/a-guide-to-the-3-in-1-teenage-booster-tdipv-vaccine',
-      pdf: 'https://assets.publishing.service.gov.uk/media/64d125a5e5491a00134b596b/UKHSA_12658_Teenage_3-in-1_booster_guide___TdIPV_05_WEB.pdf'
+    guidance: {
+      url: 'https://www.gov.uk/government/publications/a-guide-to-the-3-in-1-teenage-booster-tdipv',
+      hint: 'with links to information in other languages'
     },
     term: SchoolTerm.Summer,
     sequence: ['1P', '2P', '3P', '1B', '2B'],
@@ -114,9 +118,9 @@ export const programmeTypes = {
         'The MenACWY vaccine helps protect against life-threatening illnesses including meningitis, sepsis and septicaemia (blood poisoning).\n\nIt is recommended for all teenagers. Most people only need 1 dose of the vaccine.',
       url: 'https://www.nhs.uk/vaccinations/menacwy-vaccine/'
     },
-    leaflet: {
-      html: 'https://www.gov.uk/government/publications/menacwy-vaccine-information-for-young-people/a-guide-to-the-menacwy-vaccine',
-      pdf: 'https://assets.publishing.service.gov.uk/media/667308097d0f95cd08d0db6a/UKHSA_12972_MenACWY_vaccine_leaflet_July2024__WEB.pdf'
+    guidance: {
+      url: 'https://www.gov.uk/government/publications/menacwy-vaccine-information-for-young-people',
+      hint: 'with links to information in other languages'
     },
     term: SchoolTerm.Summer,
     yearGroups: [9, 10, 11],
@@ -132,7 +136,7 @@ export const programmeTypes = {
  * @property {string} name - Name
  * @property {string} title - Title
  * @property {object} information - NHS.UK programme information
- * @property {object} leaflet - UKHSA programme information leaflets
+ * @property {object} guidance - GOV.UK guidance
  * @property {boolean} active - Active programme
  * @property {boolean} seasonal - Seasonal programme
  * @property {ProgrammeStatus} status - Status
@@ -154,7 +158,7 @@ export class Programme {
     this.title = options?.type && programmeTypes[options.type]?.title
     this.information =
       options?.type && programmeTypes[options.type]?.information
-    this.leaflet = options?.type && programmeTypes[options.type]?.leaflet
+    this.guidance = options?.type && programmeTypes[options.type]?.guidance
     this.active = options?.type && programmeTypes[options.type]?.active
     this.seasonal = options?.type && programmeTypes[options.type]?.seasonal
     this.year = options?.year || SchoolYear.Y2024


### PR DESCRIPTION
- Bring email examples in line with those in production
  - Replace vaccine information leaflets with links to guidance on GOV.UK
  - Include vaccination name in initial invitation subject
  - Use generic content for clinic emails
- Use partials for common sections in consent invitation emails
- Update HPV catch-up email to only show HPV content
- Add note to initial invitation email about there being multiple dates