### PR TITLE
Add ‘Foster carer’ as an explicit choice for a parental relationship

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -505,8 +505,7 @@ export const en = {
         label: 'Give details'
       },
       relationshipOther: {
-        label: 'Relationship to the child',
-        hint: 'For example, carer'
+        label: 'Relationship to the child'
       },
       hasParentalResponsibility: {
         label: 'Do you have parental responsibility?',
@@ -923,8 +922,7 @@ export const en = {
       label: 'Communication needs'
     },
     relationshipOther: {
-      label: 'Give details',
-      hint: 'For example, carer'
+      label: 'Give details'
     },
     notify: {
       title:
@@ -1053,8 +1051,7 @@ export const en = {
         label: 'Phone number'
       },
       relationshipOther: {
-        label: 'Relationship to the child',
-        hint: 'For example, carer'
+        label: 'Relationship to the child'
       }
     },
     parent1: {

--- a/app/models/parent.js
+++ b/app/models/parent.js
@@ -10,6 +10,7 @@ export const ParentalRelationship = {
   Mum: 'Mum',
   Dad: 'Dad',
   Guardian: 'Guardian',
+  Fosterer: 'Foster carer',
   Other: 'Other',
   Unknown: 'Unknown'
 }

--- a/app/views/parent/form/parent.njk
+++ b/app/views/parent/form/parent.njk
@@ -22,7 +22,6 @@
       conditional: {
         html: input({
           label: { text: __("consent.parent.relationshipOther.label") },
-          hint: { text: __("consent.parent.relationshipOther.hint") },
           decorate: "consent.parent.relationshipOther"
         }) + radios({
           fieldset: {

--- a/app/views/patient/form/parent.njk
+++ b/app/views/patient/form/parent.njk
@@ -29,7 +29,6 @@
       conditional: {
         html: input({
           label: { text: __("patient.parent.relationshipOther.label") },
-          hint: { text: __("patient.parent.relationshipOther.hint") },
           decorate: "patient." + parent + ".relationshipOther"
         })
       }

--- a/app/views/reply/form/parent.njk
+++ b/app/views/reply/form/parent.njk
@@ -27,7 +27,6 @@
       conditional: {
         html: input({
           label: { text: __("parent.relationshipOther.label") },
-          hint: { text: __("parent.relationshipOther.hint") },
           decorate: "reply.parent.relationshipOther"
         }) + radios({
           fieldset: {


### PR DESCRIPTION
…and remove the hint text for ‘Other’ that previously said ‘for example, carer’.

There’s a case for removing the question ‘Do you have parental responsibility’, but I forget why we’ve always decided against this. One for another day.

![about-you](https://github.com/user-attachments/assets/f9069eb4-6693-45d0-87bc-c271a6fbcbc5)
