### PR TITLE
Update flu consent emails to be more concise and show CTA nearer the end

### DIFF
--- a/app/emails/consent/_about-the-nasal-spray.njk
+++ b/app/emails/consent/_about-the-nasal-spray.njk
@@ -1,7 +1,7 @@
-## About the nasal spray
+## How the vaccine is given
 
-The nasal spray contains gelatine. If your child does not use gelatine products, or the nasal spray is not suitable for medical reasons, they could have an injection instead.
+Most children are given the vaccine as a nasal spray. This is a quick and painless spray up the nose and offers the best protection against flu.
 
-The nasal spray gives children the best protection against flu. However, the injected vaccine is a good alternative if the nasal spray vaccine cannot be used.
+The nasal spray contains a small amount of gelatine derived from pigs (porcine gelatine). If your child does not use gelatine products, or cannot have the nasal spray for medical reasons, they could have an injection instead.
 
 [Find out more about the use of gelatine in the flu vaccine (including the views of faith communities)](https://www.gov.uk/government/publications/vaccines-and-porcine-gelatine/vaccines-and-porcine-gelatine)

--- a/app/emails/consent/_trouble-using-online-form.njk
+++ b/app/emails/consent/_trouble-using-online-form.njk
@@ -1,3 +1,1 @@
-## If you cannot use the online form
-
 If you cannot use the online form, you can respond over the phone using the contact details below.

--- a/app/emails/consent/invite-catch-up.njk
+++ b/app/emails/consent/invite-catch-up.njk
@@ -12,15 +12,15 @@ Our records show your child has not had their HPV vaccination. Pupils usually ha
 [Learn more about the {{ programme.vaccineName.sentenceCase }} on GOV.UK]({{ programme.guidance.url }}) ({{ programme.guidance.hint }})
 {% endfor %}
 
+{% if consent.child.school.phase == SchoolPhase.Secondary %}
+{% include "emails/consent/_talk-to-your-child.njk" %}
+{% endif %}
+
 {% include "emails/consent/_how-to-respond.njk" %}
 
 You need to respond by {{ session.formatted.firstDate }}.
 
 If you do not respond, you’ll be sent automatic reminders. Responding will stop reminders.
-
-{% if consent.child.school.phase == SchoolPhase.Secondary %}
-{% include "emails/consent/_talk-to-your-child.njk" %}
-{% endif %}
 
 {% include "emails/consent/_trouble-using-online-form.njk" %}
 

--- a/app/emails/consent/invite-reminder.njk
+++ b/app/emails/consent/invite-reminder.njk
@@ -16,11 +16,11 @@ If you’ve already responded to the consent request, you can ignore this messag
 {% include "emails/consent/_about-the-nasal-spray.njk" %}
 {% endif %}
 
-{% include "emails/consent/_how-to-respond.njk" %}
-
 {% if consent.child.school.phase == SchoolPhase.Secondary %}
 {% include "emails/consent/_talk-to-your-child.njk" %}
 {% endif %}
+
+{% include "emails/consent/_how-to-respond.njk" %}
 
 {% include "emails/consent/_trouble-using-online-form.njk" %}
 

--- a/app/emails/consent/invite-subsequent-reminder.njk
+++ b/app/emails/consent/invite-subsequent-reminder.njk
@@ -14,11 +14,11 @@ If you want your child to be vaccinated in school, you need to give your consent
 {% include "emails/consent/_about-the-nasal-spray.njk" %}
 {% endif %}
 
-{% include "emails/consent/_how-to-respond.njk" %}
-
 {% if consent.child.school.phase == SchoolPhase.Secondary %}
 {% include "emails/consent/_talk-to-your-child.njk" %}
 {% endif %}
+
+{% include "emails/consent/_how-to-respond.njk" %}
 
 {% include "emails/consent/_trouble-using-online-form.njk" %}
 

--- a/app/emails/consent/invite.njk
+++ b/app/emails/consent/invite.njk
@@ -12,7 +12,9 @@ We’re coming to {{ session.location.name }} on {{ session.summary.dates }} to 
 
 We would like your consent to vaccinate {{ consent.child.firstName }}. You can give this by filling in our online form (the link is below).
 
+{% if session.dates.length > 1 %}
 Note that we’re unable to say on which of the above dates individual pupils will have the vaccination, due to the large number of children being vaccinated.
+{% endif %}
 
 {% for programme in session.primaryProgrammes %}
 ## About the {{ programme.vaccineName.sentenceCase }}

--- a/app/emails/consent/invite.njk
+++ b/app/emails/consent/invite.njk
@@ -30,15 +30,15 @@ Note that we’re unable to say on which of the above dates individual pupils wi
 {% include "emails/consent/_about-the-nasal-spray.njk" %}
 {% endif %}
 
+{% if consent.child.school.phase == SchoolPhase.Secondary %}
+{% include "emails/consent/_talk-to-your-child.njk" %}
+{% endif %}
+
 {% include "emails/consent/_how-to-respond.njk" %}
 
 You need to respond by {{ session.formatted.firstDate }}.
 
 If you do not respond, you’ll be sent automatic reminders. Responding will stop reminders.
-
-{% if consent.child.school.phase == SchoolPhase.Secondary %}
-{% include "emails/consent/_talk-to-your-child.njk" %}
-{% endif %}
 
 {% include "emails/consent/_trouble-using-online-form.njk" %}
 

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -71,7 +71,7 @@ export const programmeTypes = {
       startPage:
         'Use this service to give or refuse consent for your child to have a flu vaccination.\n\nThis vaccination is recommended for school age children every year.\n\n## About the children’s flu vaccine\n\nThe children’s flu vaccine helps protect children against flu. Vaccinating children also protects others who are vulnerable to flu, such as babies and older people.\n\nThe vaccine is given as a nasal spray. This gives the most effective protection.\n\nSome children can have an injection instead, for example if they:\n\n- have had a serious allergic reaction to a previous dose of the nasal spray vaccine\n- have a severe egg allergy\n- have asthma that’s being treated with long-term steroid tablets',
       description:
-        'The vaccine protects against flu, which can cause serious health problems such as bronchitis and pneumonia.\n\nBy preventing the spread of flu, the vaccine also protects others who are vulnerable, such as babies and older people.\n\nThe vaccination is a quick and painless spray up the nose. Even if your child had the vaccine last year, the type of flu can vary each winter, so we recommend they have it again this year.',
+        'The vaccine protects against flu, which can cause serious health problems such as bronchitis and pneumonia. It is recommended for children from Reception to Year 11 every year.',
       url: 'https://www.nhs.uk/vaccinations/child-flu-vaccine/'
     },
     guidance: {


### PR DESCRIPTION
Improve the consent request emails, reducing their length and making the consent call to action easier to find, by:

- Making the description of the flu vaccination more concise
- Making the description of flu nasal spray and alternative injected vaccine more concise
- Only showing the note about multiple session dates if there are multiple session dates
- Changing the ordering of content to make sure the call to action is nearer the end
- Removing the ‘If you cannot use the online form’ heading and showing this consent under ‘How to respond’ 