### PR TITLE
Ask parents if they’d like to talk to a member of SAIS team after providing a refusal reason

### DIFF
--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -147,7 +147,7 @@ export const parentController = {
       [`/${session_id}/${consent_uuid}/new/consultation`]: {
         [`/${session_id}/${consent_uuid}/new/check-answers`]: {
           data: 'consent.decision',
-          value: ReplyDecision.Consult
+          value: ReplyDecision.Declined
         },
         [`/${session_id}/${consent_uuid}/new/refusal-reason`]: {
           data: 'consent.decision',

--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -132,7 +132,7 @@ export const parentController = {
       },
       [`/${session_id}/${consent_uuid}/new/contact-preference`]: {},
       [`/${session_id}/${consent_uuid}/new/decision`]: {
-        [`/${session_id}/${consent_uuid}/new/consultation`]: {
+        [`/${session_id}/${consent_uuid}/new/refusal-reason`]: {
           data: 'consent.decision',
           value: ReplyDecision.Refused
         }
@@ -144,16 +144,6 @@ export const parentController = {
       }),
       [`/${session_id}/${consent_uuid}/new/check-answers`]: {},
       [`/${session_id}/${consent_uuid}/new/confirmation`]: {},
-      [`/${session_id}/${consent_uuid}/new/consultation`]: {
-        [`/${session_id}/${consent_uuid}/new/check-answers`]: {
-          data: 'consent.decision',
-          value: ReplyDecision.Declined
-        },
-        [`/${session_id}/${consent_uuid}/new/refusal-reason`]: {
-          data: 'consent.decision',
-          value: ReplyDecision.Refused
-        }
-      },
       [`/${session_id}/${consent_uuid}/new/refusal-reason`]: {
         [`/${session_id}/${consent_uuid}/new/refusal-reason-details`]: {
           data: 'consent.refusalReason',
@@ -163,9 +153,12 @@ export const parentController = {
             ReplyRefusal.Medical
           ]
         },
-        [`/${session_id}/${consent_uuid}/new/check-answers`]: true
+        [`/${session_id}/${consent_uuid}/new/consultation`]: true
       },
       [`/${session_id}/${consent_uuid}/new/refusal-reason-details`]: {
+        [`/${session_id}/${consent_uuid}/new/${consent.refusalReason === ReplyRefusal.Medical ? 'consultation' : 'check-answers'}`]: true
+      },
+      [`/${session_id}/${consent_uuid}/new/consultation`]: {
         [`/${session_id}/${consent_uuid}/new/check-answers`]: true
       },
       [`/${session_id}/${consent_uuid}/new/check-answers`]: {},

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -510,7 +510,7 @@ export const en = {
     decision: {
       summary: 'Consent for the {{session.vaccinationNames.sentenceCase}}',
       title:
-        'Do you agree to your child having the {{session.vaccinationNames.sentenceCase}} in school?',
+        'Do you agree to your child having the {{session.vaccinationNames.sentenceCase}}?',
       label: 'Decision',
       yes: {
         label: 'Yes, I agree'
@@ -540,16 +540,11 @@ export const en = {
       hint: 'We may decide the nasal spray vaccine is not suitable. In this case, we may offer the injected vaccine instead.'
     },
     consultation: {
-      title: {
-        one: 'Your child may be able to have the vaccination outside of school',
-        other:
-          'Your child may be able to have the vaccinations outside of school'
-      },
-      description: 'For example, in a community clinic.',
+      title:
+        'Would you like a member of the team to contact you to discuss alternative options?',
+      hint: 'For example, it may be possible to vaccinate your child in a community clinic.',
       label: 'Discuss options',
-      legend:
-        'Would you like a member of the team to contact you to discuss your options?',
-      yes: 'Yes, I’m happy for someone to contact me',
+      yes: 'Yes, I would like someone to contact me',
       no: 'No'
     },
     refusalReason: {
@@ -597,14 +592,11 @@ export const en = {
           'Consent for the MenACWY vaccination confirmed',
         [ReplyDecision.OnlyTdIPV]:
           'Consent for the Td/IPV vaccination confirmed',
-        [ReplyDecision.Declined]: 'Follow up requested',
         [ReplyDecision.Refused]: 'Refusal confirmed'
       },
       text: {
         [ReplyDecision.Given]:
           '{{consent.child.fullName}} is due to get the {{session.vaccinationNames.sentenceCase}} at school on {{session.summary.datesDisjunction}}',
-        [ReplyDecision.Declined]:
-          'You’ve told us that you would you like a member of the team to contact you to discuss your options',
         [ReplyDecision.OnlyFluInjection]:
           '{{consent.child.fullName}} is due to get the flu injection at school on {{session.summary.datesDisjunction}}',
         [ReplyDecision.OnlyMenACWY]:
@@ -614,6 +606,8 @@ export const en = {
         [ReplyDecision.Refused]:
           'You’ve told us that you do not want {{consent.child.fullName}} to get the {{session.vaccinationNames.sentenceCase}} at school'
       },
+      consultation:
+        'A member of the team will contact you soon to discuss your options.',
       triage: {
         // TODO: Parent may have given consent for two vaccinations for doubles
         // so text should say either ‘vaccination is’ or ‘vaccinations are’

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -591,19 +591,19 @@ export const en = {
     confirmation: {
       title: {
         [ReplyDecision.Given]: 'Consent confirmed',
-        [ReplyDecision.Consult]: 'Follow up requested',
         [ReplyDecision.OnlyFluInjection]:
           'Consent for the flu injection vaccination confirmed',
         [ReplyDecision.OnlyMenACWY]:
           'Consent for the MenACWY vaccination confirmed',
         [ReplyDecision.OnlyTdIPV]:
           'Consent for the Td/IPV vaccination confirmed',
+        [ReplyDecision.Declined]: 'Follow up requested',
         [ReplyDecision.Refused]: 'Refusal confirmed'
       },
       text: {
         [ReplyDecision.Given]:
           '{{consent.child.fullName}} is due to get the {{session.vaccinationNames.sentenceCase}} at school on {{session.summary.datesDisjunction}}',
-        [ReplyDecision.Consult]:
+        [ReplyDecision.Declined]:
           'You’ve told us that you would you like a member of the team to contact you to discuss your options',
         [ReplyDecision.OnlyFluInjection]:
           '{{consent.child.fullName}} is due to get the flu injection at school on {{session.summary.datesDisjunction}}',

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -53,6 +53,7 @@ export const ReplyRefusal = {
   AlreadyGiven: 'Vaccine already received',
   GettingElsewhere: 'Vaccine will be given elsewhere',
   Medical: 'Medical reasons',
+  OutsideSchool: 'Don’t want vaccination in school',
   Personal: 'Personal choice',
   Other: 'Other'
 }
@@ -71,6 +72,8 @@ export const ReplyRefusal = {
  * @property {ReplyDecision} [decision] - Consent decision
  * @property {boolean} [alternative] - Consent for alternative vaccine
  * @property {boolean} [confirmed] - Decision confirmed
+ * @property {boolean} [consultation] - Consultation requested
+ * @property {boolean} declined - Reply declines consent
  * @property {boolean} given - Reply gives consent
  * @property {boolean} invalid - Reply is invalid
  * @property {ReplyMethod} [method] - Reply method
@@ -98,6 +101,8 @@ export class Reply {
     this.alternative =
       options?.alternative && stringToBoolean(options?.alternative)
     this.confirmed = stringToBoolean(options?.confirmed)
+    this.consultation = stringToBoolean(options?.consultation)
+    this.declined = this.decision === ReplyDecision.Refused && this.consultation
     this.given = [
       ReplyDecision.Given,
       ReplyDecision.OnlyFluInjection,
@@ -257,6 +262,9 @@ export class Reply {
     switch (this.decision) {
       case ReplyDecision.Given:
         colour = 'aqua-green'
+        break
+      case ReplyDecision.Declined:
+        colour = 'warm-yellow'
         break
       case ReplyDecision.Refused:
         colour = 'red'

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -24,13 +24,13 @@ import { User } from './user.js'
  * @enum {string}
  */
 export const ReplyDecision = {
+  NoResponse: 'No response',
   Given: 'Consent given',
-  Refused: 'Consent refused',
-  Consult: 'Follow up requested',
   OnlyFluInjection: 'Consent given for flu injection',
   OnlyMenACWY: 'Consent given for MenACWY only',
   OnlyTdIPV: 'Consent given for Td/IPV only',
-  NoResponse: 'No response'
+  Declined: 'Follow up requested',
+  Refused: 'Consent refused'
 }
 
 /**

--- a/app/views/parent/form/check-answers.njk
+++ b/app/views/parent/form/check-answers.njk
@@ -94,6 +94,9 @@
           },
           refusalReasonDetails: {
             href: editPath("refusal-reason-details")
+          },
+          consultation: {
+            href: editPath("consultation")
           }
         })
       })

--- a/app/views/parent/form/confirmation.njk
+++ b/app/views/parent/form/confirmation.njk
@@ -15,6 +15,8 @@
         text: text | safe if not consent.hasAnswersNeedingTriage
       }) }}
 
+      {{ __("consent.confirmation.consultation") | nhsukMarkdown if consent.consultation }}
+
       {{ __("consent.confirmation.triage." + consent.decision, {
         consent: consent,
         session: session

--- a/app/views/parent/form/consultation.njk
+++ b/app/views/parent/form/consultation.njk
@@ -1,31 +1,28 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __n("consent.consultation.title", session.programmes.length) %}
+{% set title = __("consent.consultation.title") %}
 
 {% block form %}
-  {{ heading({
-    title: title
-  }) }}
-
-  {{ __("consent.consultation.description") | nhsukMarkdown }}
-
   {{ radios({
     fieldset: {
       legend: {
         html: heading({
-          classes: "nhsuk-fieldset__legend--s",
-          title: __("consent.consultation.legend")
+          classes: "nhsuk-fieldset__legend--l",
+          title: title
         })
       }
     },
+    hint: {
+      text: __("consent.consultation.hint")
+    },
     items: [{
       text: __("consent.consultation.yes"),
-      value: ReplyDecision.Declined
+      value: true
     },
     {
       text: __("consent.consultation.no"),
-      value: ReplyDecision.Refused
+      value: false
     }],
-    decorate: "consent.decision"
+    decorate: "consent.consultation"
   }) }}
 {% endblock %}

--- a/app/views/parent/form/consultation.njk
+++ b/app/views/parent/form/consultation.njk
@@ -20,7 +20,7 @@
     },
     items: [{
       text: __("consent.consultation.yes"),
-      value: ReplyDecision.Consult
+      value: ReplyDecision.Declined
     },
     {
       text: __("consent.consultation.no"),

--- a/app/views/parent/form/refusal-reason.njk
+++ b/app/views/parent/form/refusal-reason.njk
@@ -31,6 +31,9 @@
         value: ReplyRefusal.GettingElsewhere
       },
       {
+        text: ReplyRefusal.OutsideSchool
+      },
+      {
         text: ReplyRefusal.Gelatine
       } if programmeIsFlu,
       {


### PR DESCRIPTION
Slightly going round in circle on this, but hopefully by doing so we’re centring in on the right approach.

This PR changes the parental consent flow such that we ask parents who refuse to give consent if they’d like to speak to a member of the SAIS team after providing a refusal reason. The journey is slightly different for each refusal reason:

- **Vaccine already received**
  1. Ask for more details (Where did the child get their vaccination?)
  2. Check answers
- **Vaccine will be given elsewhere**
  1. Ask for more details (Where will the child get their vaccination?)
  2. Check answers
- **Don’t want vaccination in school**
  1. Ask if parent would like to speak to member of staff
  2. Check answers
- **Vaccine contains gelatine** [flu programme only]
  1. Ask if parent would like to speak to member of staff
  2. Check answers
- **Medical reasons**
  1. Ask for more details (What medical reasons prevent the child from being vaccinated?)
  2. Ask if parent would like to speak to member of staff
  3. Check answers
- **Personal choice**
  1. Ask if parent would like to speak to member of staff
  2. Check answers
- **Other**
  1. Ask if parent would like to speak to member of staff
  2. Check answers

If a parent refuses and says they do not want to be contacted, we can record this as a hard refusal (do not contact). If on the other hand they refuse but indicate that they would like to be contacted, we can record this as a soft decline (follow-up).

This approach provides a few benefits:
1. Doesn’t narrow the option to speak to SAIS teams only to parents wanting a vaccination outside of school
2. Gives teams context before contacting a parent
3. Helps teams prioritise which parents to follow-up with first 

An outstanding question is, given the earlier choice between nasal or injected vaccine, do we need the ‘Vaccine contains gelatine’ refusal reason? Maybe it’s something we use to begin with to check that the earlier question is working; ideally nobody should be selecting this option.

<img width="720" alt="Screenshot of question asking parents if they would like to speak with a member of the team." src="https://github.com/user-attachments/assets/53fa0943-4ee3-4160-8381-12025e097c71" />
