### PR TITLE
Fix layout of patient session for narrower viewports

### DIFF
--- a/app/assets/stylesheets/core/objects/_grid.scss
+++ b/app/assets/stylesheets/core/objects/_grid.scss
@@ -1,18 +1,27 @@
 @use "../../vendor/nhsuk-frontend" as *;
 
-// Search filters and results
-.app-grid-column-filters > .nhsuk-card--feature,
-.app-grid-column-results > .nhsuk-card--feature,
-.app-grid-column-results > .nhsuk-warning-callout {
-  margin-top: nhsuk-spacing(3);
+// Patient session and record
+.app-grid-column-patient-session {
+  @include nhsuk-grid-column(three-quarters, $float: right, $at: large-desktop, $class: false);
 }
 
+.app-grid-column-patient-record {
+  @include nhsuk-grid-column(one-quarter, $float: right, $at: large-desktop, $class: false);
+}
+
+// Search filters and results
 .app-grid-column-filters {
   @include nhsuk-grid-column(filters, $at: large-desktop, $class: false);
 }
 
 .app-grid-column-results {
   @include nhsuk-grid-column(results, $at: large-desktop, $class: false);
+}
+
+.app-grid-column-filters > .nhsuk-card--feature,
+.app-grid-column-results > .nhsuk-card--feature,
+.app-grid-column-results > .nhsuk-warning-callout {
+  margin-top: nhsuk-spacing(3);
 }
 
 // Sticky column

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -54,23 +54,7 @@
   }) }}
 
   <div class="nhsuk-grid-row">
-    <div class="nhsuk-grid-column-three-quarters">
-      {% include "patient-session/_consent.njk" %}
-
-      {% if options.canTriage %}
-        {% include "patient-session/_triage.njk" %}
-      {% endif %}
-
-      {% if options.canReport %}
-        {% include "patient-session/_report.njk" %}
-      {% endif %}
-
-      {% if options.canRecord %}
-        {% include "patient-session/_record.njk" %}
-      {% endif %}
-    </div>
-
-    <div class="nhsuk-grid-column-one-quarter app-grid-column--sticky-below-secondary-navigation">
+    <div class="app-grid-column-patient-record app-grid-column--sticky-below-secondary-navigation">
       {{ heading({
         classes: "nhsuk-u-margin-top-1",
         level: 3,
@@ -85,6 +69,22 @@
         })
       }) }}
       {{ link(patient.uri + "?referrer=" + referrer, "View full child record") | nhsukMarkdown }}
+    </div>
+
+    <div class="app-grid-column-patient-session">
+      {% include "patient-session/_consent.njk" %}
+
+      {% if options.canTriage %}
+        {% include "patient-session/_triage.njk" %}
+      {% endif %}
+
+      {% if options.canReport %}
+        {% include "patient-session/_report.njk" %}
+      {% endif %}
+
+      {% if options.canRecord %}
+        {% include "patient-session/_record.njk" %}
+      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Add custom grid columns that `float: right` instead of `float: left`. This allows us to have the patient record in the source order first, but have it appear on the right at larger breakpoints.