### PR TITLE
Ask foster carers if they have parental responsibility

### DIFF
--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -3,6 +3,7 @@ import wizard from '@x-govuk/govuk-prototype-wizard'
 import { generateChild } from '../generators/child.js'
 import { generateParent } from '../generators/parent.js'
 import { Consent } from '../models/consent.js'
+import { ParentalRelationship } from '../models/parent.js'
 import { ProgrammeType } from '../models/programme.js'
 import { ReplyDecision, ReplyRefusal } from '../models/reply.js'
 import { ConsentWindow, Session, SessionType } from '../models/session.js'
@@ -130,6 +131,10 @@ export const parentController = {
           }
         : {}),
       [`/${session_id}/${consent_uuid}/new/parent`]: {
+        [`/${session_id}/parental-responsibility`]: {
+          data: 'consent.parent.hasParentalResponsibility',
+          value: 'false'
+        },
         [`/${session_id}/${consent_uuid}/new/decision`]: () =>
           !request.session.data.consent?.parent?.tel
       },
@@ -171,6 +176,19 @@ export const parentController = {
     const paths = wizard(journey, request)
     paths.back = referrer || paths.back
     response.locals.paths = paths
+
+    response.locals.parentalRelationshipItems = Object.values(
+      ParentalRelationship
+    )
+      .filter((relationship) => relationship !== ParentalRelationship.Unknown)
+      .map((relationship) => ({
+        text: relationship,
+        value: relationship,
+        ...([
+          ParentalRelationship.Fosterer,
+          ParentalRelationship.Other
+        ].includes(relationship) && { conditional: { html: {} } }) // Added in template
+      }))
 
     if (programmes.length > 1) {
       // MenACWY and Td/IPV: Ask for consent for none, one or all programmes

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -401,6 +401,11 @@ export const en = {
       description:
         'The deadline for responding has passed.\n\n## You can still book a clinic appointment\n\nContact {{organisation.email}} to book a clinic appointment.'
     },
+    'parental-responsibility': {
+      title: 'You cannot give or refuse consent through this service',
+      description:
+        'To give or refuse consent for a child’s vaccination, you need to have parental responsibility.\n\nIf you have any questions, please contact the local health organisation by calling {{organisation.tel}}, or email {{organisation.email}}.'
+    },
     new: {
       'check-answers': {
         confirm: 'Confirm',

--- a/app/models/parent.js
+++ b/app/models/parent.js
@@ -63,7 +63,8 @@ export class Parent {
         ? options?.relationshipOther
         : undefined
     this.hasParentalResponsibility =
-      this.relationship === ParentalRelationship.Other
+      this.relationship === ParentalRelationship.Other ||
+      ParentalRelationship.Fosterer
         ? stringToBoolean(options.hasParentalResponsibility)
         : undefined
     this.notify = stringToBoolean(options?.notify)

--- a/app/views/parent/form/parent.njk
+++ b/app/views/parent/form/parent.njk
@@ -12,27 +12,38 @@
     decorate: "consent.parent.fullName"
   }) }}
 
-  {# `pop` removes `Other` and `Unknown` from ParentalRelationship array #}
+  {%- set fosterCarerHtml = radios({
+    fieldset: {
+      legend: { text: __("consent.parent.hasParentalResponsibility.label") }
+    },
+    hint: { text: __("consent.parent.hasParentalResponsibility.hint") },
+    items: booleanItems,
+    decorate: "consent.parent.hasParentalResponsibility"
+  }) %}
+
+  {%- set otherHtml = input({
+    label: { text: __("consent.parent.relationshipOther.label") },
+    decorate: "consent.parent.relationshipOther"
+  }) + radios({
+    fieldset: {
+      legend: { text: __("consent.parent.hasParentalResponsibility.label") }
+    },
+    hint: { text: __("consent.parent.hasParentalResponsibility.hint") },
+    items: booleanItems,
+    decorate: "consent.parent.hasParentalResponsibility"
+  }) %}
+
+  {# Add conditional html for ‘Foster carer’ option #}
+  {% set items = injectConditionalHtml(parentalRelationshipItems, 3, fosterCarerHtml) %}
+
+  {# Add conditional html for ‘Other’ option #}
+  {% set items = injectConditionalHtml(items, 4, otherHtml) %}
+
   {{ radios({
     fieldset: {
       legend: { text: __("consent.parent.relationship.label") }
     },
-    items: enumItems(ParentalRelationship) | pop | pop | push({
-      text: ParentalRelationship.Other,
-      conditional: {
-        html: input({
-          label: { text: __("consent.parent.relationshipOther.label") },
-          decorate: "consent.parent.relationshipOther"
-        }) + radios({
-          fieldset: {
-            legend: { text: __("consent.parent.hasParentalResponsibility.label") }
-          },
-          hint: { text: __("consent.parent.hasParentalResponsibility.hint") },
-          items: booleanItems,
-          decorate: "consent.parent.hasParentalResponsibility"
-        })
-      }
-    }),
+    items: items,
     decorate: "consent.parent.relationship"
   }) }}
 

--- a/app/views/parent/parental-responsibility.njk
+++ b/app/views/parent/parental-responsibility.njk
@@ -1,0 +1,17 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = __("consent.parental-responsibility.title") %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      {{ heading({
+        title: title
+      }) }}
+
+      {{ __("consent.parental-responsibility.description", {
+        organisation: data.organisation
+      }) | nhsukMarkdown }}
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
In #94 we made ‘Foster carer’ an explicit parental relationship. However, we still need to ascertain if they have parental responsibility.

This option now shows a conditional question asking if they have parental responsibility.

If they select ‘No’ (or select ‘No’ if they select ‘Other’), we now take the user to a parent saying they can’t use this service. This was added to production, but not shown in the prototype.

![Screenshot of ‘Foster carer’ conditional question.](https://github.com/user-attachments/assets/0a783025-2359-4bb3-a46e-cd0fb2437914)

![Screenshot of ‘Other’ conditional question.](https://github.com/user-attachments/assets/1812b4ac-aca1-4338-88b8-4a2a31a77fd0)

![Screenshot of page shown if parent says they do not have parental responsibility.](https://github.com/user-attachments/assets/9f75fe37-5dc2-40b3-a685-897f6418ad5d)

