### PR TITLE
Always get consent for the injected flu vaccine

### DIFF
--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -131,10 +131,9 @@ export const parentController = {
       },
       [`/${session_id}/${consent_uuid}/new/address`]: {},
       ...getHealthQuestionPaths(`/${session_id}/${consent_uuid}/new/`, consent),
-      ...(consent.hasAnswersNeedingTriage &&
-        consent.decision === ReplyDecision.Given && {
-          [`/${session_id}/${consent_uuid}/new/alternative`]: {}
-        }),
+      ...(consent.decision === ReplyDecision.Given && {
+        [`/${session_id}/${consent_uuid}/new/alternative`]: {}
+      }),
       [`/${session_id}/${consent_uuid}/new/check-answers`]: {},
       [`/${session_id}/${consent_uuid}/new/confirmation`]: {},
       [`/${session_id}/${consent_uuid}/new/consultation`]: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -537,7 +537,7 @@ export const en = {
       title:
         'If your child cannot have the nasal spray, do you agree to them having the injected vaccine instead?',
       label: 'Consent given for injected vaccine',
-      hint: 'If you answered yes to one or more of the health questions, we may decide the nasal spray vaccine is not suitable. In this case, we may offer the injected vaccine instead.'
+      hint: 'We may decide the nasal spray vaccine is not suitable. In this case, we may offer the injected vaccine instead.'
     },
     consultation: {
       title: {


### PR DESCRIPTION
We previously asked for consent for the injected flu vaccine if a parent gave consent for the nasal flu spray AND answered yes to any health questions.

However, in a situation where one parent has given consent for the injected vaccine, and one parent has given consent for the nasal spray (and not answered ‘yes’ to any health answers), a team would need to call up the other parent to get consent for the injected vaccine. If we always ask this question, this call wouldn’t need to be made.

<img width="670" alt="Screenshot of updated consent question." src="https://github.com/user-attachments/assets/937bebd2-e4db-45ca-8b49-6576acc2b670" />
