### PR TITLE
Create a new session

### DIFF
--- a/app/datasets/clinics.js
+++ b/app/datasets/clinics.js
@@ -392,6 +392,7 @@ export default {
   X99999: {
     id: 'X99999',
     name: 'Community clinic',
+    addressLevel1: 'Coventry',
     organisation_code: 'RYG'
   }
 }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -657,7 +657,7 @@ export const en = {
     },
     startAt: {
       label: 'From',
-      hint: 'For example, 27 10 2024'
+      hint: 'For example, 27 10 2025'
     },
     endAt: {
       label: 'Until',
@@ -1498,15 +1498,18 @@ export const en = {
       label: 'Overview',
       summary: 'Session overview'
     },
+    new: {
+      label: 'Add a new session',
+      'check-answers': {
+        confirm: 'Add session',
+        title: 'Check and confirm',
+        summary: 'Session details'
+      },
+      success: '{{session.name}} created'
+    },
     edit: {
       title: 'Edit session',
       summary: 'Session details',
-      programme: {
-        title: 'Which programmes is this session part of?'
-      },
-      dates: {
-        title: 'When will sessions be held?'
-      },
       success: '{{session.name}} updated'
     },
     consent: {
@@ -1633,28 +1636,44 @@ export const en = {
     },
     date: {
       label: 'Session date',
-      hint: 'For example, 27 3 2024'
+      hint: 'For example, 27 3 2025'
     },
     dates: {
-      label: 'Session dates'
+      label: 'Session dates',
+      title: 'When will sessions be held?'
     },
     school: {
-      label: 'School'
+      label: 'School',
+      title: 'Where is this school session taking place?'
     },
     school_urn: {
-      label: 'School URN'
+      label: 'School URN',
+      title: 'Select a school'
+    },
+    clinic: {
+      label: 'Clinic',
+      title: 'Where is this community clinic taking place?'
     },
     location: {
       label: 'Location'
     },
     programmes: {
+      label: 'Programmes',
+      title: 'Which programmes is this session part of?'
+    },
+    primaryProgrammes: {
       label: 'Programmes'
+    },
+    catchupProgrammes: {
+      label: 'Catch-ups',
+      title: 'Which catch-up programmes does this session support?'
     },
     status: {
       label: 'Status'
     },
     type: {
-      label: 'Type'
+      label: 'Type',
+      title: 'What type of session is this?'
     },
     consentUrl: {
       label: 'Online consent form'

--- a/app/middleware/enumeration.js
+++ b/app/middleware/enumeration.js
@@ -17,7 +17,7 @@ import {
   ScreenOutcome,
   TriageOutcome
 } from '../models/patient-session.js'
-import { ProgrammeType } from '../models/programme.js'
+import { ProgrammeType, ProgrammePreset } from '../models/programme.js'
 import { ReplyDecision, ReplyMethod, ReplyRefusal } from '../models/reply.js'
 import { SchoolPhase } from '../models/school.js'
 import {
@@ -51,6 +51,7 @@ export const enumeration = (request, response, next) => {
   response.locals.ParentalRelationship = ParentalRelationship
   response.locals.PatientOutcome = PatientOutcome
   response.locals.ProgrammeType = ProgrammeType
+  response.locals.ProgrammePreset = ProgrammePreset
   response.locals.RegistrationOutcome = RegistrationOutcome
   response.locals.ReplyDecision = ReplyDecision
   response.locals.ReplyMethod = ReplyMethod

--- a/app/middleware/navigation.js
+++ b/app/middleware/navigation.js
@@ -3,6 +3,7 @@ import { Move } from '../models/move.js'
 import { Notice } from '../models/notice.js'
 import { Organisation } from '../models/organisation.js'
 import { ProgrammeType } from '../models/programme.js'
+import { Session } from '../models/session.js'
 import { Upload } from '../models/upload.js'
 import { User, UserRole } from '../models/user.js'
 import { formatDate, today } from '../utils/date.js'
@@ -11,7 +12,6 @@ import { getProgrammeSession } from '../utils/session.js'
 export const navigation = (request, response, next) => {
   const { data } = request.session
   const { __ } = response.locals
-  const { sessions } = data
 
   const organisation = new Organisation(data.organisation)
   const user = new User(data.token)
@@ -24,6 +24,7 @@ export const navigation = (request, response, next) => {
   const consents = Consent.readAll(data)
   const moves = Move.readAll(data)
   const notices = Notice.readAll(data)
+  const sessions = Session.readAll(data)
   const reviews = Upload.readAll(data).flatMap((upload) => upload.duplicates)
 
   // Get account navigation

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -36,13 +36,37 @@ export const ProgrammeType = {
   MenACWY: 'MenACWY'
 }
 
+/**
+ * @readonly
+ * @enum {object}
+ */
+export const ProgrammePreset = {
+  SeasonalFlu: {
+    active: true,
+    primaryProgrammeTypes: [ProgrammeType.Flu],
+    term: SchoolTerm.Autumn
+  },
+  HPV: {
+    active: true,
+    adolescent: true,
+    primaryProgrammeTypes: [ProgrammeType.HPV],
+    term: SchoolTerm.Spring
+  },
+  Doubles: {
+    active: true,
+    adolescent: true,
+    primaryProgrammeTypes: [ProgrammeType.MenACWY, ProgrammeType.TdIPV],
+    catchupProgrammeTypes: [ProgrammeType.HPV],
+    term: SchoolTerm.Summer
+  }
+}
+
 export const programmeTypes = {
   [ProgrammeType.Flu]: {
     id: 'flu',
     name: 'Flu',
     title: 'Children’s flu',
     vaccineName: 'Children’s flu vaccine',
-    active: true,
     information: {
       startPage:
         'Use this service to give or refuse consent for your child to have a flu vaccination.\n\nThis vaccination is recommended for school age children every year.\n\n## About the children’s flu vaccine\n\nThe children’s flu vaccine helps protect children against flu. Vaccinating children also protects others who are vulnerable to flu, such as babies and older people.\n\nThe vaccine is given as a nasal spray. This gives the most effective protection.\n\nSome children can have an injection instead, for example if they:\n\n- have had a serious allergic reaction to a previous dose of the nasal spray vaccine\n- have a severe egg allergy\n- have asthma that’s being treated with long-term steroid tablets',
@@ -54,8 +78,6 @@ export const programmeTypes = {
       url: 'https://www.gov.uk/government/publications/flu-vaccination-leaflets-and-posters',
       hint: 'with information available in different languages and alternative formats, including BSL and Braille'
     },
-    term: SchoolTerm.Autumn,
-    seasonal: true,
     yearGroups: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
     vaccine_smomeds: ['43208811000001106', '40085011000001101']
   },
@@ -64,7 +86,6 @@ export const programmeTypes = {
     name: 'HPV',
     title: 'Human papillomavirus (HPV)',
     vaccineName: 'HPV vaccine',
-    active: false,
     information: {
       startPage:
         'The HPV vaccine helps to prevent HPV related cancers from developing in boys and girls.\n\nThe number of doses you need depends on your age and how well your immune system works. Young people usually only need 1 dose.',
@@ -76,7 +97,6 @@ export const programmeTypes = {
       url: 'https://www.gov.uk/government/publications/hpv-vaccine-vaccination-guide-leaflet',
       hint: 'with information available in different languages and alternative formats, including BSL and Braille'
     },
-    term: SchoolTerm.Spring,
     sequence: ['1P', '2P', '3P'],
     sequenceDefault: '1P',
     yearGroups: [8, 9, 10, 11],
@@ -87,7 +107,6 @@ export const programmeTypes = {
     name: 'Td/IPV',
     title: 'Td/IPV (3-in-1 teenage booster)',
     vaccineName: 'Td/IPV vaccine',
-    active: false,
     information: {
       startPage:
         'The Td/IPV vaccine (also called the 3-in-1 teenage booster) helps protect against tetanus, diphtheria and polio.\n\nIt boosts the protection provided by the [6-in-1 vaccine](https://www.nhs.uk/vaccinations/6-in-1-vaccine/) and [4-in-1 pre-school booster vaccine](https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/).',
@@ -99,7 +118,6 @@ export const programmeTypes = {
       url: 'https://www.gov.uk/government/publications/a-guide-to-the-3-in-1-teenage-booster-tdipv',
       hint: 'with links to information in other languages'
     },
-    term: SchoolTerm.Summer,
     sequence: ['1P', '2P', '3P', '1B', '2B'],
     sequenceDefault: '2B',
     yearGroups: [9, 10, 11],
@@ -110,7 +128,6 @@ export const programmeTypes = {
     name: 'MenACWY',
     title: 'MenACWY',
     vaccineName: 'MenACWY vaccine',
-    active: false,
     information: {
       startPage:
         'The MenACWY vaccine helps protect against meningitis and sepsis. It is recommended for all teenagers. Most people only need one dose of the vaccine.',
@@ -122,7 +139,6 @@ export const programmeTypes = {
       url: 'https://www.gov.uk/government/publications/menacwy-vaccine-information-for-young-people',
       hint: 'with links to information in other languages'
     },
-    term: SchoolTerm.Summer,
     yearGroups: [9, 10, 11],
     vaccine_smomeds: ['39779611000001104']
   }
@@ -137,10 +153,7 @@ export const programmeTypes = {
  * @property {string} title - Title
  * @property {object} information - NHS.UK programme information
  * @property {object} guidance - GOV.UK guidance
- * @property {boolean} active - Active programme
- * @property {boolean} seasonal - Seasonal programme
  * @property {ProgrammeStatus} status - Status
- * @property {SchoolTerm} term - School term administered in
  * @property {ProgrammeType} type - Programme type
  * @property {Array<string>} sequence - Vaccine dose sequence
  * @property {string} sequenceDefault - Default vaccine dose sequence
@@ -159,10 +172,7 @@ export class Programme {
     this.information =
       options?.type && programmeTypes[options.type]?.information
     this.guidance = options?.type && programmeTypes[options.type]?.guidance
-    this.active = options?.type && programmeTypes[options.type]?.active
-    this.seasonal = options?.type && programmeTypes[options.type]?.seasonal
     this.year = options?.year || SchoolYear.Y2024
-    this.term = options?.type && programmeTypes[options.type]?.term
     this.type = options?.type
     this.sequence = options?.type && programmeTypes[options.type]?.sequence
     this.sequenceDefault =

--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -10,19 +10,25 @@ router.get('/planned', session.readAll, session.list('planned'))
 router.get('/unplanned', session.readAll, session.list('unplanned'))
 router.get('/closed', session.readAll, session.list('closed'))
 
+router.get('/new', session.new)
+
 router.param('session_id', session.read)
 
-router.post('/:session_id/offline', session.downloadFile)
+router.all('/:session_id/new/:view', session.readForm('new'))
+router.get('/:session_id/new/:view', session.showForm)
+router.post('/:session_id/new/check-answers', session.update('new'))
+router.post('/:session_id/new/:view', session.updateForm)
 
 router.get('/:session_id/edit', session.edit)
-router.post('/:session_id/edit', session.update)
+router.post('/:session_id/edit', session.update('edit'))
 
-router.all('/:session_id/edit/:view', session.readForm)
+router.all('/:session_id/edit/:view', session.readForm('edit'))
 router.get('/:session_id/edit/:view', session.showForm)
 router.post('/:session_id/edit/:view', session.updateForm)
 
 router.post('/:session_id/close', session.close)
 router.post('/:session_id/default-batch', session.updateDefaultBatch)
+router.post('/:session_id/offline', session.downloadFile)
 
 router.all('/:session_id/:view', session.readPatientSessions)
 router.post('/:session_id/:view', session.filterPatientSessions)

--- a/app/utils/date.js
+++ b/app/utils/date.js
@@ -93,7 +93,7 @@ export function convertIsoDateToObject(date) {
 /**
  * Add days to a date
  *
- * @param {Date} date - Date
+ * @param {Date|string} date - Date
  * @param {number} days - Number of days to add
  * @returns {Date} Date with days added
  */
@@ -107,7 +107,7 @@ export function addDays(date, days) {
 /**
  * Remove days from a date
  *
- * @param {Date} date - Date
+ * @param {Date|string} date - Date
  * @param {number} days - Number of days to remove
  * @returns {Date} Date with days removed
  */

--- a/app/utils/session.js
+++ b/app/utils/session.js
@@ -39,8 +39,7 @@ export const getProgrammeSession = (sessions, type, isSchool = true) => {
   const sessionType = isSchool ? SessionType.School : SessionType.Clinic
 
   return Object.values(sessions)
-    .map((session) => new Session(session))
-    .filter((session) => session.programme_ids.includes(id))
+    .filter((session) => session?.programme_ids.includes(id))
     .filter((session) => session.type === sessionType)
     .filter((session) => session.status !== SessionStatus.Unplanned)
     .at(-1)

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -40,6 +40,17 @@ export function stringToBoolean(value) {
 }
 
 /**
+ * Convert string to array
+ *
+ * @param {any} value - Value to test
+ * @returns {Array} Array
+ */
+export function stringToArray(value) {
+  const array = Array.isArray(value) ? value : []
+  return array.filter((item) => item !== '_unchecked')
+}
+
+/**
  * Format highlight
  *
  * @param {object} healthAnswer - Health answer
@@ -226,7 +237,7 @@ export function formatList(array) {
 
   // Only use list if more than one item in array
   if (array.length === 1) {
-    return array[0]
+    return formatMarkdown(array[0])
   }
 
   const list = array.map((item) => `- ${item}`)

--- a/app/views/programme/sessions.njk
+++ b/app/views/programme/sessions.njk
@@ -26,6 +26,12 @@
     view: "sessions"
   }) }}
 
+  {{ button({
+    classes: "nhsuk-button--secondary",
+    text: __("session.new.label"),
+    href: "/sessions/new"
+  }) }}
+
   {% macro count(number, percentage) %}
     <div>
       <span class="nhsuk-u-font-size-36 nhsuk-u-font-weight-bold">{{ number or "0" }}</span>

--- a/app/views/session/_list-navigation.njk
+++ b/app/views/session/_list-navigation.njk
@@ -1,23 +1,40 @@
-{{ secondaryNavigation({
-  items: [{
-    text: __("session.list.active.label"),
-    href: "/sessions",
-    current: view == "active"
-  }, {
-    text: __("session.list.unplanned.label"),
-    href: "/sessions/unplanned",
-    current: view == "unplanned"
-  }, {
-    text: __("session.list.planned.label"),
-    href: "/sessions/planned",
-    current: view == "planned"
-  }, {
-    text: __("session.list.completed.label"),
-    href: "/sessions/completed",
-    current: view == "completed"
-  }, {
-    text: __("session.list.closed.label"),
-    href: "/sessions/closed",
-    current: view == "closed"
-  }]
-}) }}
+{% from "components/button/macro.njk" import button %}
+{% from "_macros/heading.njk" import heading %}
+{% from "_macros/secondary-navigation.njk" import secondaryNavigation %}
+
+{% macro sessionListNavigation(params) %}
+  {{ heading({
+    size: "xl",
+    title: __("session.list.title")
+  }) }}
+
+  {{ button({
+    classes: "nhsuk-button--secondary",
+    text: __("session.new.label"),
+    href: "/sessions/new"
+  }) }}
+
+  {{ secondaryNavigation({
+    items: [{
+      text: __("session.list.active.label"),
+      href: "/sessions",
+      current: params.view == "active"
+    }, {
+      text: __("session.list.unplanned.label"),
+      href: "/sessions/unplanned",
+      current: params.view == "unplanned"
+    }, {
+      text: __("session.list.planned.label"),
+      href: "/sessions/planned",
+      current: params.view == "planned"
+    }, {
+      text: __("session.list.completed.label"),
+      href: "/sessions/completed",
+      current: params.view == "completed"
+    }, {
+      text: __("session.list.closed.label"),
+      href: "/sessions/closed",
+      current: params.view == "closed"
+    }]
+  }) }}
+{% endmacro %}

--- a/app/views/session/edit.njk
+++ b/app/views/session/edit.njk
@@ -17,8 +17,18 @@
     headingClasses: "nhsuk-heading-m",
     descriptionHtml: summaryList({
       rows: summaryRows(session, {
-        programmes: {
-          href: session.uri + "/edit/programmes"
+        type: {
+          href: session.uri + "/edit/type"
+        },
+        clinic: {
+          href: session.uri + "/edit/clinic"
+        },
+        school: {
+          href: session.uri + "/edit/school"
+        },
+        primaryProgrammes: {},
+        catchupProgrammes: {
+          href: session.uri + "/edit/catchup-programmes"
         },
         dates: {
           href: session.uri + "/edit/dates"

--- a/app/views/session/form/catchup-programmes.njk
+++ b/app/views/session/form/catchup-programmes.njk
@@ -1,0 +1,23 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.programmes.title") %}
+
+{% block form %}
+  {% set catchupItems = [] %}
+  {% for value in ProgrammePreset[session.programmePreset].catchupProgrammeTypes %}
+    {% set catchupItems = catchupItems | push({
+      text: value,
+      value: value
+    }) %}
+  {% endfor %}
+  {{ checkboxes({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--l",
+        text: __("session.catchupProgrammes.title")
+      }
+    },
+    items: catchupItems,
+    decorate: "session.catchupProgrammeTypes"
+  }) }}
+{% endblock %}

--- a/app/views/session/form/check-answers.njk
+++ b/app/views/session/form/check-answers.njk
@@ -1,0 +1,43 @@
+{% extends "_layouts/form.njk" %}
+
+{% set confirmButtonText = __("session.new.check-answers.confirm") %}
+{% set title = __("session.new.check-answers.title") %}
+
+{% block form %}
+  {{ heading({
+    title: title
+  }) }}
+
+  {{ card({
+    heading: __("session.new.check-answers.summary"),
+    headingClasses: "nhsuk-heading-m",
+    descriptionHtml: summaryList({
+      rows: summaryRows(session, {
+        type: {
+          href: session.uri + "/new/type"
+        },
+        clinic: {
+          href: session.uri + "/new/clinic"
+        },
+        school: {
+          href: session.uri + "/new/school"
+        },
+        primaryProgrammes: {
+          href: session.uri + "/edit/programmes"
+        },
+        catchupProgrammes: {
+          href: session.uri + "/edit/programmes"
+        },
+        dates: {
+          href: session.uri + "/new/dates"
+        },
+        openAt: {
+          href: session.uri + "/new/open-at"
+        },
+        reminderWeeks: {
+          href: session.uri + "/new/reminders"
+        }
+      })
+    })
+  }) }}
+{% endblock %}

--- a/app/views/session/form/clinic.njk
+++ b/app/views/session/form/clinic.njk
@@ -1,0 +1,18 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.clinic.title") %}
+
+{% block form %}
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--l",
+        html: heading({
+          title: title
+        })
+      }
+    },
+    items: clinicIdItems,
+    decorate: "session.clinic_id"
+  })}}
+{% endblock %}

--- a/app/views/session/form/dates.njk
+++ b/app/views/session/form/dates.njk
@@ -1,6 +1,6 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("session.edit.dates.title") %}
+{% set title = __("session.dates.title") %}
 
 {% macro dateFieldset(index) %}
   {{ dateInput({

--- a/app/views/session/form/programmes.njk
+++ b/app/views/session/form/programmes.njk
@@ -1,19 +1,44 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("session.edit.programme.title") %}
+{% set title = __("session.programmes.title") %}
 
 {% block form %}
-  {{ checkboxes({
+  {% macro catchupConditionalHtml(catchup) %}
+    {% set catchupItems = [] %}
+    {% for value in catchup %}
+      {% set catchupItems = catchupItems | push({
+        text: value,
+        value: value
+      }) %}
+    {% endfor %}
+    {{ checkboxes({
+      fieldset: {
+        legend: { text: __("session.catchupProgrammes.title") }
+      },
+      items: catchupItems,
+      decorate: "session.catchupProgrammeTypes"
+    }) }}
+  {% endmacro %}
+
+  {% set presetItems = [] %}
+  {% for key, value in ProgrammePreset %}
+    {% set presetItems = presetItems | push({
+      text: value.primaryProgrammeTypes | formatList,
+      value: key,
+      conditional: {
+        html: catchupConditionalHtml(value.catchupProgrammeTypes)
+      } if value.catchupProgrammeTypes
+    }) %}
+  {% endfor %}
+
+  {{ radios({
     fieldset: {
       legend: {
         classes: "nhsuk-fieldset__legend--l",
-        html: heading({
-          caption: session.location.name,
-          title: title
-        })
+        text: title
       }
     },
-    items: programmeItems,
-    decorate: "session.programme_ids"
+    items: presetItems,
+    decorate: "session.programmePreset"
   }) }}
 {% endblock %}

--- a/app/views/session/form/school.njk
+++ b/app/views/session/form/school.njk
@@ -1,0 +1,18 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.school.title") %}
+
+{% block form %}
+  {{ heading({
+    title: title
+  }) }}
+
+  {{ xGovukAutocomplete({
+    id: "school-urn",
+    name: "[session][school_urn]",
+    value: session.school_urn,
+    allowEmpty: false,
+    label: { text: __("session.school_urn.title") },
+    items: schoolUrnItems
+  }) | replace("govuk-", "nhsuk-") }}
+{% endblock %}

--- a/app/views/session/form/type.njk
+++ b/app/views/session/form/type.njk
@@ -1,0 +1,18 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.type.title") %}
+
+{% block form %}
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--l",
+        html: heading({
+          title: title
+        })
+      }
+    },
+    items: enumItems(SessionType),
+    decorate: "session.type"
+  }) }}
+{% endblock %}

--- a/app/views/session/list.njk
+++ b/app/views/session/list.njk
@@ -1,3 +1,5 @@
+{% from "session/_list-navigation.njk" import sessionListNavigation with context %}
+
 {% extends "_layouts/default.njk" %}
 
 {% set title = __("session.list.title") + " – " + __("session.list." + view + ".label") %}
@@ -6,12 +8,10 @@
 {% block content %}
   {{ super() }}
 
-  {{ heading({
-    size: "xl",
-    title: __("session.list.title")
+  {{ sessionListNavigation({
+    session: session,
+    view: view
   }) }}
-
-  {% include "session/_list-navigation.njk" %}
 
   {% if sessions.length %}
     {% set sessionRows = [] %}

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -609,25 +609,22 @@ vaccinations.forEach((vaccination) => {
 })
 
 // Generate date files
-generateDataFile('.data/batches.json', Object.fromEntries(batches))
-generateDataFile('.data/clinics.json', Object.fromEntries(clinics))
-generateDataFile('.data/cohorts.json', Object.fromEntries(cohorts))
-generateDataFile('.data/moves.json', Object.fromEntries(moves))
-generateDataFile('.data/notices.json', Object.fromEntries(notices))
-generateDataFile('.data/organisations.json', Object.fromEntries(organisations))
-generateDataFile('.data/patients.json', Object.fromEntries(patients))
-generateDataFile(
-  '.data/patient-sessions.json',
-  Object.fromEntries(patientSessions)
-)
-generateDataFile('.data/programmes.json', Object.fromEntries(programmes))
-generateDataFile('.data/records.json', Object.fromEntries(records))
-generateDataFile('.data/replies.json', Object.fromEntries(replies))
-generateDataFile('.data/schools.json', Object.fromEntries(schools))
-generateDataFile('.data/sessions.json', Object.fromEntries(sessions))
-generateDataFile('.data/uploads.json', Object.fromEntries(uploads))
-generateDataFile('.data/users.json', Object.fromEntries(users))
-generateDataFile('.data/vaccinations.json', Object.fromEntries(vaccinations))
+generateDataFile('.data/batches.json', batches)
+generateDataFile('.data/clinics.json', clinics)
+generateDataFile('.data/cohorts.json', cohorts)
+generateDataFile('.data/moves.json', moves)
+generateDataFile('.data/notices.json', notices)
+generateDataFile('.data/organisations.json', organisations)
+generateDataFile('.data/patients.json', patients)
+generateDataFile('.data/patient-sessions.json', patientSessions)
+generateDataFile('.data/programmes.json', programmes)
+generateDataFile('.data/records.json', records)
+generateDataFile('.data/replies.json', replies)
+generateDataFile('.data/schools.json', schools)
+generateDataFile('.data/sessions.json', sessions)
+generateDataFile('.data/uploads.json', uploads)
+generateDataFile('.data/users.json', users)
+generateDataFile('.data/vaccinations.json', vaccinations)
 
 // Show information about generated data
 console.info(

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -31,8 +31,12 @@ import {
   PatientSession,
   ScreenOutcome
 } from '../app/models/patient-session.js'
-import { ProgrammeType, programmeTypes } from '../app/models/programme.js'
-import { SchoolPhase, schoolTerms } from '../app/models/school.js'
+import {
+  ProgrammePreset,
+  ProgrammeType,
+  programmeTypes
+} from '../app/models/programme.js'
+import { SchoolPhase } from '../app/models/school.js'
 import {
   ConsentWindow,
   RegistrationOutcome,
@@ -119,10 +123,7 @@ Array.from([...range(0, totalRecords)]).forEach(() => {
 const programmes = new Map()
 for (const type of Object.keys(programmeTypes)) {
   const programme = generateProgramme(type)
-
-  if (programme.active) {
-    programmes.set(programme.id, programme)
-  }
+  programmes.set(programme.id, programme)
 }
 
 // Cohorts
@@ -184,55 +185,38 @@ for (const school of schools.values()) {
 
 // Sessions
 const sessions = new Map()
-const programmesGroupedByTerm = Object.groupBy(
-  programmes.values(),
-  ({ term }) => term
-)
-for (const [term, termProgrammes] of Object.entries(programmesGroupedByTerm)) {
-  const programme_ids = [...termProgrammes.values()]
-    .filter((programme) => programme.term === term)
-    .map((programme) => programme.id)
-
-  const isSeasonal = [...termProgrammes.values()].some(
-    ({ seasonal }) => seasonal === true
-  )
-
+for (const [programmePreset, preset] of Object.entries(ProgrammePreset)) {
   const urns = [...schools.values()]
     .filter(({ phase }) =>
-      // Non-seasonal programmes are only held at secondary schools
-      !isSeasonal ? phase === SchoolPhase.Secondary : phase
+      // Adolescent programmes are only held at secondary schools
+      preset.adolescent ? phase === SchoolPhase.Secondary : phase
     )
     .map(({ urn }) => urn)
 
   // Schedule school sessions
   for (const school_urn of urns) {
-    let schoolSession = generateSession(
-      programme_ids,
-      schoolTerms[term],
-      nurse,
-      {
-        school_urn
-      }
-    )
-    schoolSession = new Session(schoolSession, {
-      programmes: Object.fromEntries(programmes),
-      schools: Object.fromEntries(schools)
-    })
-    sessions.set(schoolSession.id, schoolSession)
+    let schoolSession = generateSession(programmePreset, nurse, { school_urn })
+    if (schoolSession) {
+      schoolSession = new Session(schoolSession, {
+        programmes: Object.fromEntries(programmes),
+        schools: Object.fromEntries(schools)
+      })
+      sessions.set(schoolSession.id, schoolSession)
+    }
   }
 
   // Schedule clinic sessions
   // TODO: Get clinics from team (linked to patient’s school)
   let clinicSession
   for (const clinic_id of ['X99999']) {
-    clinicSession = generateSession(programme_ids, schoolTerms[term], nurse, {
-      clinic_id
-    })
-    clinicSession = new Session(clinicSession, {
-      clinics: Object.fromEntries(clinics),
-      programmes: Object.fromEntries(programmes)
-    })
-    sessions.set(clinicSession.id, clinicSession)
+    clinicSession = generateSession(programmePreset, nurse, { clinic_id })
+    if (clinicSession) {
+      clinicSession = new Session(clinicSession, {
+        clinics: Object.fromEntries(clinics),
+        programmes
+      })
+      sessions.set(clinicSession.id, clinicSession)
+    }
   }
 }
 
@@ -386,16 +370,19 @@ for (const patientSession of patientSessions.values()) {
 const vaccinations = new Map()
 for (const patientSession of patientSessions.values()) {
   // Update patient session to include replies in context
-  const patientSessionWithReplyContext = new PatientSession(patientSession, {
+  const patientSessionWithContext = new PatientSession(patientSession, {
+    clinics: Object.fromEntries(clinics),
     patients: Object.fromEntries(patients),
     replies: Object.fromEntries(replies),
-    sessions: Object.fromEntries(sessions)
+    schools: Object.fromEntries(schools),
+    sessions: Object.fromEntries(sessions),
+    programmes: Object.fromEntries(programmes)
   })
 
   // Screen answers to health questions
-  if (patientSessionWithReplyContext.screen === ScreenOutcome.NeedsTriage) {
+  if (patientSessionWithContext.screen === ScreenOutcome.NeedsTriage) {
     // Get triage notes
-    for (const response of patientSessionWithReplyContext.responsesWithTriageNotes) {
+    for (const response of patientSessionWithContext.responsesWithTriageNotes) {
       const triaged = faker.datatype.boolean(0.3)
       if (triaged) {
         const outcome = faker.helpers.weightedArrayElement([
@@ -431,13 +418,12 @@ for (const patientSession of patientSessions.values()) {
     }
   }
 
-  const patient = patients.get(patientSessionWithReplyContext.patient_uuid)
-  const session = sessions.get(patientSessionWithReplyContext.session_id)
+  const { patient, session } = patientSessionWithContext
 
   // Vaccination outcome
   if (session.isCompleted) {
     // Ensure any outstanding triage has been completed
-    if (patientSessionWithReplyContext.screen === ScreenOutcome.NeedsTriage) {
+    if (patientSessionWithContext.screen === ScreenOutcome.NeedsTriage) {
       const outcome = ScreenOutcome.Vaccinate
       const note = 'Spoke to GP, safe to vaccinate.'
 
@@ -459,7 +445,7 @@ for (const patientSession of patientSessions.values()) {
         .find(({ archivedAt }) => archivedAt)
 
       let vaccination = generateVaccination(
-        patientSessionWithReplyContext,
+        patientSessionWithContext,
         programme,
         session,
         batch,

--- a/lib/generate-data-file.js
+++ b/lib/generate-data-file.js
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-export const generateDataFile = async (outputPath, data) => {
+export const generateDataFile = async (outputPath, dataMap) => {
   try {
     const fileDir = path.join(
       import.meta.url,
@@ -10,9 +10,11 @@ export const generateDataFile = async (outputPath, data) => {
       path.dirname(outputPath)
     )
     await fs.mkdir(fileURLToPath(fileDir), { recursive: true })
+    const data = Object.fromEntries(dataMap)
+    dataMap.clear()
     const fileData = JSON.stringify(data, null, 2)
     await fs.writeFile(outputPath, fileData)
-    console.info(`Data file generated: ${outputPath}`)
+    console.info(`✓ Generated ${outputPath}`)
   } catch (error) {
     console.error(error)
   }


### PR DESCRIPTION
This PR adds the ability to create new sessions, for presets groupings of programmes without optional catchup programmes.

## Add a new session

New button link appears on session page.

Link also added to Programmes → [Programme name] → Sessions.

![Screenshot of sessions page.](https://github.com/user-attachments/assets/a17cb4e2-d393-4b37-9c9e-9268d8043172)

## New session: Type

Can choose from ‘School session’ or ‘Community clinic’.

* If ‘School session’, asked to pick a school in a later question
* If ‘Community clinic’, asked to pick a clinic in a later question

If an organisation is not using, or does not have any clinics set up, this question should not be asked, and the session type should be saved as ‘School session’.

![Screenshot of session type page.](https://github.com/user-attachments/assets/e4bbc392-cb37-4eaa-b198-d517bf58cb2d)

## New session: Programme

A user can select from a number of ‘primary’ programmes, each with optional catch-ups. When all 5 vaccination programmes are supported, this may look something like this:

```
○ Flu
○ HPV
    □ With MMR catch-up
○ MenACWY and Td/IPV
    □ With HPV catch-up
    □ With MMR catch-up
```

Restricting this programme mix (fixed primary programmes with select, optional catch-up programmes) should prevent cases where duplicate session dates can be created for overlapping sessions.

* The primary programme can’t be changed once the session is created
* Secondary catch-up programmes, where available, can be added after a session is created, but not removed

![Screenshot of session programmes page.](https://github.com/user-attachments/assets/72b1e7a0-5711-4ad9-bfd8-9415053a164e)

## New session: School

Using familiar autocomplete for schools. A school is available to select if it:

* is associated with the user’s organisation (later, team?)
* does not already have dates for the chosen primary programme assigned to it

![Screenshot of session school page.](https://github.com/user-attachments/assets/2aa4ec53-7904-4480-bada-72b4629a5a4b)

## New session: Clinic

A community clinic is available to select if:

* it is associated with the user’s organisation (later, team)
* there is more than one clinic to choose from, else defaults to available clinic

![Screenshot of session clinic page.](https://github.com/user-attachments/assets/509ed558-8676-4038-b6b9-949c49d56eab)

## New session: Dates

As currently implemented.

![Screenshot of session dates page.](https://github.com/user-attachments/assets/75c4069f-9f54-4ad1-8e9f-7e134d677f94)

## New session: Check answers

A user can review their answers before saving.

* We don’t ask for for the date when consent requests open, or when reminders are sent, as these values default to the organisation’s (later, team’s) session defaults (which in production are currently still fixed). They can however be edited before saving a new session.
* Saving a session selects the cohort based on eligibility and vaccination status. For example:
  * Flu: All children in the school who have not been vaccinated
  * HPV: All Year 8 children in the school, and children in other years who have not had their HPV vaccination
  * MenACWY and Td/IPV with HPV catch-up: All Year 9 children in the school, and children in other years who have not had their MenACWY and/or Td/IV vaccinations yet, and all children who have not had their HPV vaccination yet.

![Screenshot of session check answers page.](https://github.com/user-attachments/assets/18d6e19b-f735-4536-952b-a7d3b0678172)

## New session: Created

![Screenshot of a new session.](https://github.com/user-attachments/assets/42ad4f59-f5bf-4022-ae45-066a655f1385)

## Existing session: Edit

Depending on the context, certain values will be editable, and some not:

* You can’t change the primary programme
* You can add catch-up programmes, if primary programme supports it.
* You can add new dates, and edit any existing dates that are not in the past

![Screenshot of session edit page.](https://github.com/user-attachments/assets/4a31725c-8165-4f15-8ea5-2ff58a341817)

## Existing session: Edit catch-ups

Example of only being able to edit catch-up programmes on an existing session.

![Screenshot of session catchup programmes page.](https://github.com/user-attachments/assets/98352008-ca0e-41c2-950d-170fc7e9ddfb)

## New session: Updated

![Screenshot of a updated session.](https://github.com/user-attachments/assets/ec98b113-e9d4-486b-b625-8ec705546548)


