### PR TITLE
Send manual reminders to parents who have not responded to consent requests

### DIFF
--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -472,6 +472,14 @@ export const sessionController = {
     response.end(buffer)
   },
 
+  sendReminders(request, response) {
+    const { __, session } = response.locals
+
+    request.flash('success', __(`session.reminders.success`, { session }))
+
+    response.redirect(session.uri)
+  },
+
   close(request, response) {
     const { data } = request.session
     const { __, session } = response.locals

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -189,7 +189,7 @@ export const sessionController = {
         ({ nextActivity, register, vaccineMethod }) =>
           nextActivity === Activity.Record &&
           register !== RegistrationOutcome.Pending &&
-          permissions?.vaccineMethods.includes(vaccineMethod)
+          permissions?.vaccineMethods?.includes(vaccineMethod)
       )
     }
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1645,6 +1645,16 @@ export const en = {
       label: 'Unmatched responses',
       warning: 'You need to review unmatched consent responses for this session'
     },
+    reminders: {
+      label: 'Send reminders',
+      title: 'Manage consent reminders',
+      description:
+        'Mavis automatically sends email and text reminders to parents who have not responded to the initial consent request.\n\nAutomatic reminders are sent 14, 7 and 3 days before a session.\n\nYou can also send reminders manually. Mavis will then skip the next automatic reminder if it’s due to be sent within 3 days.',
+      preConfirm:
+        'Mavis will skip the next automatic reminder if it’s scheduled to be sent within 3 days.',
+      confirm: 'Send manual consent reminders',
+      success: 'Manual consent reminders sent'
+    },
     address: {
       label: 'Address'
     },
