### PR TITLE
Capture vaccine method when recording verbal consent for flu programme

### DIFF
--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -267,10 +267,7 @@ export const parentController = {
     view = view.startsWith('health-question-') ? 'health-question' : view
 
     // Only ask for details if question does not have sub-questions
-    const healthQuestions = Object.fromEntries(
-      consent.healthQuestionsForDecision
-    )
-    const hasSubQuestions = healthQuestions[key]?.conditional
+    const hasSubQuestions = consent.healthQuestionsForDecision[key]?.conditional
 
     response.render(`parent/form/${view}`, { key, hasSubQuestions })
   },

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -77,7 +77,7 @@ export const patientSessionController = {
       hasTriage: triageNotes.length > 0,
       hasSupplier: data?.token?.role === UserRole.HCA,
       canRecord:
-        permissions?.vaccineMethods.includes(patientSession.vaccineMethod) &&
+        permissions?.vaccineMethods?.includes(patientSession.vaccineMethod) &&
         register === RegistrationOutcome.Present &&
         nextActivity === Activity.Record,
       canReport:

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1429,10 +1429,28 @@ export const en = {
           'Does the child agree to having the {{programme.vaccineName.sentenceCase}}?',
         Parent:
           'Do they agree to {{patient.firstName}} having the {{programme.vaccineName.sentenceCase}}?'
+      },
+      yes: {
+        label: 'Yes'
+      },
+      nasal: {
+        label: 'Yes, for the nasal spray'
+      },
+      injection: {
+        label: 'Yes, for the injected vaccine only'
+      },
+      no: {
+        label: 'No'
+      },
+      noResponse: {
+        label: 'No response'
       }
     },
     alternative: {
-      label: 'Consent given for injected vaccine'
+      label: 'Consent given for injected vaccine',
+      title:
+        'Do they also agree to the injected vaccine if the nasal spray is not suitable?',
+      hint: 'For example, if the child is heavily congested on the day of the vaccination'
     },
     invalid: {
       label: 'Invalid response'

--- a/app/models/consent.js
+++ b/app/models/consent.js
@@ -1,81 +1,13 @@
-import vaccines from '../datasets/vaccines.js'
 import { hasAnswersNeedingTriage } from '../utils/reply.js'
 import { formatLinkWithSecondaryText } from '../utils/string.js'
 
-import { ProgrammeType } from './programme.js'
-import { Reply, ReplyDecision } from './reply.js'
-import { VaccineMethod } from './vaccine.js'
+import { Reply } from './reply.js'
 
 /**
  * @class Consent
  * @augments Reply
  */
 export class Consent extends Reply {
-  /**
-   * Get health questions to show based on programme and decision given
-   *
-   * @returns {Map} - Health questions
-   */
-  get healthQuestionsForDecision() {
-    const { Flu, HPV, MenACWY, TdIPV } = ProgrammeType
-    const { Injection, Nasal } = VaccineMethod
-    const programme = this.session.primaryProgrammes[0]
-
-    const healthQuestionsForDecision = new Map()
-    let consentedMethod
-    let consentedVaccine
-
-    // Consent given for flu programme with method of vaccination
-    if (programme.type === Flu) {
-      consentedMethod =
-        this.decision === ReplyDecision.OnlyFluInjection ? Injection : Nasal
-      consentedVaccine = Object.values(vaccines).find(
-        (programme) =>
-          programme.type === Flu && programme.method === consentedMethod
-      )
-    }
-
-    // Consent given for HPV programme
-    if (programme.type === HPV) {
-      consentedVaccine = Object.values(vaccines).find(
-        (programme) => programme.type === HPV
-      )
-    }
-
-    // Consent given for MenACWY programme only
-    if (this.decision === ReplyDecision.OnlyMenACWY) {
-      consentedVaccine = Object.values(vaccines).find(
-        (programme) => programme.type === MenACWY
-      )
-    }
-
-    // Consent given for Td/IPV programme only
-    if (this.decision === ReplyDecision.OnlyTdIPV) {
-      consentedVaccine = Object.values(vaccines).find(
-        (programme) => programme.type === TdIPV
-      )
-    }
-
-    // Consent given for all programmes
-    if (ReplyDecision.Given && !consentedVaccine) {
-      consentedVaccine = this.session.vaccines
-    }
-
-    const consentedVaccines = Array.isArray(consentedVaccine)
-      ? consentedVaccine
-      : [consentedVaccine]
-    for (const vaccine of consentedVaccines) {
-      for (const [key, value] of Object.entries(vaccine.healthQuestions)) {
-        healthQuestionsForDecision.set(key, value)
-      }
-    }
-
-    // Always ask support question last
-    healthQuestionsForDecision.set('support', {})
-
-    return healthQuestionsForDecision
-  }
-
   /**
    * Answers in this consent response need triage
    *

--- a/app/utils/consent.js
+++ b/app/utils/consent.js
@@ -19,7 +19,7 @@ export const getHealthQuestionPaths = (pathPrefix, consent) => {
   }
 
   const paths = {}
-  const healthQuestions = [...consent.healthQuestionsForDecision.entries()]
+  const healthQuestions = Object.entries(consent.healthQuestionsForDecision)
 
   healthQuestions.forEach(([key, question], index) => {
     const questionPath = getHealthQuestionPath(key, pathPrefix)

--- a/app/views/reply/form/decision.njk
+++ b/app/views/reply/form/decision.njk
@@ -17,18 +17,39 @@
         })
       }
     },
-    items: [{
-      text: "Yes",
-      value: ReplyDecision.Given
-    }, {
-      text: "No",
-      value: ReplyDecision.Refused
-    }, {
-      divider: "or"
-    }, {
-      text: "No response",
-      value: ReplyDecision.NoResponse
-    }],
+    items: [
+      {
+        text: __('reply.decision.nasal.label') if programme.hasAlternativeVaccines else __('reply.decision.yes.label'),
+        value: ReplyDecision.Given,
+        conditional: {
+          html: radios({
+            fieldset: {
+              legend: {
+                text: __("reply.alternative.title")
+              }
+            },
+            hint: { text: __("reply.alternative.hint") },
+            items: booleanItems,
+            decorate: "reply.alternative"
+          })
+        } if programme.hasAlternativeVaccines
+      },
+      {
+        text: __('reply.decision.injection.label'),
+        value: ReplyDecision.OnlyFluInjection
+      } if programme.hasAlternativeVaccines,
+      {
+        text: __('reply.decision.no.label'),
+        value: ReplyDecision.Refused
+      },
+      {
+        divider: "or"
+      },
+      {
+        text: __('reply.decision.noResponse.label'),
+        value: ReplyDecision.NoResponse
+      }
+    ],
     decorate: "reply.decision"
   }) }}
 

--- a/app/views/reply/form/health-answers.njk
+++ b/app/views/reply/form/health-answers.njk
@@ -16,8 +16,8 @@
               label: { text: __("reply.healthAnswers.details") },
               decorate: ["reply", "healthAnswers", key, "details"]
             })
-          } if not patientSession.vaccine.healthQuestions[key].conditional else {
-            html: questions(patientSession.vaccine.healthQuestions[key].conditional)
+          } if not value.conditional else {
+            html: questions(value.conditional)
           }
         },
         {
@@ -35,5 +35,5 @@
     title: title
   }) }}
 
-  {{ questions(patientSession.vaccine.healthQuestions) }}
+  {{ questions(reply.healthQuestionsForDecision) }}
 {% endblock %}


### PR DESCRIPTION
When getting consent for the flu programme:

- Rename the ‘Yes’ option to ‘Yes, for the nasal spray’ and ask a follow-on conditional question about consent for the alternative injected vaccines
- Add an option to get consent for the injected vaccine only, ‘Yes, for the injected vaccine only’ 

<img width="670" alt="Screenshot of initial question." src="https://github.com/user-attachments/assets/e73d398a-aac0-49bd-b803-41ef58843d92" />

<img width="800" alt="Screenshot of conditional question." src="https://github.com/user-attachments/assets/f11975a2-5160-4ca8-a7fe-89f0efaae158" />
