### PR TITLE
Support delegation to healthcare assistants under National protocol (injected flu vaccine only)

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -40,7 +40,8 @@ export const patientSessionController = {
       session,
       triage,
       triageNotes,
-      vaccine
+      vaccine,
+      vaccineMethod
     } = patientSession
 
     const outcomed = patientSession.siblingPatientSessions.filter(
@@ -50,6 +51,15 @@ export const patientSessionController = {
     const notOutcomed = patientSession.siblingPatientSessions.filter(
       ({ outcome }) => outcome === PatientOutcome.NoOutcomeYet
     )
+
+    // Upgrade permissions according to session delegation settings
+    if (session.nationalProtocol) {
+      permissions.vaccineMethods.push(VaccineMethod.Injection)
+    }
+
+    const userIsHCA = data?.token?.role === UserRole.HCA
+    const userHasSupplier =
+      vaccineMethod === VaccineMethod.Nasal || session.nationalProtocol
 
     response.locals.options = {
       // Show outstanding vaccinations
@@ -75,7 +85,7 @@ export const patientSessionController = {
       canTriage: triage !== TriageOutcome.NotNeeded,
       // Patient already triaged
       hasTriage: triageNotes.length > 0,
-      hasSupplier: data?.token?.role === UserRole.HCA,
+      hasSupplier: userIsHCA && userHasSupplier,
       canRecord:
         permissions?.vaccineMethods?.includes(patientSession.vaccineMethod) &&
         register === RegistrationOutcome.Present &&

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -111,6 +111,11 @@ export const sessionController = {
 
     let results = session.patientSessions
 
+    // Upgrade permissions according to session delegation settings
+    if (session.nationalProtocol) {
+      permissions.vaccineMethods.push(VaccineMethod.Injection)
+    }
+
     // Convert year groups query into an array of numbers
     let yearGroups
     if (yearGroup) {

--- a/app/datasets/vaccines.js
+++ b/app/datasets/vaccines.js
@@ -1,3 +1,4 @@
+import { VaccinationProtocol } from '../models/vaccination.js'
 import {
   PreScreenQuestion,
   VaccineMethod,
@@ -17,6 +18,7 @@ export default {
       size: '197KB'
     },
     method: VaccineMethod.Nasal,
+    delegationProtocol: VaccinationProtocol.PSD,
     dose: 0.2,
     sideEffects: [
       VaccineSideEffect.BlockedNose,
@@ -58,6 +60,7 @@ export default {
       size: '174KB'
     },
     method: VaccineMethod.Injection,
+    delegationProtocol: VaccinationProtocol.National,
     dose: 0.5,
     sideEffects: [
       VaccineSideEffect.PainSite,
@@ -98,6 +101,7 @@ export default {
       size: '110KB'
     },
     method: VaccineMethod.Injection,
+    delegationProtocol: VaccinationProtocol.PSD,
     dose: 0.5,
     sideEffects: [
       VaccineSideEffect.Bruising,
@@ -132,6 +136,7 @@ export default {
       size: '2.64MB'
     },
     method: VaccineMethod.Injection,
+    delegationProtocol: VaccinationProtocol.PSD,
     dose: 0.5,
     sideEffects: [
       VaccineSideEffect.PainSite,
@@ -168,6 +173,7 @@ export default {
       size: '177KB'
     },
     method: VaccineMethod.Injection,
+    delegationProtocol: VaccinationProtocol.PSD,
     dose: 0.5,
     sideEffects: [
       VaccineSideEffect.PainSite,

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1580,6 +1580,35 @@ export const en = {
       title: 'Register attendance',
       information: 'You can register attendance when a session is in progress.'
     },
+    delegation: {
+      title: 'Delegation'
+    },
+    nationalProtocol: {
+      label: 'Use National protocol',
+      title:
+        'Can healthcare assistants administer the injected flu vaccine using the national protocol?',
+      yes: {
+        label: 'Yes',
+        hint: 'Healthcare assistants can administer an injected vaccine when supplied by a nurse'
+      },
+      no: {
+        label: 'No',
+        hint: 'Only nurses can administer the injected vaccine'
+      }
+    },
+    psdProtocol: {
+      label: 'Use Patient Specific Direction',
+      title:
+        'Can healthcare assistants administer the nasal spray using Patient Specific Direction (PSD)?',
+      yes: {
+        label: 'Yes',
+        hint: 'Healthcare assistants can supply and administer a nasal spray when instructed by a prescriber'
+      },
+      no: {
+        label: 'No',
+        hint: 'Healthcare assistants can only administer a nasal spray when supplied by a nurse'
+      }
+    },
     record: {
       label: 'Record vaccinations',
       title: 'Record vaccinations',

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -102,6 +102,8 @@ export const RegistrationOutcome = {
  * @property {object} [register] - Patient register
  * @property {string} [programmePreset] - Programme preset name
  * @property {Array<string>} [catchupProgrammeTypes] - Catchup programmes
+ * @property {boolean} [nationalProtocol] - Enable national protocol
+ * @property {boolean} [psdProtocol] - Enable PSD protocol
  * @property {object} [defaultBatch_ids] - Vaccine SNOMED code: Default batch ID
  */
 export class Session {
@@ -131,7 +133,13 @@ export class Session {
     this.register = options?.register || {}
     this.programmePreset = options?.programmePreset
     this.catchupProgrammeTypes = stringToArray(options?.catchupProgrammeTypes)
+    this.psdProtocol = stringToBoolean(options?.psdProtocol) || false
     this.defaultBatch_ids = options?.defaultBatch_ids || {}
+
+    if (this.programmePreset === 'SeasonalFlu') {
+      this.nationalProtocol =
+        stringToBoolean(options?.nationalProtocol) || false
+    }
   }
 
   /**

--- a/app/models/vaccination.js
+++ b/app/models/vaccination.js
@@ -75,7 +75,9 @@ export const VaccinationSite = {
  * @enum {string}
  */
 export const VaccinationProtocol = {
-  PGD: 'Patient Group Directions'
+  PGD: 'Patient Group Direction (PGD)',
+  PSD: 'Patient Specific Direction (PSD)',
+  National: 'National protocol'
 }
 
 /**

--- a/app/models/vaccination.js
+++ b/app/models/vaccination.js
@@ -131,7 +131,9 @@ export class Vaccination {
     this.injectionSite = options?.injectionSite
     this.dose = this.given ? options?.dose || '' : undefined
     this.sequence = options?.sequence
-    this.protocol = this.given ? VaccinationProtocol.PGD : undefined
+    this.protocol = this.given
+      ? options?.protocol || VaccinationProtocol.PGD
+      : undefined
     this.note = options?.note || ''
     this.school_urn = options?.school_urn
     this.session_id = options?.session_id

--- a/app/models/vaccine.js
+++ b/app/models/vaccine.js
@@ -67,6 +67,7 @@ export const VaccineMethod = {
  * @property {object} [leaflet] - Leaflet
  * @property {number} dose - Dosage
  * @property {VaccineMethod} method - Method
+ * @property {Array<VaccinationProtocol>} delegationProtocols - Delegation protocols
  * @property {Array<VaccineSideEffect>} sideEffects - Side effects
  * @property {object} healthQuestions - Health questions
  * @property {Array<PreScreenQuestion>} preScreenQuestions - Pre-screening questions
@@ -81,6 +82,7 @@ export class Vaccine {
     this.leaflet = options.leaflet
     this.dose = options.dose
     this.method = options.method
+    this.delegationProtocols = options.delegationProtocols || []
     this.sideEffects = options.sideEffects
     this.healthQuestions = options.healthQuestions
     this.preScreenQuestions = options.preScreenQuestions

--- a/app/models/vaccine.js
+++ b/app/models/vaccine.js
@@ -67,7 +67,7 @@ export const VaccineMethod = {
  * @property {object} [leaflet] - Leaflet
  * @property {number} dose - Dosage
  * @property {VaccineMethod} method - Method
- * @property {Array<VaccinationProtocol>} delegationProtocols - Delegation protocols
+ * @property {VaccinationProtocol} delegationProtocol - Delegation protocol
  * @property {Array<VaccineSideEffect>} sideEffects - Side effects
  * @property {object} healthQuestions - Health questions
  * @property {Array<PreScreenQuestion>} preScreenQuestions - Pre-screening questions
@@ -82,7 +82,7 @@ export class Vaccine {
     this.leaflet = options.leaflet
     this.dose = options.dose
     this.method = options.method
-    this.delegationProtocols = options.delegationProtocols || []
+    this.delegationProtocol = options.delegationProtocol
     this.sideEffects = options.sideEffects
     this.healthQuestions = options.healthQuestions
     this.preScreenQuestions = options.preScreenQuestions

--- a/app/views/patient-session/_record.njk
+++ b/app/views/patient-session/_record.njk
@@ -70,7 +70,7 @@
     label: { text: __("patientSession.preScreen.suppliedBy.title") },
     items: userItems(data.users, patientSession.preScreen.suppliedBy),
     decorate: "patientSession.preScreen.suppliedBy_uid"
-  }) if options.hasSupplier and patientSession.vaccineMethod == VaccineMethod.Nasal }}
+  }) if options.hasSupplier }}
 
   <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--l">
 

--- a/app/views/session/edit.njk
+++ b/app/views/session/edit.njk
@@ -41,6 +41,12 @@
         },
         registration: {
           href: session.uri + "/edit/registration"
+        },
+        psdProtocol: {
+          href: session.uri + "/edit/delegation"
+        },
+        nationalProtocol: {
+          href: session.uri + "/edit/delegation"
         }
       })
     })

--- a/app/views/session/form/check-answers.njk
+++ b/app/views/session/form/check-answers.njk
@@ -39,6 +39,12 @@
         },
         registration: {
           href: session.uri + "/new/registration"
+        },
+        psdProtocol: {
+          href: session.uri + "/new/delegation"
+        },
+        nationalProtocol: {
+          href: session.uri + "/new/delegation"
         }
       })
     })

--- a/app/views/session/form/delegation.njk
+++ b/app/views/session/form/delegation.njk
@@ -1,0 +1,52 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.delegation.title") %}
+{% set hasNasalVaccine = session.delegationNasalProtocols.length > 0 %}
+
+{% block form %}
+  {{ heading({
+    caption: session.location.name,
+    title: title
+  }) }}
+
+  {{ radios({
+    formGroup: {
+      classes: "nhsuk-u-margin-bottom-6"
+    },
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--m",
+        text: __("session.psdProtocol.title")
+      }
+    },
+    items: [{
+      text: "Yes",
+      hint: { text: __("session.psdProtocol.yes.hint") },
+      value: true
+    }, {
+      text: "No",
+      hint: { text: __("session.psdProtocol.no.hint") },
+      value: false
+    }],
+    decorate: "session.psdProtocol"
+  }) }}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--m",
+        text: __("session.nationalProtocol.title")
+      }
+    },
+    items: [{
+      text: "Yes",
+      hint: { text: __("session.nationalProtocol.yes.hint") },
+      value: true
+    }, {
+      text: "No",
+      hint: { text: __("session.nationalProtocol.no.hint") },
+      value: false
+    }],
+    decorate: "session.nationalProtocol"
+  }) if session.programmePreset === "SeasonalFlu" }}
+{% endblock %}


### PR DESCRIPTION
Different protocols allow vaccinations to be delegated to healthcare assistants:

1. PGD (with supply) can be used for the flu nasal spray
2. National protocol can be used for the injected flu vaccine
3. PSD can also be used for the nasal flu spray (and potentially injected vaccines for other programmes)

A nurse will always vaccinate using the PGD protocol, for which they essentially supply the vaccine to themselves.

#104 added support for the first protocol.

**This PR addresses the second protocol, as well as enabling protocols for a session**.

Another PR will add support for prescribing vaccines, allowing a HCA to record a vaccine using the PSD protocol.

## Edit protocols used in a session

![Screenshot of a session ready to edit.](https://github.com/user-attachments/assets/f261401a-76eb-4209-a522-0309813e644b)

![Screenshot of session delegation options.](https://github.com/user-attachments/assets/7b946b30-0dcd-4b9a-a139-1d6c799cf710)

## Injected flu vaccination recorded using the national protocol

Most of the process for recording injected flu vaccines under the national protocol is the same as that for recording a vaccination using the nasal spray under PGD. By enabling the national protocol for a session, HCAs can also see children who need the injection in the ‘Record vaccinations’ list.

When viewing an injected vaccination supplied by a nurse and performed by a HCA, the protocol is shown as ‘National protocol’ instead of ‘Patient Group Directions’:

![vaccination-check-answers-im](https://github.com/user-attachments/assets/dc23aa6a-1ee3-4ebd-bbd3-d50be92d22e0)
 