@@ -1672,7 +1682,9 @@ export const en = {
       label: 'Vaccinated'
     },
     patientsToGetConsent: {
-      label: 'No consent response'
+      label: 'No consent response',
+      reminders:
+        '{{session.patientsToGetConsent.length}} parents out of {{session.patients.length}} have not responded yet'
     },
     patientsToFollowUp: {
       label: 'Requested follow up'
@@ -1743,6 +1755,14 @@ export const en = {
       title: 'When should parents get a request to give consent?',
       label: 'Consent requests',
       hint: 'For example, 27 3 2025'
+    },
+    reminderDates: {
+      label: 'Automatic consent reminder schedule',
+      description: 'Reminders will be sent automatically on these dates:'
+    },
+    nextReminderDate: {
+      label: 'Next reminder',
+      text: 'The next automatic consent reminder will be sent on %s'
     },
     reminderWeeks: {
       title: 'When should parents get a reminder to give consent?',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1676,30 +1676,64 @@ export const en = {
       }
     },
     patientsRefused: {
-      label: 'Consent refused'
+      label: 'Consent refused',
+      count: {
+        one: '%s child with consent refused',
+        other:
+          '[0] No children with consent refused|%s children with consent refused'
+      }
     },
     patientsVaccinated: {
-      label: 'Vaccinated'
+      label: 'Vaccinated',
+      count: {
+        one: '%s child vaccinated',
+        other: '[0] No children vaccinated|%s children vaccinated'
+      }
     },
     patientsToGetConsent: {
       label: 'No consent response',
+      count: {
+        one: '%s child with no response',
+        other: '[0] No children with no response|%s children with no response'
+      },
       reminders:
         '{{session.patientsToGetConsent.length}} parents out of {{session.patients.length}} have not responded yet'
     },
     patientsToFollowUp: {
-      label: 'Requested follow up'
+      label: 'Requested follow up',
+      count: {
+        one: '%s child to follow up',
+        other: '[0] No children to follow up|%s children to follow up'
+      }
     },
     patientsToResolveConsent: {
-      label: 'Conflicting consent'
+      label: 'Conflicting consent',
+      count: {
+        one: '%s child to review',
+        other: '[0] No children to review|%s children to review'
+      }
     },
     patientsToTriage: {
-      label: 'Triage needed'
+      label: 'Triage needed',
+      count: {
+        one: '%s child to triage',
+        other: '[0] No children to triage|%s children to triage'
+      }
     },
     patientsToRegister: {
-      label: 'Register attendance'
+      label: 'Register attendance',
+      count: {
+        one: '%s child to register',
+        other: '[0] No children to register|%s children to register'
+      }
     },
     patientsToRecord: {
-      label: 'Ready for vaccinator'
+      label: 'Ready for vaccinator',
+      count: {
+        one: '%s child ready for vaccinator',
+        other:
+          '[0] No children ready for vaccinator|%s children ready for vaccinator'
+      }
     },
     activities: {
       label: 'Action required'

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -216,6 +216,20 @@ export class Session {
   }
 
   /**
+   * Get dates reminders to give consent are sent
+   *
+   * @returns {Array<Date>|undefined} - Reminder dates
+   */
+  get reminderDates() {
+    const reminderDates = []
+    for (const date of this.dates) {
+      reminderDates.push(removeDays(date, 7))
+    }
+
+    return reminderDates
+  }
+
+  /**
    * Get date next automated reminder will be sent
    *
    * @returns {Date|undefined} - Next reminder date
@@ -788,6 +802,13 @@ export class Session {
         ? this.dates.map((date) => formatDate(date, { dateStyle: 'full' }))
         : ''
 
+    const formattedReminderDates =
+      this.reminderDates.length > 0
+        ? this.reminderDates.map((date) =>
+            formatDate(date, { dateStyle: 'full' })
+          )
+        : []
+
     const formattedNextReminderDate = formatDate(this.nextReminderDate, {
       dateStyle: 'full'
     })
@@ -832,6 +853,11 @@ export class Session {
         day: 'numeric'
       }),
       openAt: formatDate(this.openAt, { dateStyle: 'full' }),
+      reminderDates: formatList(formattedReminderDates).replace(
+        'nhsuk-list--bullet',
+        'app-list--spaced'
+      ),
+      nextReminderDate: formattedNextReminderDate,
       reminderWeeks: formattedNextReminderDate
         ? formatWithSecondaryText(
             `Send ${reminderWeeks} before each session`,

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -820,8 +820,18 @@ export class Session {
       patientsToRecord = Object.entries(this.patientsToRecord).map(
         ([name, patientSessions]) =>
           this.programmes.length > 1
-            ? `${filters.plural(patientSessions.length, 'child')} for ${name}`
-            : `${filters.plural(patientSessions.length, 'child')}`
+            ? patientSessions.length > 0
+              ? formatLink(
+                  `${this.uri}/record`,
+                  `${filters.plural(patientSessions.length, 'child')} are ready for ${name}`
+                )
+              : 'No children'
+            : patientSessions.length > 0
+              ? formatLink(
+                  `${this.uri}/record`,
+                  `${filters.plural(patientSessions.length, 'child')} are ready`
+                )
+              : 'No children'
       )
     }
 
@@ -832,8 +842,18 @@ export class Session {
         Object.entries(this.patientsVaccinated).map(
           ([name, patientSessions]) =>
             this.programmes.length > 1
-              ? `${filters.plural(patientSessions.length, 'vaccination')} given for ${name}`
-              : `${filters.plural(patientSessions.length, 'vaccination')} given`
+              ? patientSessions.length > 0
+                ? formatLink(
+                    `${this.uri}/outcomes?outcome=${PatientOutcome.Vaccinated}`,
+                    `${filters.plural(patientSessions.length, 'vaccination')} given for ${name}`
+                  )
+                : `No vaccinations given for ${name}`
+              : patientSessions.length > 0
+                ? formatLink(
+                    `${this.uri}/outcomes?outcome=${PatientOutcome.Vaccinated}`,
+                    `${filters.plural(patientSessions.length, 'vaccination')} given`
+                  )
+                : 'No vaccinations given'
         )
     }
 
@@ -869,30 +889,6 @@ export class Session {
       consents:
         this.consents.length > 0
           ? filters.plural(this.consents.length, 'child')
-          : undefined,
-      patientsToGetConsent:
-        this.patientsToGetConsent?.length > 0
-          ? filters.plural(this.patientsToGetConsent.length, 'child')
-          : undefined,
-      patientsToFollowUp:
-        this.patientsToFollowUp?.length > 0
-          ? filters.plural(this.patientsToFollowUp.length, 'child')
-          : undefined,
-      patientsToResolveConsent:
-        this.patientsToResolveConsent?.length > 0
-          ? filters.plural(this.patientsToResolveConsent.length, 'child')
-          : undefined,
-      patientsRefused:
-        this.patientsRefused?.length > 0
-          ? filters.plural(this.patientsRefused.length, 'child')
-          : undefined,
-      patientsToTriage:
-        this.patientsToTriage?.length > 0
-          ? filters.plural(this.patientsToTriage.length, 'child')
-          : undefined,
-      patientsToRegister:
-        this.patientsToRegister?.length > 0
-          ? filters.plural(this.patientsToRegister.length, 'child')
           : undefined,
       patientsToRecord: patientsToRecord
         ? patientsToRecord.join('<br>')

--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -29,6 +29,7 @@ router.post('/:session_id/edit/:view', session.updateForm)
 router.post('/:session_id/close', session.close)
 router.post('/:session_id/default-batch', session.updateDefaultBatch)
 router.post('/:session_id/offline', session.downloadFile)
+router.post('/:session_id/reminders', session.sendReminders)
 
 router.all('/:session_id/:view', session.readPatientSessions)
 router.post('/:session_id/:view', session.filterPatientSessions)

--- a/app/views/session/reminders.njk
+++ b/app/views/session/reminders.njk
@@ -1,0 +1,73 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.reminders.title") %}
+{% set confirmButtonText = __("session.reminders.confirm") %}
+
+{% block beforeContent %}
+  {{ breadcrumb({
+    items: [{
+      text: __("home.show.title"),
+      href: "/"
+    }, {
+      text: __("session.list.title"),
+      href: "/sessions"
+    }, {
+      text: session.location.name,
+      href: "/sessions/" + session.id
+    }]
+  }) }}
+{% endblock %}
+
+{% block form %}
+  {{ heading({
+    title: title
+  }) }}
+
+  {{ __("session.reminders.description") | nhsukMarkdown }}
+
+  {{ heading({
+    classes: "nhsuk-u-margin-bottom-2",
+    level: 2,
+    size: "m",
+    title: __("session.dates.label")
+  }) }}
+
+  {{ session.formatted.dates | safe }}
+
+  {% set detailsHtml %}
+    {{ __("session.reminderDates.description") | nhsukMarkdown }}
+
+    {{ session.formatted.reminderDates | safe }}
+  {% endset %}
+
+  {{ details({
+    text: __("session.reminderDates.label"),
+    html: detailsHtml
+  }) }}
+
+  {% set insetTextHtml %}
+    {{ heading({
+      classes: "nhsuk-u-margin-bottom-2",
+      level: 3,
+      size: "s",
+      title: __("session.patientsToGetConsent.reminders", {
+        session: session
+      })
+    }) }}
+
+    {{ __("session.nextReminderDate.text", session.formatted.nextReminderDate) | nhsukMarkdown }}
+  {% endset %}
+
+  {{ insetText({
+    html: insetTextHtml
+  }) }}
+
+  {{ heading({
+    classes: "nhsuk-u-margin-bottom-2",
+    level: 2,
+    size: "m",
+    title: "Send parents a manual consent reminder"
+  }) }}
+
+  {{ __("session.reminders.preConfirm") | nhsukMarkdown }}
+{% endblock %}

--- a/app/views/session/show.njk
+++ b/app/views/session/show.njk
@@ -47,21 +47,38 @@
     }) }}
 
     {{ summaryList({
-      rows: summaryRows(session, {
-        patients: {
-          changeText: __("session.upload-class-list.title"),
-          href: "/uploads/new?type=" + UploadType.School + "&urn=" + session.school.urn if session.type == SessionType.School
+      rows: [
+        {
+          key: {
+            text: __("session.patients.label")
+          },
+          value: {
+            text: session.formatted.patients
+          },
+          actions: {
+            items: [{
+              text: __("session.upload-class-list.title"),
+              href: "/uploads/new?type=" + UploadType.School + "&urn=" + session.school.urn if session.type == SessionType.School
+            }]
+          }
         },
-        patientsRefused: {
-          changeText: __("actions.review"),
-          href: session.uri + "/consent?consent=" + ConsentOutcome.Refused
-        },
-        patientsAttending: {},
-        patientsVaccinated: {
-          changeText: __("actions.review"),
-          href: session.uri + "/outcome?outcome=" + VaccinationOutcome.Vaccinated
+        {
+          key: {
+            text: __("session.patientsRefused.label")
+          },
+          value: {
+            html: link(session.uri + "/consent?consent=" + ConsentOutcome.Refused, __n("session.patientsRefused.count", session.patientsRefused.length))
+          }
+        } if session.patientsRefused.length,
+        {
+          key: {
+            text: __("session.patientsVaccinated.label")
+          },
+          value: {
+            html: session.formatted.patientsVaccinated
+          }
         }
-      })
+      ]
     }) }}
 
     {% if not session.isUnplanned %}
@@ -73,36 +90,70 @@
       }) }}
 
       {{ summaryList({
-        rows: summaryRows(session, {
-          consents: {
-            changeText: __("actions.review"),
-            href: session.uri + "/consents"
-          },
-          patientsToGetConsent: {
-            changeText: __("actions.review"),
-            href: session.uri + "/consent?consent=" + ConsentOutcome.NoResponse
-          },
-          patientsToFollowUp: {
-            changeText: __("actions.review"),
-            href: session.uri + "/consent?consent=" + ConsentOutcome.Declined
-          },
-          patientsToResolveConsent: {
-            changeText: __("actions.review"),
-            href: session.uri + "/consent?consent=" + ConsentOutcome.Inconsistent
-          },
-          patientsToTriage: {
-            changeText: __("actions.review"),
-            href: session.uri + "/screen?screen=" + ScreenOutcome.NeedsTriage
-          },
-          patientsToRegister: {
-            changeText: __("actions.review"),
-            href: session.uri + "/register"
-          },
-          patientsToRecord: {
-            changeText: __("actions.review"),
-            href: session.uri + "/record"
+        rows: [
+          {
+            key: {
+              text: __("session.consents.label")
+            },
+            value: {
+              html: link(session.uri + "/consent?consent=" + ConsentOutcome.Given, __n("consent.count", session.consents.length))
+            }
+          } if session.consents.length,
+          {
+            key: {
+              text: __("session.patientsToGetConsent.label")
+            },
+            value: {
+              html: link(session.uri + "/consent?consent=" + ConsentOutcome.NoResponse, __n("session.patientsToGetConsent.count", session.patientsToGetConsent.length))
+            },
+            actions: {
+              items: [{
+                text: __("session.reminders.label"),
+                href: session.uri + "/reminders"
+              }]
+            }
+          } if session.patientsToGetConsent.length,
+          {
+            key: {
+              text: __("session.patientsToFollowUp.label")
+            },
+            value: {
+              html: link(session.uri + "/consent?consent=" + ConsentOutcome.Declined, __n("session.patientsToFollowUp.count", session.patientsToFollowUp.length))
+            }
+          } if session.patientsToFollowUp.length,
+          {
+            key: {
+              text: __("session.patientsToFollowUp.label")
+            },
+            value: {
+              html: link(session.uri + "/consent?consent=" + ConsentOutcome.Inconsistent, __n("session.patientsToResolveConsent.count", session.patientsToResolveConsent.length))
+            }
+          } if session.patientsToResolveConsent.length,
+          {
+            key: {
+              text: __("session.patientsToTriage.label")
+            },
+            value: {
+              html: link(session.uri + "/screen?screen=" + ScreenOutcome.NeedsTriage, __n("session.patientsToTriage.count", session.patientsToTriage.length))
+            }
+          } if session.patientsToTriage.length,
+          {
+            key: {
+              text: __("session.patientsToRegister.label")
+            },
+            value: {
+              html: link(session.uri + "/register", __n("session.patientsToRegister.count", session.patientsToRegister.length))
+            }
+          } if session.patientsToRegister.length,
+          {
+            key: {
+              text: __("session.patientsToRecord.label")
+            },
+            value: {
+              html: session.formatted.patientsToRecord
+            }
           }
-        })
+        ]
       }) }}
     {% endif %}
 


### PR DESCRIPTION
- Update session overview and actions required summary lists to link the values to respective lists, reserving the action area for links to specific actions.
  - This gives us a clear area from which to link to the ‘Manage consent reminders’ page 
- Add ‘Manage consent reminders’ page, which gives overview of upcoming sessions, reminders schedule and how many parents would get a reminder. This is taken from the ops prototype, and work done earlier this year by @rivalee.

## Outstanding questions

Once a set of reminders has been sent, and there are no parents for which to send a manual reminder to, what should this page show? Is it possible you could use this page to keep spamming the same parents over and over again (not sure that’s a great idea).

## Screenshots

![Screenshot of session overview page.](https://github.com/user-attachments/assets/dca95f42-1c90-4a2c-a90d-922bc0a4b9bb)

![Screenshot of session reminders page.](https://github.com/user-attachments/assets/beb28a77-dfd2-48ab-8909-cbab3800d514)

![Screenshot of session overview page with success banner.](https://github.com/user-attachments/assets/3f669ed3-84a8-4bae-9323-bf9ab4fd888f)