### PR TITLE
Update health questions

### DIFF
--- a/app/datasets/health-conditions.js
+++ b/app/datasets/health-conditions.js
@@ -103,7 +103,7 @@ export const healthConditions = {
       'Spoke with parent. Safe to vaccinate, but monitor for adverse reactions'
   },
   covid19: {
-    householdImmuneSystem:
+    immuneSystemCloseContact:
       'Their grandmother lives with us, and has recently got covid.',
     triageNote:
       'Spoke with parent. Child has sufficiently recovered. It is safe to vaccinate'

--- a/app/datasets/health-questions.js
+++ b/app/datasets/health-questions.js
@@ -5,8 +5,9 @@ export const healthQuestions = {
     detailsHint: false
   },
   allergy: {
-    label: 'Does the child have any severe allergies?',
-    hint: false,
+    label:
+      'Has the child had a severe allergic reaction (anaphylaxis) to a previous dose of the nasal flu vaccine, or any ingredient of the vaccine?',
+    hint: 'This includes gelatine, neomycin or gentamicin',
     detailsHint: false
   },
   asthma: {
@@ -17,23 +18,23 @@ export const healthQuestions = {
   asthmaAdmitted: {
     label:
       'Has the child ever been admitted to intensive care because of their asthma?',
-    hint: false,
+    hint: 'This does not include visits to A&E or stays in hospital wards outside the intensive care unit',
     detailsHint: false
   },
   asthmaSteroids: {
-    label: 'Does the child take steroid tablets for their asthma?',
+    label: 'Does the child take oral steroids for their asthma?',
     hint: 'This does not include medicine taken through an inhaler',
-    detailsHint: 'Include the steroid name, dose and length of course'
+    detailsHint: 'Include the steroid name, dose and end date of the course'
   },
   bleeding: {
     label:
-      'Does the child have a bleeding disorder or another medical condition they receive treatment for?',
+      'Does the child have a bleeding disorder or are they taking anticoagulant therapy?',
     hint: false,
     detailsHint: false
   },
   eggAllergy: {
     label:
-      'Has the child ever been admitted to intensive care due to an allergic reaction to egg?',
+      'Has the child ever been admitted to intensive care due to a severe allergic reaction (anaphylaxis) to egg?',
     hint: false,
     detailsHint: false
   },
@@ -48,11 +49,12 @@ export const healthQuestions = {
     hint: false,
     detailsHint: false
   },
-  householdImmuneSystem: {
+  immuneSystemCloseContact: {
     label:
-      'Is anyone in the child’s household currently having treatment that severely affects their immune system?',
+      'Is the child in regular close contact with anyone currently having treatment that severely affects their immune system?',
     hint: false,
-    detailsHint: false
+    detailsHint:
+      'Let us know if they are able to avoid contact with the immunocompromised person for 2 weeks'
   },
   medicationAllergies: {
     label: 'Does the child have any allergies to medication?',
@@ -61,7 +63,7 @@ export const healthQuestions = {
   },
   medicalConditions: {
     label:
-      'Does the child have any medical conditions for which they receive treatment?',
+      'Does the child have any other medical conditions the immunisation team should be aware of?',
     hint: false,
     detailsHint: false
   },

--- a/app/datasets/vaccines.js
+++ b/app/datasets/vaccines.js
@@ -32,7 +32,8 @@ export default {
         }
       },
       'immuneSystem': {},
-      'householdImmuneSystem': {},
+      'immuneSystemCloseContact': {},
+      'bleeding': {},
       'eggAllergy': {},
       'medicationAllergies': {},
       'medicalConditions': {},
@@ -71,6 +72,7 @@ export default {
       VaccineSideEffect.Unwell
     ],
     healthQuestions: {
+      'bleeding': {},
       'allergy': {},
       'medicalConditions': {},
       'previousReaction': {},
@@ -105,6 +107,7 @@ export default {
       VaccineSideEffect.PainArms
     ],
     healthQuestions: {
+      'bleeding': {},
       'allergy': {},
       'medicalConditions': {},
       'previousReaction': {}


### PR DESCRIPTION
- Add bleeding health question if giving consent for nasal flu (as we’d need an answer to this if the parent consents to the injection as an alternative)
  - Also make sure we are asking this question for all injected vaccines 
- Update some questions to be more prescriptive, or add hint text to guide parents

Note: the prototype currently treats all health questions equally; if there is a ‘yes’ answer, triage is needed. In reality, some answers will not require triaging (but will be still be shown to the nurse).