### PR TITLE
Session notes

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -332,5 +332,26 @@ export const patientSessionController = {
     request.flash('success', __(`triage.edit.success`, { patientSession }))
 
     response.redirect(back)
+  },
+
+  note(request, response) {
+    const { note } = request.body
+    const { data } = request.session
+    const { __, back, patientSession } = response.locals
+
+    patientSession.saveNote({
+      note,
+      createdBy_uid: data.token?.uid || '000123456789'
+    })
+
+    // Clean up session data
+    delete data.note
+
+    request.flash(
+      'success',
+      __(`patientSession.notes.new.success`, { patientSession })
+    )
+
+    response.redirect(back)
   }
 }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1074,10 +1074,19 @@ export const en = {
       title: 'Child record'
     },
     events: {
-      title: 'Activity log',
+      title: 'Session activity and notes',
       count: {
         one: '%s event',
         other: '[0] No events|%s events'
+      }
+    },
+    notes: {
+      label: 'Notes',
+      new: {
+        title: 'Add a note',
+        label: 'Note',
+        confirm: 'Save note',
+        success: 'Note added'
       }
     },
     consent: {

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -3,6 +3,7 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 import { formatDate, today } from '../utils/date.js'
 import {
   formatTag,
+  formatMarkdown,
   formatWithSecondaryText,
   formatTagWithSecondaryText
 } from '../utils/string.js'
@@ -23,7 +24,8 @@ export const EventType = {
   Screen: 'Screen',
   Register: 'Register',
   Record: 'Record',
-  Notice: 'Notice'
+  Notice: 'Notice',
+  Unknown: 'Unknown'
 }
 
 /**
@@ -167,7 +169,8 @@ export class AuditEvent {
         ? [datetime, this.createdBy.link.fullName].join(` · `)
         : datetime,
       datetime,
-      note: this.note && `<blockquote>${this.note}</blockquote>`,
+      note:
+        this.note && `<blockquote>${formatMarkdown(this.note)}</blockquote>`,
       outcomeStatus,
       programmes: this.programmes.flatMap(({ nameTag }) => nameTag).join(' ')
     }

--- a/app/routes/patient-session.js
+++ b/app/routes/patient-session.js
@@ -15,6 +15,7 @@ router.post('/:nhsn/new/pre-screen', patientSession.preScreen)
 router.post('/:nhsn/new/invite', patientSession.invite)
 router.post('/:nhsn/new/remind', patientSession.remind)
 router.post('/:nhsn/new/triage', patientSession.triage)
+router.post('/:nhsn/new/note', patientSession.note)
 
 router.all('/:nhsn/edit/:view', patientSession.readForm)
 router.get('/:nhsn/edit/:view', patientSession.showForm('edit'))

--- a/app/views/patient-session/_note.njk
+++ b/app/views/patient-session/_note.njk
@@ -1,0 +1,22 @@
+{% set cardDescriptionHtml %}
+  {{ textarea({
+    label: {
+      text: __("patientSession.notes.new.label")
+    },
+    rows: 5,
+    decorate: "note"
+  }) }}
+
+  {{ button({
+    text: __("patientSession.notes.new.confirm"),
+    attributes: {
+      formaction: patientSession.uri + "/new/note?referrer=" + patientSession.uri + "/events?activity=" + activity
+    }
+  }) }}
+{% endset %}
+
+{{ details({
+  classes: "nhsuk-expander",
+  text: __("patientSession.notes.new.title"),
+  html: cardDescriptionHtml
+}) }}

--- a/app/views/patient-session/events.njk
+++ b/app/views/patient-session/events.njk
@@ -1,8 +1,10 @@
 {% from "patient-session/_navigation.njk" import patientSessionNavigation with context %}
 
-{% extends "_layouts/default.njk" %}
+{% extends "_layouts/form.njk" %}
 
 {% set title = patient.fullName + " – " + __("patient.events.title") %}
+{% set gridColumns = "three-quarters" %}
+{% set hideConfirmButton = true %}
 {% set view = "events" %}
 
 {% block beforeContent %}
@@ -35,28 +37,28 @@
   }) }}
 {% endblock %}
 
-{% block content %}
-  <div class="nhsuk-u-width-three-quarters">
-    {{ super() }}
+{% block form %}
+  {{ super() }}
 
-    {{ patientSessionNavigation({
-      patientSession: patientSession,
-      view: "events"
-    }) }}
+  {{ patientSessionNavigation({
+    patientSession: patientSession,
+    view: "events"
+  }) }}
 
-    {% for group, auditEvents in patientSession.auditEventLog %}
-      <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color nhsuk-u-font-weight-normal">{{ group }}</h3>
+  {% include "patient-session/_note.njk" %}
 
-      {% for auditEvent in auditEvents %}
-        {{ card({
-          heading: auditEvent.name,
-          headingLevel: 4,
-          descriptionHtml: event(auditEvent),
-          attributes: {
-            id: auditEvent.uuid
-          }
-        }) }}
-      {% endfor %}
+  {% for group, auditEvents in patientSession.auditEventLog %}
+    <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color nhsuk-u-font-weight-normal">{{ group }}</h3>
+
+    {% for auditEvent in auditEvents %}
+      {{ card({
+        heading: auditEvent.name,
+        headingLevel: 4,
+        descriptionHtml: event(auditEvent),
+        attributes: {
+          id: auditEvent.uuid
+        }
+      }) }}
     {% endfor %}
-  </div>
+  {% endfor %}
 {% endblock %}

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -114,7 +114,11 @@
                   label: __("patientSession." + view + ".label"),
                   value: statusHtml,
                   href: (patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view) if view == "register" and patientSession.register != RegistrationOutcome.Pending
-                } if view != "record"
+                } if view != "record",
+                notes: {
+                  label: __("patientSession.notes.label"),
+                  value: patientSession.latestNote.formatted.note
+                }
               })
             }) }}
 


### PR DESCRIPTION
First pass at session notes, and we’ll start simple:

- Rename ‘Activity log’ to ‘Session activity and notes’
- Show an expander, under which a user can add a free text note
- This gets saved in the activity log as a note against the data and user’s name
- The most recent note gets shown on the patient card in session lists

## To do

Some of this can maybe wait until we have some research findings on this feature:

- [ ] Edit a note
- [ ] Delete a note
- [ ] Currently notes are associated with the patient session; in co-administered sessions, it’s likely that these notes should appear for all patient sessions in a session

## Screenshots

![Screenshot of session activity and notes page.](https://github.com/user-attachments/assets/f6107273-53ff-40c1-9dad-70ba0396cd0d)

![Screenshot of session activity and notes page with new note.](https://github.com/user-attachments/assets/f4ec333c-7ea3-483e-99d8-cf936995fa47)

![Screenshot of session activity and notes page with new note saved.](https://github.com/user-attachments/assets/bc945b71-5066-4f8e-acea-d2df60fefde3)

![Screenshot of latest session note showing on a patient card.](https://github.com/user-attachments/assets/ca6f6c15-ac4f-4250-9592-5845c2065d71)
