### PR TITLE
Allow session registration to be toggleable

### DIFF
--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -53,6 +53,8 @@ export const sessionController = {
 
     const session = new Session(
       {
+        // TODO: This needs contextual organisation data to work
+        registration: data.organisation.sessionRegistration,
         ...(data.token && { createdBy_uid: data.token?.uid })
       },
       data
@@ -420,6 +422,10 @@ export const sessionController = {
         }),
         ...(referrer && { back: referrer })
       }
+
+      // Some questions are not asked during journey, so need explicit next path
+      response.locals.paths.next =
+        response.locals.paths.next || `${session.uri}/new/check-answers`
 
       response.locals.clinicIdItems = Object.values(organisation.clinics)
         .map((clinic) => new Clinic(clinic))

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -865,6 +865,10 @@ export const en = {
       label: 'Consent reminders',
       hint: 'Enter the number of weeks before a session takes place'
     },
+    sessionRegistration: {
+      title: 'Will children register their attendance at a session?',
+      label: 'Register attendance'
+    },
     password: {
       label: 'Shared password',
       title: 'Shared password',
@@ -1703,6 +1707,10 @@ export const en = {
       title: 'When should parents get a reminder to give consent?',
       label: 'Consent reminders',
       hint: 'Enter the number of weeks before a session takes place'
+    },
+    registration: {
+      title: 'Will children register their attendance at sessions?',
+      label: 'Register attendance'
     },
     offline: {
       title: 'Record offline',

--- a/app/models/organisation.js
+++ b/app/models/organisation.js
@@ -1,15 +1,18 @@
 import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
+import { stringToBoolean } from '../utils/string.js'
+
 import { Clinic } from './clinic.js'
 import { School } from './school.js'
 
 /**
  * @readonly
- * @enum {number}
+ * @enum {boolean|number}
  */
 export const OrganisationDefaults = {
   SessionOpenWeeks: 3,
-  SessionReminderWeeks: 1
+  SessionReminderWeeks: 1,
+  SessionRegistration: true
 }
 
 /**
@@ -24,7 +27,8 @@ export const OrganisationDefaults = {
  * @property {string} [tel] - Phone number
  * @property {string} [privacyPolicyUrl] - Privacy policy URL
  * @property {number} [sessionOpenWeeks] - Weeks before session to request consent
- * @property {number} [SessionReminderWeeks] - Days before sending first reminder
+ * @property {number} [sessionReminderWeeks] - Days before sending first reminder
+ * @property {boolean} [sessionRegistration] - Should sessions have registration
  * @property {string} [password] - Shared password
  * @property {Array<string>} [clinic_ids] - Clinic organisation IDs
  * @property {Array<string>} [school_urns] - School URNs
@@ -39,9 +43,13 @@ export class Organisation {
     this.tel = options?.tel
     this.privacyPolicyUrl = options?.privacyPolicyUrl
     this.sessionOpenWeeks =
-      options?.sessionOpenWeeks || OrganisationDefaults.SessionOpenWeeks
+      Number(options?.sessionOpenWeeks) || OrganisationDefaults.SessionOpenWeeks
     this.sessionReminderWeeks =
-      options?.sessionReminderWeeks || OrganisationDefaults.SessionReminderWeeks
+      Number(options?.sessionReminderWeeks) ||
+      OrganisationDefaults.SessionReminderWeeks
+    this.sessionRegistration =
+      stringToBoolean(options.sessionRegistration) ||
+      OrganisationDefaults.SessionRegistration
     this.password = options?.password
     this.clinic_ids = options?.clinic_ids || []
     this.school_urns = options?.school_urns || []

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -21,7 +21,8 @@ import {
   formatWithSecondaryText,
   lowerCaseFirst,
   sentenceCaseProgrammeName,
-  stringToArray
+  stringToArray,
+  stringToBoolean
 } from '../utils/string.js'
 
 import { Batch } from './batch.js'
@@ -97,6 +98,7 @@ export const RegistrationOutcome = {
  * @property {object} [openAt_] - Date consent window opens (from `dateInput`)
  * @property {boolean} [closed] - Session closed
  * @property {number} [reminderWeeks] - Weeks before session to send reminders
+ * @property {boolean} [registration] - Does session have registration?
  * @property {object} [register] - Patient register
  * @property {string} [programmePreset] - Programme preset name
  * @property {Array<string>} [catchupProgrammeTypes] - Catchup programmes
@@ -124,6 +126,7 @@ export class Session {
     this.closed = options?.closed || false
     this.reminderWeeks =
       options?.reminderWeeks || OrganisationDefaults.SessionReminderWeeks
+    this.registration = stringToBoolean(options?.registration)
     this.register = options?.register || {}
     this.programmePreset = options?.programmePreset
     this.catchupProgrammeTypes = stringToArray(options?.catchupProgrammeTypes)

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -283,6 +283,10 @@ export const getReportStatus = (patientSession) => {
 export const getRegistrationOutcome = (patientSession) => {
   const { patient, session, report } = patientSession
 
+  if (!session.registration) {
+    return RegistrationOutcome.Present
+  }
+
   if (report === PatientOutcome.Vaccinated) {
     return RegistrationOutcome.Complete
   } else if (session.register[patient.uuid]) {

--- a/app/views/organisation/form/sessions.njk
+++ b/app/views/organisation/form/sessions.njk
@@ -14,7 +14,7 @@
 
   {{ input({
     formGroup: {
-      classes: "nhsuk-u-margin-bottom-6"
+      classes: "nhsuk-u-margin-bottom-7"
     },
     classes: "nhsuk-input--width-2",
     label: {
@@ -27,6 +27,9 @@
   }) }}
 
   {{ input({
+    formGroup: {
+      classes: "nhsuk-u-margin-bottom-7"
+    },
     classes: "nhsuk-input--width-2",
     label: {
       classes: "nhsuk-label--m",
@@ -35,5 +38,17 @@
     hint: { text: __("organisation.sessionReminderWeeks.hint") },
     suffix: "weeks",
     decorate: "organisation.sessionReminderWeeks"
+  }) }}
+
+  {{ radios({
+    classes: "nhsuk-radios--inline",
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--m",
+        text: __("organisation.sessionRegistration.title")
+      }
+    },
+    items: booleanItems,
+    decorate: "organisation.sessionRegistration"
   }) }}
 {% endblock %}

--- a/app/views/organisation/sessions.njk
+++ b/app/views/organisation/sessions.njk
@@ -28,6 +28,9 @@
             },
             sessionReminderWeeks: {
               href: organisation.uri + "/edit/sessions"
+            },
+            sessionRegistration: {
+              href: organisation.uri + "/edit/sessions"
             }
           })
         })

--- a/app/views/session/_navigation.njk
+++ b/app/views/session/_navigation.njk
@@ -29,7 +29,7 @@
         text: __("session.register.label"),
         href: params.session.uri + "/register",
         current: params.view == "register"
-      },
+      } if params.session.registration,
       {
         text: __("session.record.label"),
         href: params.session.uri + "/record",

--- a/app/views/session/edit.njk
+++ b/app/views/session/edit.njk
@@ -38,6 +38,9 @@
         },
         reminderWeeks: {
           href: session.uri + "/edit/reminders"
+        },
+        registration: {
+          href: session.uri + "/edit/registration"
         }
       })
     })

--- a/app/views/session/form/check-answers.njk
+++ b/app/views/session/form/check-answers.njk
@@ -36,6 +36,9 @@
         },
         reminderWeeks: {
           href: session.uri + "/new/reminders"
+        },
+        registration: {
+          href: session.uri + "/new/registration"
         }
       })
     })

--- a/app/views/session/form/registration.njk
+++ b/app/views/session/form/registration.njk
@@ -1,0 +1,19 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.registration.title") %}
+
+{% block form %}
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-label--l",
+        html: heading({
+          caption: session.location.name,
+          title: title
+        })
+      }
+    },
+    items: booleanItems,
+    decorate: "session.registration"
+  }) }}
+{% endblock %}


### PR DESCRIPTION
Currently, sessions include registration. This means that all children need to have their attendance registered before they can be vaccinated.

This PR:

- Makes session registration toggleable. When creating a new session, the organisation’s (and/or later, a team’s) default is used, but can be overridden when creating a new session. It can also be turned on/off when editing a session.
- When registration is not enabled, the ‘Register’ tab is not shown for a session. Children who are ready to vaccinate are automatically added to the ‘Record vaccinations’ view.

Also need to make sure new sessions respect organisation defaults, but this requires a separate bit of work to make sure organisation data works like other data does in the prototype.

## Screenshots

### Organisation session defaults

![Screenshot of organisation session defaults.](https://github.com/user-attachments/assets/9846ebf5-8069-457c-b19b-41ae2a69c15e)

### Editing organisation session defaults

![Screenshot of editing organisation session defaults.](https://github.com/user-attachments/assets/61d78d44-cb26-4ca3-8d2b-b600354b50a8)

### Reviewing a new session, using session defaults

![Screenshot of new session check answers page.](https://github.com/user-attachments/assets/f9a23c7b-b6f7-4f53-adc9-070c7cddd4c2)

### Editing session registration

![Screenshot of editing session registration.](https://github.com/user-attachments/assets/f853f893-75da-4a73-b69a-1c5797c22243)
