### PR TITLE
Support delegation to healthcare assistants under PSD (nasal spray only)

### DIFF
--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -1,4 +1,4 @@
-import { UserRole } from '../models/user.js'
+import { UserRole } from '../enums.js'
 
 export const accountController = {
   changeRole(request, response) {

--- a/app/controllers/download.js
+++ b/app/controllers/download.js
@@ -1,9 +1,9 @@
 import wizard from '@x-govuk/govuk-prototype-wizard'
 
+import { UserRole } from '../enums.js'
 import { Download } from '../models/download.js'
 import { Organisation } from '../models/organisation.js'
 import { Programme } from '../models/programme.js'
-import { UserRole } from '../models/user.js'
 
 export const downloadController = {
   readForm(request, response, next, download_id) {

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -1,5 +1,5 @@
+import { UserRole } from '../enums.js'
 import { Notice } from '../models/notice.js'
-import { UserRole } from '../models/user.js'
 
 export const homeController = {
   redirect(request, response, next) {

--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -1,12 +1,17 @@
 import wizard from '@x-govuk/govuk-prototype-wizard'
 
+import {
+  ConsentWindow,
+  ParentalRelationship,
+  ProgrammeType,
+  ReplyDecision,
+  ReplyRefusal,
+  SessionType
+} from '../enums.js'
 import { generateChild } from '../generators/child.js'
 import { generateParent } from '../generators/parent.js'
 import { Consent } from '../models/consent.js'
-import { ParentalRelationship } from '../models/parent.js'
-import { ProgrammeType } from '../models/programme.js'
-import { ReplyDecision, ReplyRefusal } from '../models/reply.js'
-import { ConsentWindow, Session, SessionType } from '../models/session.js'
+import { Session } from '../models/session.js'
 import { getHealthQuestionPaths } from '../utils/consent.js'
 import { formatList, kebabToCamelCase } from '../utils/string.js'
 

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -60,7 +60,10 @@ export const patientSessionController = {
 
     const userIsHCA = data?.token?.role === UserRole.HCA
     const userHasSupplier =
-      vaccineMethod === VaccineMethod.Nasal || session.nationalProtocol
+      // Injected vaccine using national protocol
+      (vaccineMethod === VaccineMethod.Injection && session.nationalProtocol) ||
+      // Nasal spray using PGD
+      (vaccineMethod === VaccineMethod.Nasal && !session.psdProtocol)
 
     response.locals.options = {
       // Show outstanding vaccinations

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -14,6 +14,7 @@ import {
   VaccineMethod
 } from '../enums.js'
 import { Gillick } from '../models/gillick.js'
+import { Instruction } from '../models/instruction.js'
 import { PatientSession } from '../models/patient-session.js'
 import { Programme } from '../models/programme.js'
 import { Vaccination } from '../models/vaccination.js'
@@ -335,6 +336,18 @@ export const patientSessionController = {
     const { data } = request.session
     const { __, back, patientSession } = response.locals
 
+    if (triage.psd) {
+      const instruction = new Instruction({
+        createdBy_uid: data.token?.uid,
+        programme_id: patientSession.programme.id,
+        patientSession_uuid: patientSession.uuid
+      })
+
+      instruction.create(instruction, data)
+
+      patientSession.giveInstruction(instruction)
+    }
+
     patientSession.recordTriage({
       outcome: triage.outcome,
       name:
@@ -344,6 +357,9 @@ export const patientSessionController = {
       note: triage.note,
       createdBy_uid: data.token?.uid || '000123456789'
     })
+
+    // Update patient session
+    patientSession.update(patientSession, data)
 
     // Clean up session data
     delete data.triage

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -1,21 +1,22 @@
-import { Gillick } from '../models/gillick.js'
 import {
   Activity,
   ConsentOutcome,
+  ConsentWindow,
   PatientOutcome,
-  PatientSession,
+  PreScreenQuestion,
+  ProgrammeType,
+  RegistrationOutcome,
   ScreenOutcome,
-  TriageOutcome
-} from '../models/patient-session.js'
-import { Programme, ProgrammeType } from '../models/programme.js'
-import { ConsentWindow, RegistrationOutcome } from '../models/session.js'
-import { UserRole } from '../models/user.js'
-import {
-  Vaccination,
+  TriageOutcome,
+  UserRole,
   VaccinationOutcome,
-  VaccinationSite
-} from '../models/vaccination.js'
-import { PreScreenQuestion, VaccineMethod } from '../models/vaccine.js'
+  VaccinationSite,
+  VaccineMethod
+} from '../enums.js'
+import { Gillick } from '../models/gillick.js'
+import { PatientSession } from '../models/patient-session.js'
+import { Programme } from '../models/programme.js'
+import { Vaccination } from '../models/vaccination.js'
 import { today } from '../utils/date.js'
 
 export const patientSessionController = {

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -15,6 +15,10 @@ import { Vaccination } from '../models/vaccination.js'
 import { today } from '../utils/date.js'
 import { hasAnswersNeedingTriage } from '../utils/reply.js'
 import { formatParent } from '../utils/string.js'
+import {
+  getScreenOutcomesForConsentMethod,
+  getScreenVaccinationMethod
+} from '../utils/triage.js'
 
 export const replyController = {
   read(request, response, next, reply_uuid) {
@@ -148,9 +152,10 @@ export const replyController = {
         patientSession.session.primaryProgrammes.length > 1
       response.locals.isMultiProgrammeSession = isMultiProgrammeSession
 
-      response.locals.programme = isMultiProgrammeSession
+      const programme = isMultiProgrammeSession
         ? reply.programme_id && Programme.read(reply.programme_id, data)
         : patientSession.session.primaryProgrammes[0]
+      response.locals.programme = programme
 
       response.locals.triage = {
         ...(type === 'edit' && triage), // Previous values
@@ -255,6 +260,14 @@ export const replyController = {
           })
         )
       }
+
+      response.locals.screenOutcomesForConsentMethod =
+        getScreenOutcomesForConsentMethod(programme, [reply])
+
+      response.locals.screenVaccinationMethod = getScreenVaccinationMethod(
+        programme,
+        [reply]
+      )
 
       next()
     }

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -1,16 +1,17 @@
 import wizard from '@x-govuk/govuk-prototype-wizard'
 
-import { GillickCompetent } from '../models/gillick.js'
+import {
+  GillickCompetent,
+  ReplyDecision,
+  ReplyMethod,
+  ReplyRefusal,
+  VaccinationOutcome
+} from '../enums.js'
 import { Parent } from '../models/parent.js'
 import { PatientSession } from '../models/patient-session.js'
 import { Programme } from '../models/programme.js'
-import {
-  Reply,
-  ReplyDecision,
-  ReplyMethod,
-  ReplyRefusal
-} from '../models/reply.js'
-import { Vaccination, VaccinationOutcome } from '../models/vaccination.js'
+import { Reply } from '../models/reply.js'
+import { Vaccination } from '../models/vaccination.js'
 import { today } from '../utils/date.js'
 import { hasAnswersNeedingTriage } from '../utils/reply.js'
 import { formatParent } from '../utils/string.js'

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -3,6 +3,7 @@ import _ from 'lodash'
 
 import { Batch } from '../models/batch.js'
 import { Clinic } from '../models/clinic.js'
+import { InstructionOutcome } from '../models/instruction.js'
 import { Organisation } from '../models/organisation.js'
 import {
   Activity,
@@ -39,7 +40,16 @@ export const sessionController = {
   show(request, response) {
     let { view } = request.params
 
-    if (['consent', 'screen', 'register', 'record', 'outcome'].includes(view)) {
+    if (
+      [
+        'consent',
+        'screen',
+        'instruct',
+        'register',
+        'record',
+        'outcome'
+      ].includes(view)
+    ) {
       view = 'activity'
     } else if (!view) {
       view = 'show'
@@ -151,14 +161,15 @@ export const sessionController = {
       )
     }
 
-    // Filter by screen/register/outcome status
+    // Filter by screen/instruct/register/outcome status
     const filters = {
       screen: request.query.screen || 'none',
+      instruct: request.query.instruct || 'none',
       register: request.query.register || 'none',
       outcome: request.query.outcome || 'none'
     }
 
-    for (const activity of ['screen', 'register', 'outcome']) {
+    for (const activity of ['screen', 'instruct', 'register', 'outcome']) {
       if (activity === view && filters[view] !== 'none') {
         results = results.filter(
           (patientSession) => patientSession[view] === filters[view]
@@ -257,7 +268,7 @@ export const sessionController = {
     }
 
     // Screen/register/outcome status filter options (select one)
-    for (const activity of ['screen', 'register', 'outcome']) {
+    for (const activity of ['screen', 'instruct', 'register', 'outcome']) {
       const screenOutcomes = session.programmes.find(
         (programme) => programme.hasAlternativeVaccines
       )
@@ -268,6 +279,7 @@ export const sessionController = {
 
       const statusItems = {
         screen: screenOutcomes,
+        instruct: InstructionOutcome,
         register: RegistrationOutcome,
         outcome: VaccinationOutcome
       }
@@ -305,6 +317,7 @@ export const sessionController = {
     delete data.q
     delete data.consent
     delete data.screen
+    delete data.instruct
     delete data.register
     delete data.report
 
@@ -321,6 +334,7 @@ export const sessionController = {
       'q',
       'triage',
       'screen',
+      'instruct',
       'register',
       'outcome',
       'vaccineMethod'

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -1,25 +1,23 @@
 import wizard from '@x-govuk/govuk-prototype-wizard'
 import _ from 'lodash'
 
-import { Batch } from '../models/batch.js'
-import { Clinic } from '../models/clinic.js'
-import { InstructionOutcome } from '../models/instruction.js'
-import { Organisation } from '../models/organisation.js'
 import {
   Activity,
   ConsentOutcome,
+  InstructionOutcome,
   PatientOutcome,
-  ScreenOutcome
-} from '../models/patient-session.js'
-import { Patient } from '../models/patient.js'
-import {
   RegistrationOutcome,
-  Session,
+  ScreenOutcome,
   SessionStatus,
-  SessionType
-} from '../models/session.js'
-import { VaccinationOutcome } from '../models/vaccination.js'
-import { VaccineMethod } from '../models/vaccine.js'
+  SessionType,
+  VaccinationOutcome,
+  VaccineMethod
+} from '../enums.js'
+import { Batch } from '../models/batch.js'
+import { Clinic } from '../models/clinic.js'
+import { Organisation } from '../models/organisation.js'
+import { Patient } from '../models/patient.js'
+import { Session } from '../models/session.js'
 import { getDateValueDifference } from '../utils/date.js'
 import { getResults, getPagination } from '../utils/pagination.js'
 import { formatYearGroup } from '../utils/string.js'

--- a/app/controllers/upload.js
+++ b/app/controllers/upload.js
@@ -1,7 +1,8 @@
 import wizard from '@x-govuk/govuk-prototype-wizard'
 
+import { UploadType } from '../enums.js'
 import { Notice } from '../models/notice.js'
-import { Upload, UploadType } from '../models/upload.js'
+import { Upload } from '../models/upload.js'
 import { getDateValueDifference } from '../utils/date.js'
 import { formatYearGroup } from '../utils/string.js'
 

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -65,10 +65,8 @@ export const vaccinationController = {
     const { patientSession_uuid } = request.query
     const { data } = request.session
 
-    const { patient, session, programme, vaccine } = PatientSession.read(
-      patientSession_uuid,
-      data
-    )
+    const { patient, session, programme, vaccine, instruction } =
+      PatientSession.read(patientSession_uuid, data)
     const { identifiedBy, injectionSite, ready, selfId, suppliedBy_uid } =
       data.patientSession.preScreen
 
@@ -114,10 +112,9 @@ export const vaccinationController = {
         protocol = VaccinationProtocol.National
       }
 
-      // TODO: Only use PSD protocol if PSD enable and vaccine was prescribed
-      // if (session.psdProtocol && isNasalSpray) {
-      //   protocol = VaccinationProtocol.PSD
-      // }
+      if (session.psdProtocol && instruction) {
+        protocol = VaccinationProtocol.PSD
+      }
     }
 
     const vaccination = new Vaccination({

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -2,18 +2,20 @@ import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 import wizard from '@x-govuk/govuk-prototype-wizard'
 import _ from 'lodash'
 
-import { Batch } from '../models/batch.js'
-import { PatientSession } from '../models/patient-session.js'
-import { Programme } from '../models/programme.js'
-import { User, UserRole } from '../models/user.js'
 import {
-  Vaccination,
   VaccinationMethod,
   VaccinationOutcome,
   VaccinationProtocol,
-  VaccinationSite
-} from '../models/vaccination.js'
-import { Vaccine, VaccineMethod } from '../models/vaccine.js'
+  VaccinationSite,
+  VaccineMethod,
+  UserRole
+} from '../enums.js'
+import { Batch } from '../models/batch.js'
+import { PatientSession } from '../models/patient-session.js'
+import { Programme } from '../models/programme.js'
+import { User } from '../models/user.js'
+import { Vaccination } from '../models/vaccination.js'
+import { Vaccine } from '../models/vaccine.js'
 
 export const vaccinationController = {
   read(request, response, next, vaccination_uuid) {

--- a/app/data.js
+++ b/app/data.js
@@ -2,6 +2,7 @@ import vaccines from './datasets/vaccines.js'
 import batches from '../.data/batches.json' with { type: 'json' }
 import clinics from '../.data/clinics.json' with { type: 'json' }
 import cohorts from '../.data/cohorts.json' with { type: 'json' }
+import instructions from '../.data/instructions.json' with { type: 'json' }
 import moves from '../.data/moves.json' with { type: 'json' }
 import notices from '../.data/notices.json' with { type: 'json' }
 import organisations from '../.data/organisations.json' with { type: 'json' }
@@ -32,6 +33,7 @@ export default {
   clinics,
   cohorts,
   features: {},
+  instructions,
   moves,
   notices,
   organisation,

--- a/app/datasets/users.js
+++ b/app/datasets/users.js
@@ -1,4 +1,4 @@
-import { UserRole } from '../models/user.js'
+import { UserRole } from '../enums.js'
 
 export default [
   {

--- a/app/datasets/vaccines.js
+++ b/app/datasets/vaccines.js
@@ -1,9 +1,9 @@
-import { VaccinationProtocol } from '../models/vaccination.js'
 import {
   PreScreenQuestion,
   VaccineMethod,
+  VaccinationProtocol,
   VaccineSideEffect
-} from '../models/vaccine.js'
+} from '../enums.js'
 
 export default {
   // Flu vaccines

--- a/app/enums.js
+++ b/app/enums.js
@@ -233,7 +233,7 @@ export const ProgrammePreset = {
     term: SchoolTerm.Autumn
   },
   HPV: {
-    active: false,
+    active: true,
     adolescent: true,
     primaryProgrammeTypes: [ProgrammeType.HPV],
     term: SchoolTerm.Spring
@@ -313,6 +313,17 @@ export const SchoolPhase = {
 export const SchoolYear = {
   Y2024: '2024 to 2025',
   Y2023: '2023 to 2024'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ScreenVaccinationMethod = {
+  NasalOnly: 'The parent has consented to the nasal spray only',
+  InjectionOnly: 'The parent has consented to the injected vaccine only',
+  NasalOrInjection:
+    'The parent has consented to the injected vaccine being offered if the nasal spray is not suitable'
 }
 
 /**

--- a/app/enums.js
+++ b/app/enums.js
@@ -1,0 +1,475 @@
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const AcademicYear = {
+  Y2024: '2024/25',
+  Y2025: '2025/26'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const Activity = {
+  Consent: 'Get consent',
+  Triage: 'Triage health questions',
+  Register: 'Register attendance',
+  Record: 'Record vaccination',
+  DoNotRecord: 'Do not vaccinate',
+  Report: 'Report vaccination'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ConsentOutcome = {
+  NoRequest: 'Request failed',
+  NoResponse: 'No response',
+  Inconsistent: 'Conflicting consent',
+  Given: 'Consent given',
+  Declined: 'Follow up requested',
+  Refused: 'Consent refused',
+  FinalRefusal: 'Refusal confirmed'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ConsentWindow = {
+  Opening: 'Opening',
+  Open: 'Open',
+  Closed: 'Closed',
+  None: 'Session not scheduled'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const DownloadFormat = {
+  CSV: 'CSV',
+  CarePlus: 'XLSX for CarePlus (System C)',
+  SystmOne: 'XLSX for SystmOne (TPP)'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const EventType = {
+  Select: 'Select',
+  Invite: 'Invite',
+  Remind: 'Remind',
+  Consent: 'Consent',
+  Screen: 'Screen',
+  Instruct: 'Instruct',
+  Register: 'Register',
+  Record: 'Record',
+  Notice: 'Notice',
+  Unknown: 'Unknown'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const Gender = {
+  Female: 'Female',
+  Male: 'Male',
+  NotKnown: 'Not known',
+  NotSpecified: 'Not specified'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const GillickCompetent = {
+  True: 'Child assessed as Gillick competent',
+  False: 'Child assessed as not Gillick competent'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const InstructionOutcome = {
+  Given: 'PSD added',
+  Needed: 'PSD not added'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const MoveSource = {
+  Cohort: 'Cohort record',
+  Consent: 'Consent response',
+  School: 'Class list',
+  External: 'Another SAIS team'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const NoticeType = {
+  Deceased: 'Deceased',
+  Hidden: 'Hidden',
+  Invalid: 'Invalid',
+  Sensitive: 'Sensitive'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const NotifyEmailStatus = {
+  Delivered: 'Delivered',
+  Permanent: 'Email address does not exist',
+  Temporary: 'Inbox not accepting messages right now',
+  Technical: 'Technical failure'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const NotifySmsStatus = {
+  Delivered: 'Delivered',
+  Permanent: 'Not delivered',
+  Temporary: 'Phone not accepting messages right now',
+  Technical: 'Technical failure'
+}
+
+/**
+ * @readonly
+ * @enum {boolean|number}
+ */
+export const OrganisationDefaults = {
+  SessionOpenWeeks: 3,
+  SessionReminderWeeks: 1,
+  SessionRegistration: true
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ParentalRelationship = {
+  Mum: 'Mum',
+  Dad: 'Dad',
+  Guardian: 'Guardian',
+  Fosterer: 'Foster carer',
+  Other: 'Other',
+  Unknown: 'Unknown'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const PatientOutcome = {
+  Vaccinated: 'Vaccinated',
+  CouldNotVaccinate: 'Could not vaccinate',
+  NoOutcomeYet: 'No outcome yet'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const PreScreenQuestion = {
+  IsWell: 'are not acutely unwell',
+  IsPregnant: 'are not pregnant',
+  IsMedicated: 'are not taking any medication which prevents vaccination',
+  IsAllergic: 'have no allergies which would prevent vaccination',
+  IsVaccinated: 'have not already had this vaccination',
+  IsHappy: 'know what the vaccination is for, and are happy to have it'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ProgrammeStatus = {
+  Planned: 'Planned',
+  Current: 'Current',
+  Completed: 'Completed'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ProgrammeType = {
+  Flu: 'Flu',
+  HPV: 'HPV',
+  TdIPV: 'TdIPV',
+  MenACWY: 'MenACWY'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const SchoolTerm = {
+  Autumn: 'Autumn',
+  Spring: 'Spring',
+  Summer: 'Summer'
+}
+
+/**
+ * @readonly
+ * @enum {object}
+ */
+export const ProgrammePreset = {
+  SeasonalFlu: {
+    active: true,
+    primaryProgrammeTypes: [ProgrammeType.Flu],
+    term: SchoolTerm.Autumn
+  },
+  HPV: {
+    active: false,
+    adolescent: true,
+    primaryProgrammeTypes: [ProgrammeType.HPV],
+    term: SchoolTerm.Spring
+  },
+  Doubles: {
+    active: false,
+    adolescent: true,
+    primaryProgrammeTypes: [ProgrammeType.MenACWY, ProgrammeType.TdIPV],
+    catchupProgrammeTypes: [ProgrammeType.HPV],
+    term: SchoolTerm.Summer
+  }
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const RegistrationOutcome = {
+  Pending: 'Not registered yet',
+  Present: 'Attending session',
+  Absent: 'Absent from session',
+  Complete: 'Completed session'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ReplyDecision = {
+  NoResponse: 'No response',
+  Given: 'Consent given',
+  OnlyFluInjection: 'Consent given for flu injection',
+  OnlyMenACWY: 'Consent given for MenACWY only',
+  OnlyTdIPV: 'Consent given for Td/IPV only',
+  Declined: 'Follow up requested',
+  Refused: 'Consent refused'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ReplyMethod = {
+  Website: 'Online',
+  Phone: 'By phone',
+  Paper: 'Paper form',
+  InPerson: 'In person'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ReplyRefusal = {
+  Gelatine: 'Vaccine contains gelatine',
+  AlreadyGiven: 'Vaccine already received',
+  GettingElsewhere: 'Vaccine will be given elsewhere',
+  Medical: 'Medical reasons',
+  OutsideSchool: 'Don’t want vaccination in school',
+  Personal: 'Personal choice',
+  Other: 'Other'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const SchoolPhase = {
+  Primary: 'Primary',
+  Secondary: 'Secondary'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const SchoolYear = {
+  Y2024: '2024 to 2025',
+  Y2023: '2023 to 2024'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ScreenOutcome = {
+  Vaccinate: 'Safe to vaccinate',
+  VaccinateInjection: 'Safe to vaccinate with injected vaccine',
+  VaccinateNasal: 'Safe to vaccinate with nasal spray',
+  NeedsTriage: 'Needs triage',
+  DelayVaccination: 'Delay vaccination',
+  DoNotVaccinate: 'Do not vaccinate'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const SessionStatus = {
+  Unplanned: 'No sessions scheduled',
+  Planned: 'Sessions scheduled',
+  Completed: 'All session dates completed',
+  Closed: 'Closed'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const SessionType = {
+  School: 'School session',
+  Clinic: 'Community clinic'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const TriageOutcome = {
+  Needed: 'Triage needed',
+  Completed: 'Triage completed',
+  NotNeeded: 'No triage needed'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const UploadType = {
+  Cohort: 'Child records',
+  School: 'Class list records',
+  Report: 'Vaccination records'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const UploadStatus = {
+  Processing: 'Processing',
+  Complete: 'Completed',
+  Invalid: 'Invalid'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const UserRole = {
+  Nurse: 'Nurse',
+  NursePrescriber: 'Prescribing nurse',
+  Pharmacist: 'Pharmacist',
+  HCA: 'Healthcare assistant',
+  MedicalSecretary: 'Medical secretary',
+  DataConsumer: 'Data consumer'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const VaccinationOutcome = {
+  Vaccinated: 'Vaccinated',
+  PartVaccinated: 'Partially vaccinated',
+  AlreadyVaccinated: 'Already had the vaccine',
+  Contraindications: 'Had contraindications',
+  Refused: 'Refused vaccine',
+  Absent: 'Absent from the session',
+  Unwell: 'Unwell',
+  NoConsent: 'Unable to contact parent',
+  LateConsent: 'Consent received too late'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const VaccinationMethod = {
+  Nasal: 'Nasal spray',
+  Intramuscular: 'Intramuscular (IM) injection',
+  Subcutaneous: 'Subcutaneous injection'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const VaccinationSite = {
+  Nose: 'Nose',
+  ArmLeftUpper: 'Left arm (upper position)',
+  ArmLeftLower: 'Left arm (lower position)',
+  ArmRightUpper: 'Right arm (upper position)',
+  ArmRightLower: 'Right arm (lower position)',
+  ThighLeft: 'Left thigh',
+  ThighRight: 'Right thigh',
+  Other: 'Other'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const VaccinationProtocol = {
+  PGD: 'Patient Group Direction (PGD)',
+  PSD: 'Patient Specific Direction (PSD)',
+  National: 'National protocol'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const VaccineMethod = {
+  Nasal: 'Nasal spray',
+  Injection: 'Injection'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const VaccineSideEffect = {
+  AppetiteLoss: 'loss of appetite',
+  BlockedNose: 'a runny or blocked nose',
+  Bruising: 'bruising or itching at the site of the injection',
+  Dizzy: 'dizziness',
+  Drowsy: 'feeling drowsy',
+  Headache: 'a headache',
+  Irritable: 'feeling irritable',
+  PainArms: 'pain in the arms, hands, fingers',
+  PainSite: 'pain, swelling or itchiness where the injection was given',
+  Rash: 'a rash',
+  Sick: 'feeling or being sick',
+  SickFeeling: 'feeling sick (nausea)',
+  Tiredness: 'general tiredness',
+  Temperature: 'a high temperature',
+  TemperatureShiver: 'a high temperature, or feeling hot and shivery',
+  Unwell: 'generally feeling unwell'
+}

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -3,8 +3,9 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 import gpSurgeries from '../datasets/clinics.js'
 import firstNames from '../datasets/first-names.js'
 import schools from '../datasets/schools.js'
+import { Gender } from '../enums.js'
 import { generateAddress } from '../generators/address.js'
-import { Child, Gender } from '../models/child.js'
+import { Child } from '../models/child.js'
 import { getYearGroup } from '../utils/date.js'
 
 /**

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -1,9 +1,14 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
 import { healthConditions } from '../datasets/health-conditions.js'
+import {
+  ProgrammeType,
+  ReplyDecision,
+  ReplyMethod,
+  ReplyRefusal
+} from '../enums.js'
 import { Consent } from '../models/consent.js'
-import { ProgrammeType } from '../models/programme.js'
-import { ReplyDecision, ReplyMethod, ReplyRefusal } from '../models/reply.js'
+import {} from '../models/programme.js'
 import { removeDays, today } from '../utils/date.js'
 import {
   getHealthAnswers,

--- a/app/generators/instruction.js
+++ b/app/generators/instruction.js
@@ -1,0 +1,24 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+
+import { Instruction } from '../models/instruction.js'
+import { removeDays } from '../utils/date.js'
+
+/**
+ * Generate fake instruction
+ *
+ * @param {import('../models/patient-session.js').PatientSession} patientSession - Patient session
+ * @param {import('../models/programme.js').Programme} programme - Programme
+ * @param {import('../models/session.js').Session} session - Session
+ * @param {Array<import('../models/user.js').User>} users - Users
+ * @returns {Instruction} - Instruction
+ */
+export function generateInstruction(patientSession, programme, session, users) {
+  const user = faker.helpers.arrayElement(users)
+
+  return new Instruction({
+    createdAt: removeDays(session.firstDate, 7),
+    createdBy_uid: user.uid,
+    programme_id: programme.id,
+    patientSession_uuid: patientSession.uuid
+  })
+}

--- a/app/generators/parent.js
+++ b/app/generators/parent.js
@@ -1,11 +1,11 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
 import {
-  EmailStatus,
-  Parent,
+  NotifyEmailStatus,
   ParentalRelationship,
-  SmsStatus
-} from '../models/parent.js'
+  NotifySmsStatus
+} from '../enums.js'
+import { Parent } from '../models/parent.js'
 
 /**
  * Generate fake parent
@@ -49,18 +49,18 @@ export function generateParent(childLastName, isMum) {
 
   const sms = faker.datatype.boolean(0.5)
   const smsStatus = faker.helpers.weightedArrayElement([
-    { value: SmsStatus.Delivered, weight: 100 },
-    { value: SmsStatus.Permanent, weight: 10 },
-    { value: SmsStatus.Temporary, weight: 5 },
-    { value: SmsStatus.Technical, weight: 1 }
+    { value: NotifySmsStatus.Delivered, weight: 100 },
+    { value: NotifySmsStatus.Permanent, weight: 10 },
+    { value: NotifySmsStatus.Temporary, weight: 5 },
+    { value: NotifySmsStatus.Technical, weight: 1 }
   ])
 
   const email = faker.internet.email({ firstName, lastName }).toLowerCase()
   const emailStatus = faker.helpers.weightedArrayElement([
-    { value: EmailStatus.Delivered, weight: 100 },
-    { value: EmailStatus.Permanent, weight: 10 },
-    { value: EmailStatus.Temporary, weight: 5 },
-    { value: EmailStatus.Technical, weight: 1 }
+    { value: NotifyEmailStatus.Delivered, weight: 100 },
+    { value: NotifyEmailStatus.Permanent, weight: 10 },
+    { value: NotifyEmailStatus.Temporary, weight: 5 },
+    { value: NotifyEmailStatus.Technical, weight: 1 }
   ])
 
   const contactPreference = faker.datatype.boolean(0.2)

--- a/app/generators/session.js
+++ b/app/generators/session.js
@@ -1,9 +1,14 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import { isAfter } from 'date-fns'
 
-import { ProgrammePreset, ProgrammeType } from '../models/programme.js'
+import {
+  ProgrammePreset,
+  ProgrammeType,
+  SessionStatus,
+  SessionType
+} from '../enums.js'
 import { schoolTerms } from '../models/school.js'
-import { Session, SessionStatus, SessionType } from '../models/session.js'
+import { Session } from '../models/session.js'
 import { addDays, removeDays, setMidday, today } from '../utils/date.js'
 
 /**

--- a/app/generators/session.js
+++ b/app/generators/session.js
@@ -1,7 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import { isAfter } from 'date-fns'
 
-import { ProgrammePreset } from '../models/programme.js'
+import { ProgrammePreset, ProgrammeType } from '../models/programme.js'
 import { schoolTerms } from '../models/school.js'
 import { Session, SessionStatus, SessionType } from '../models/session.js'
 import { addDays, removeDays, setMidday, today } from '../utils/date.js'
@@ -94,12 +94,17 @@ export function generateSession(programmePreset, user, options) {
 
   const sessionHasCatchups = faker.datatype.boolean(0.5)
 
+  const psdProtocol =
+    preset.primaryProgrammeTypes.includes(ProgrammeType.Flu) &&
+    faker.datatype.boolean(0.5)
+
   return new Session({
     createdAt: removeDays(term.from, 60),
     createdBy_uid: user.uid,
     dates,
     registration: true,
     programmePreset,
+    psdProtocol,
     ...(sessionHasCatchups && {
       catchupProgrammeTypes: preset.catchupProgrammeTypes
     }),

--- a/app/generators/upload.js
+++ b/app/generators/upload.js
@@ -1,6 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
-import { Upload, UploadStatus } from '../models/upload.js'
+import { UploadStatus } from '../enums.js'
+import { Upload } from '../models/upload.js'
 import { today } from '../utils/date.js'
 
 /**
@@ -8,7 +9,7 @@ import { today } from '../utils/date.js'
  *
  * @param {Array<string>|boolean|undefined} record_nhsns - Records
  * @param {import('../models/user.js').User} user - User
- * @param {import('../models/upload.js').UploadType} [type] - Upload type
+ * @param {import('../enums.js').UploadType} [type] - Upload type
  * @param {import('../models/school.js').School} [school] - School
  * @returns {Upload} - Upload
  */

--- a/app/generators/user.js
+++ b/app/generators/user.js
@@ -1,6 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
-import { User, UserRole } from '../models/user.js'
+import { UserRole } from '../enums.js'
+import { User } from '../models/user.js'
 
 /**
  * Generate fake user

--- a/app/generators/vaccination.js
+++ b/app/generators/vaccination.js
@@ -1,8 +1,8 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
 import vaccines from '../datasets/vaccines.js'
-import { ConsentOutcome, ScreenOutcome } from '../models/patient-session.js'
-import { Vaccination, VaccinationOutcome } from '../models/vaccination.js'
+import { ConsentOutcome, ScreenOutcome, VaccinationOutcome } from '../enums.js'
+import { Vaccination } from '../models/vaccination.js'
 
 /**
  * Generate fake vaccination

--- a/app/globals.js
+++ b/app/globals.js
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 
 import { healthQuestions } from './datasets/health-questions.js'
+import { ScreenOutcome } from './enums.js'
 import { School } from './models/school.js'
 import { User } from './models/user.js'
 import {
@@ -106,20 +107,22 @@ export default () => {
   /**
    * Get triage outcome form field items
    *
-   * @param {import('./models/patient-session.js').PatientSession} patientSession - Patient session
+   * @param {Array} outcomes - Screen outcomes
    * @returns {object} Form field items
    */
-  globals.triageOutcomeItems = function (patientSession) {
+  globals.triageOutcomeItems = function (outcomes) {
     const { __ } = this.ctx
 
-    return Object.values(patientSession.triageOutcomesForConsentedMethod).map(
-      (value) =>
-        value === 'or'
-          ? { divider: 'or' }
-          : {
-              text: __(`triage.outcome.${value}`),
-              value
-            }
+    return Object.values(outcomes).map((value) =>
+      value === 'or'
+        ? { divider: 'or' }
+        : {
+            text: __(`triage.outcome.${value}`),
+            value,
+            ...(value === ScreenOutcome.VaccinateNasal && {
+              conditional: { html: {} }
+            }) // Added in template
+          }
     )
   }
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1992,11 +1992,8 @@ export const en = {
         'No, delay vaccination (and invite to clinic)',
       [ScreenOutcome.NeedsTriage]: 'No, keep in triage'
     },
-    injection: {
-      consentGiven:
-        'The parent has consented to the injected vaccine being offered instead',
-      consentRefused:
-        'The parent has not given consent for the injected vaccine'
+    psd: {
+      label: 'Do you want to add a PSD?'
     },
     [TriageOutcome.Needed]: {
       label: 'Triage needed',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1104,6 +1104,9 @@ export const en = {
     screen: {
       label: 'Triage status'
     },
+    instruct: {
+      label: 'PSD status'
+    },
     register: {
       label: 'Registration status'
     },
@@ -1575,6 +1578,10 @@ export const en = {
     screen: {
       label: 'Triage',
       title: 'Review triage statuses'
+    },
+    instruct: {
+      label: 'PSDs',
+      title: 'Review PSDs'
     },
     register: {
       label: 'Register',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1683,6 +1683,13 @@ export const en = {
       label: 'Unmatched responses',
       warning: 'You need to review unmatched consent responses for this session'
     },
+    instructions: {
+      label: 'Add new PSDs',
+      title: 'Add new PSDs',
+      description:
+        'There are %s children with consent for the nasal flu vaccine who do not require triage and do not yet have a PSD in place.\n\nYou can add a PSD instruction for these children now.',
+      success: '{{session.patientSessionsToInstruct.length}} PSDs added'
+    },
     reminders: {
       label: 'Send reminders',
       title: 'Manage consent reminders',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -3,12 +3,13 @@ import {
   Activity,
   ConsentOutcome,
   PatientOutcome,
+  ProgrammeType,
+  RegistrationOutcome,
+  ReplyDecision,
+  ReplyRefusal,
   ScreenOutcome,
   TriageOutcome
-} from '../models/patient-session.js'
-import { ProgrammeType } from '../models/programme.js'
-import { ReplyDecision, ReplyRefusal } from '../models/reply.js'
-import { RegistrationOutcome } from '../models/session.js'
+} from '../enums.js'
 
 /**
  * @returns {import("i18n").LocaleCatalog}

--- a/app/middleware/enumeration.js
+++ b/app/middleware/enumeration.js
@@ -1,75 +1,7 @@
-import { EventType } from '../models/audit-event.js'
-import { Gender } from '../models/child.js'
-import { AcademicYear } from '../models/cohort.js'
-import { DownloadFormat } from '../models/download.js'
-import { GillickCompetent } from '../models/gillick.js'
-import { MoveSource } from '../models/move.js'
-import { NoticeType } from '../models/notice.js'
-import {
-  EmailStatus,
-  ParentalRelationship,
-  SmsStatus
-} from '../models/parent.js'
-import {
-  ConsentOutcome,
-  Activity,
-  PatientOutcome,
-  ScreenOutcome,
-  TriageOutcome
-} from '../models/patient-session.js'
-import { ProgrammeType, ProgrammePreset } from '../models/programme.js'
-import { ReplyDecision, ReplyMethod, ReplyRefusal } from '../models/reply.js'
-import { SchoolPhase } from '../models/school.js'
-import {
-  ConsentWindow,
-  RegistrationOutcome,
-  SessionStatus,
-  SessionType
-} from '../models/session.js'
-import { UploadStatus, UploadType } from '../models/upload.js'
-import { UserRole } from '../models/user.js'
-import {
-  VaccinationMethod,
-  VaccinationOutcome,
-  VaccinationProtocol,
-  VaccinationSite
-} from '../models/vaccination.js'
-import { VaccineMethod } from '../models/vaccine.js'
+import * as enums from '../enums.js'
 
 export const enumeration = (request, response, next) => {
-  response.locals.AcademicYear = AcademicYear
-  response.locals.ConsentOutcome = ConsentOutcome
-  response.locals.ConsentWindow = ConsentWindow
-  response.locals.DownloadFormat = DownloadFormat
-  response.locals.EmailStatus = EmailStatus
-  response.locals.EventType = EventType
-  response.locals.Gender = Gender
-  response.locals.GillickCompetent = GillickCompetent
-  response.locals.MoveSource = MoveSource
-  response.locals.Activity = Activity
-  response.locals.NoticeType = NoticeType
-  response.locals.ParentalRelationship = ParentalRelationship
-  response.locals.PatientOutcome = PatientOutcome
-  response.locals.ProgrammeType = ProgrammeType
-  response.locals.ProgrammePreset = ProgrammePreset
-  response.locals.RegistrationOutcome = RegistrationOutcome
-  response.locals.ReplyDecision = ReplyDecision
-  response.locals.ReplyMethod = ReplyMethod
-  response.locals.ReplyRefusal = ReplyRefusal
-  response.locals.SchoolPhase = SchoolPhase
-  response.locals.ScreenOutcome = ScreenOutcome
-  response.locals.SessionStatus = SessionStatus
-  response.locals.SessionType = SessionType
-  response.locals.SmsStatus = SmsStatus
-  response.locals.TriageOutcome = TriageOutcome
-  response.locals.UploadStatus = UploadStatus
-  response.locals.UploadType = UploadType
-  response.locals.UserRole = UserRole
-  response.locals.VaccinationMethod = VaccinationMethod
-  response.locals.VaccinationOutcome = VaccinationOutcome
-  response.locals.VaccinationProtocol = VaccinationProtocol
-  response.locals.VaccinationSite = VaccinationSite
-  response.locals.VaccineMethod = VaccineMethod
+  response.app.locals = { ...response.app.locals, ...enums }
 
   next()
 }

--- a/app/middleware/navigation.js
+++ b/app/middleware/navigation.js
@@ -1,11 +1,11 @@
+import { ProgrammeType, UserRole } from '../enums.js'
 import { Consent } from '../models/consent.js'
 import { Move } from '../models/move.js'
 import { Notice } from '../models/notice.js'
 import { Organisation } from '../models/organisation.js'
-import { ProgrammeType } from '../models/programme.js'
 import { Session } from '../models/session.js'
 import { Upload } from '../models/upload.js'
-import { User, UserRole } from '../models/user.js'
+import { User } from '../models/user.js'
 import { formatDate, today } from '../utils/date.js'
 import { getProgrammeSession } from '../utils/session.js'
 

--- a/app/middleware/permission.js
+++ b/app/middleware/permission.js
@@ -1,5 +1,4 @@
-import { UserRole } from '../models/user.js'
-import { VaccineMethod } from '../models/vaccine.js'
+import { UserRole, VaccineMethod } from '../enums.js'
 
 export const permission = (request, response, next) => {
   const { data } = request.session

--- a/app/middleware/permission.js
+++ b/app/middleware/permission.js
@@ -11,6 +11,11 @@ export const permission = (request, response, next) => {
   } else {
     permissions.vaccineMethods = []
   }
+  if (
+    [UserRole.NursePrescriber, UserRole.Pharmacist].includes(data?.token?.role)
+  ) {
+    permissions.canPrescribe = true
+  }
 
   request.app.locals.permissions = permissions
 

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -21,6 +21,7 @@ export const EventType = {
   Remind: 'Remind',
   Consent: 'Consent',
   Screen: 'Screen',
+  Instruct: 'Instruct',
   Register: 'Register',
   Record: 'Record',
   Notice: 'Notice',

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -1,5 +1,6 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
+import { EventType, ScreenOutcome } from '../enums.js'
 import { formatDate, today } from '../utils/date.js'
 import {
   formatTag,
@@ -7,26 +8,8 @@ import {
   formatWithSecondaryText
 } from '../utils/string.js'
 
-import { ScreenOutcome } from './patient-session.js'
 import { Programme } from './programme.js'
 import { User } from './user.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const EventType = {
-  Select: 'Select',
-  Invite: 'Invite',
-  Remind: 'Remind',
-  Consent: 'Consent',
-  Screen: 'Screen',
-  Instruct: 'Instruct',
-  Register: 'Register',
-  Record: 'Record',
-  Notice: 'Notice',
-  Unknown: 'Unknown'
-}
 
 /**
  * @class Audit event

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -11,17 +11,6 @@ import { formatYearGroup } from '../utils/string.js'
 import { Address } from './address.js'
 
 /**
- * @readonly
- * @enum {string}
- */
-export const Gender = {
-  Female: 'Female',
-  Male: 'Male',
-  NotKnown: 'Not known',
-  NotSpecified: 'Not specified'
-}
-
-/**
  * @class Child
  * @property {string} [firstName] - First name
  * @property {string} [lastName] - Last name
@@ -30,7 +19,7 @@ export const Gender = {
  * @property {Date} [dob] - Date of birth
  * @property {object} [dob_] - Date of birth (from `dateInput`)
  * @property {Date} [dod] - Date of death
- * @property {Gender} gender - Gender
+ * @property {import('../enums.js).Gender} gender - Gender
  * @property {import('./address.js').Address} [address] - Address
  * @property {string} [gpSurgery] - GP surgery
  * @property {string} [registrationGroup] - Registration group

--- a/app/models/cohort.js
+++ b/app/models/cohort.js
@@ -1,3 +1,4 @@
+import { AcademicYear } from '../enums.js'
 import { createMap } from '../utils/object.js'
 import {
   formatLink,
@@ -7,15 +8,6 @@ import {
 
 import { Patient } from './patient.js'
 import { Programme } from './programme.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const AcademicYear = {
-  Y2024: '2024/25',
-  Y2025: '2025/26'
-}
 
 /**
  * @class Cohort

--- a/app/models/download.js
+++ b/app/models/download.js
@@ -1,6 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import xlsx from 'json-as-xlsx'
 
+import { DownloadFormat } from '../enums.js'
 import {
   convertIsoDateToObject,
   convertObjectToIsoDate,
@@ -12,16 +13,6 @@ import { formatList } from '../utils/string.js'
 import { Organisation } from './organisation.js'
 import { Programme } from './programme.js'
 import { Vaccination } from './vaccination.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const DownloadFormat = {
-  CSV: 'CSV',
-  CarePlus: 'XLSX for CarePlus (System C)',
-  SystmOne: 'XLSX for SystmOne (TPP)'
-}
 
 /**
  * @class Vaccination report download

--- a/app/models/gillick.js
+++ b/app/models/gillick.js
@@ -1,14 +1,6 @@
+import { GillickCompetent } from '../enums.js'
 import { today } from '../utils/date.js'
 import { stringToBoolean } from '../utils/string.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const GillickCompetent = {
-  True: 'Child assessed as Gillick competent',
-  False: 'Child assessed as not Gillick competent'
-}
 
 /**
  * @class Gillick assessment

--- a/app/models/instruction.js
+++ b/app/models/instruction.js
@@ -1,0 +1,277 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+
+import {
+  convertIsoDateToObject,
+  convertObjectToIsoDate,
+  formatDate,
+  today
+} from '../utils/date.js'
+import { formatLink, formatMillilitres } from '../utils/string.js'
+
+import { PatientSession } from './patient-session.js'
+import { Programme, ProgrammeType } from './programme.js'
+import { User } from './user.js'
+import { VaccinationMethod, VaccinationSite } from './vaccination.js'
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const InstructionOutcome = {
+  Given: 'Given',
+  Needed: 'Needed'
+}
+
+/**
+ * @class Instruction
+ * @param {object} options - Options
+ * @param {object} [context] - Global context
+ * @property {object} [context] - Global context
+ * @property {string} uuid - UUID
+ * @property {Date} [createdAt] - Created date
+ * @property {object} [createdAt_] - Created date (from `dateInput`)
+ * @property {string} [createdBy_uid] - User who performed instruction
+ * @property {Date} [updatedAt] - Updated date
+ * @property {InstructionOutcome} [outcome] - Outcome
+ * @property {string} [patientSession_uuid] - Patient session UUID
+ * @property {string} [programme_id] - Programme ID
+ */
+export class Instruction {
+  constructor(options, context) {
+    this.context = context
+    this.uuid = options?.uuid || faker.string.uuid()
+    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
+    this.createdAt_ = options?.createdAt_
+    this.createdBy_uid = options?.createdBy_uid
+    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
+    this.patientSession_uuid = options?.patientSession_uuid
+    this.programme_id = options?.programme_id
+  }
+
+  /**
+   * Get created date for `dateInput`
+   *
+   * @returns {object|undefined} - `dateInput` object
+   */
+  get createdAt_() {
+    return convertIsoDateToObject(this.createdAt)
+  }
+
+  /**
+   * Set created date from `dateInput`
+   *
+   * @param {object} object - dateInput object
+   */
+  set createdAt_(object) {
+    if (object) {
+      this.createdAt = convertObjectToIsoDate(object)
+    }
+  }
+
+  /**
+   * Get vaccine
+   *
+   * @returns {import('./vaccine.js').Vaccine} - Vaccine
+   */
+  get vaccine() {
+    return this.programme.vaccines.find(
+      (vaccine) => vaccine.method === this.injectionMethod
+    )
+  }
+
+  /**
+   * Get dosage (ml)
+   *
+   * @returns {number} - Dosage
+   */
+  get dose() {
+    return this.vaccine.dose
+  }
+
+  /**
+   * Get injection method
+   *
+   * @returns {VaccinationMethod} - Injection method
+   */
+  get injectionMethod() {
+    return this.programme.type === ProgrammeType.Flu
+      ? VaccinationSite.Nose
+      : VaccinationSite.ArmLeftLower
+  }
+
+  /**
+   * Get anatomical site
+   *
+   * @returns {VaccinationSite} - Anatomical site
+   */
+  get injectionSite() {
+    return this.programme.type === ProgrammeType.Flu
+      ? VaccinationMethod.Nasal
+      : VaccinationMethod.Intramuscular
+  }
+
+  /**
+   * Get patient session
+   *
+   * @returns {PatientSession} - Patient session
+   */
+  get patientSession() {
+    try {
+      return PatientSession.read(this.patientSession_uuid, this.context)
+    } catch (error) {
+      console.error('Instruction.patientSession', error.message)
+    }
+  }
+
+  /**
+   * Get user who performed instruction
+   *
+   * @returns {User} - User
+   */
+  get createdBy() {
+    try {
+      if (this.createdBy_uid) {
+        return User.read(this.createdBy_uid, this.context)
+      }
+    } catch (error) {
+      console.error('Instruction.createdBy', error.message)
+    }
+  }
+
+  /**
+   * Get programme
+   *
+   * @returns {Programme} - Programme
+   */
+  get programme() {
+    try {
+      return Programme.read(this.programme_id, this.context)
+    } catch (error) {
+      console.error('Instruction.programme', error.message)
+    }
+  }
+
+  /**
+   * Get formatted values
+   *
+   * @returns {object} - Formatted values
+   */
+  get formatted() {
+    return {
+      createdAt: formatDate(this.createdAt, {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true
+      }),
+      createdAt_date: formatDate(this.createdAt, {
+        dateStyle: 'long'
+      }),
+      createdBy: this.createdBy?.fullName || '',
+      updatedAt: formatDate(this.updatedAt, {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true
+      }),
+      dose: formatMillilitres(this.dose),
+      vaccine_snomed: this.vaccine?.brand,
+      programme: this.programme && this.programme.nameTag
+    }
+  }
+
+  /**
+   * Get formatted links
+   *
+   * @returns {object} - Formatted links
+   */
+  get link() {
+    return {
+      createdAt_date: formatLink(this.uri, this.formatted.createdAt_date)
+    }
+  }
+
+  /**
+   * Get namespace
+   *
+   * @returns {string} - Namespace
+   */
+  get ns() {
+    return 'instruction'
+  }
+
+  /**
+   * Get URI
+   *
+   * @returns {string} - URI
+   */
+  get uri() {
+    return `/programmes/${this.programme_id}/instructions/${this.uuid}`
+  }
+
+  /**
+   * Read all
+   *
+   * @param {object} context - Context
+   * @returns {Array<Instruction>|undefined} Instructions
+   * @static
+   */
+  static readAll(context) {
+    return Object.values(context.instructions).map(
+      (instruction) => new Instruction(instruction, context)
+    )
+  }
+
+  /**
+   * Read
+   *
+   * @param {string} uuid - Instruction UUID
+   * @param {object} context - Context
+   * @returns {Instruction|undefined} Instruction
+   * @static
+   */
+  static read(uuid, context) {
+    if (context?.instructions?.[uuid]) {
+      return new Instruction(context.instructions[uuid], context)
+    }
+  }
+
+  /**
+   * Create
+   *
+   * @param {Instruction} instruction - Instruction
+   * @param {object} context - Context
+   */
+  create(instruction, context) {
+    instruction = new Instruction(instruction)
+
+    // Update context
+    context.instructions = context.instructions || {}
+    context.instructions[instruction.uuid] = instruction
+  }
+
+  /**
+   * Update
+   *
+   * @param {object} updates - Updates
+   * @param {object} context - Context
+   */
+  update(updates, context) {
+    this.updatedAt = new Date()
+
+    // Remove patient context
+    delete this.context
+
+    // Delete original patient (with previous UUID)
+    delete context.instructions[this.uuid]
+
+    // Update context
+    const updatedInstruction = Object.assign(this, updates)
+
+    context.instructions[updatedInstruction.uuid] = updatedInstruction
+  }
+}

--- a/app/models/instruction.js
+++ b/app/models/instruction.js
@@ -18,8 +18,8 @@ import { VaccinationMethod, VaccinationSite } from './vaccination.js'
  * @enum {string}
  */
 export const InstructionOutcome = {
-  Given: 'Given',
-  Needed: 'Needed'
+  Given: 'PSD added',
+  Needed: 'PSD not added'
 }
 
 /**

--- a/app/models/instruction.js
+++ b/app/models/instruction.js
@@ -1,5 +1,6 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
+import { ProgrammeType, VaccinationMethod, VaccinationSite } from '../enums.js'
 import {
   convertIsoDateToObject,
   convertObjectToIsoDate,
@@ -9,18 +10,8 @@ import {
 import { formatLink, formatMillilitres } from '../utils/string.js'
 
 import { PatientSession } from './patient-session.js'
-import { Programme, ProgrammeType } from './programme.js'
+import { Programme } from './programme.js'
 import { User } from './user.js'
-import { VaccinationMethod, VaccinationSite } from './vaccination.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const InstructionOutcome = {
-  Given: 'PSD added',
-  Needed: 'PSD not added'
-}
 
 /**
  * @class Instruction
@@ -32,7 +23,7 @@ export const InstructionOutcome = {
  * @property {object} [createdAt_] - Created date (from `dateInput`)
  * @property {string} [createdBy_uid] - User who performed instruction
  * @property {Date} [updatedAt] - Updated date
- * @property {InstructionOutcome} [outcome] - Outcome
+ * @property {import('../enums.js').InstructionOutcome} [outcome] - Outcome
  * @property {string} [patientSession_uuid] - Patient session UUID
  * @property {string} [programme_id] - Programme ID
  */

--- a/app/models/move.js
+++ b/app/models/move.js
@@ -5,17 +5,6 @@ import { Patient } from '../models/patient.js'
 import { formatDate, getDateValueDifference, today } from '../utils/date.js'
 
 /**
- * @readonly
- * @enum {string}
- */
-export const MoveSource = {
-  Cohort: 'Cohort record',
-  Consent: 'Consent response',
-  School: 'Class list',
-  External: 'Another SAIS team'
-}
-
-/**
  * @class Move
  * @param {object} options - Options
  * @param {object} [context] - Context
@@ -25,7 +14,7 @@ export const MoveSource = {
  * @property {Date} [updatedAt] - Updated date
  * @property {string} from - Current school URN (moving from)
  * @property {string} to - Proposed school URN (moving to)
- * @property {MoveSource} source - Reporting source
+ * @property {import('../enums.js').MoveSource} source - Reporting source
  * @property {boolean} ignored - Reported move is ignored
  * @property {string} patient_uuid - Patient UUID
  */

--- a/app/models/notice.js
+++ b/app/models/notice.js
@@ -5,24 +5,13 @@ import { formatDate, getDateValueDifference, today } from '../utils/date.js'
 import { Patient } from './patient.js'
 
 /**
- * @readonly
- * @enum {string}
- */
-export const NoticeType = {
-  Deceased: 'Deceased',
-  Hidden: 'Hidden',
-  Invalid: 'Invalid',
-  Sensitive: 'Sensitive'
-}
-
-/**
  * @class Notice
  * @param {object} options - Options
  * @param {object} [context] - Context
  * @property {object} [context] - Context
  * @property {string} uuid - UUID
  * @property {Date} [createdAt] - Created date
- * @property {NoticeType} type - Notice type
+ * @property {import('../enums.js').NoticeType} type - Notice type
  * @property {string} patient_uuid - Patient notice applies to
  */
 export class Notice {

--- a/app/models/organisation.js
+++ b/app/models/organisation.js
@@ -1,19 +1,10 @@
 import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
+import { OrganisationDefaults } from '../enums.js'
 import { stringToBoolean } from '../utils/string.js'
 
 import { Clinic } from './clinic.js'
 import { School } from './school.js'
-
-/**
- * @readonly
- * @enum {boolean|number}
- */
-export const OrganisationDefaults = {
-  SessionOpenWeeks: 3,
-  SessionReminderWeeks: 1,
-  SessionRegistration: true
-}
 
 /**
  * @class Organisation

--- a/app/models/parent.js
+++ b/app/models/parent.js
@@ -1,41 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
+import { ParentalRelationship } from '../enums.js'
 import { formatOther, formatParent, stringToBoolean } from '../utils/string.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const ParentalRelationship = {
-  Mum: 'Mum',
-  Dad: 'Dad',
-  Guardian: 'Guardian',
-  Fosterer: 'Foster carer',
-  Other: 'Other',
-  Unknown: 'Unknown'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const EmailStatus = {
-  Delivered: 'Delivered',
-  Permanent: 'Email address does not exist',
-  Temporary: 'Inbox not accepting messages right now',
-  Technical: 'Technical failure'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const SmsStatus = {
-  Delivered: 'Delivered',
-  Permanent: 'Not delivered',
-  Temporary: 'Phone not accepting messages right now',
-  Technical: 'Technical failure'
-}
 
 /**
  * @class Parent
@@ -47,9 +13,9 @@ export const SmsStatus = {
  * @property {boolean} notify - Notify about consent and vaccination events
  * @property {string} tel - Phone number
  * @property {string} email - Email address
- * @property {EmailStatus} emailStatus - Email status
+ * @property {import('../enums.js').NotifyEmailStatus} emailStatus - Email status
  * @property {boolean} sms - Update via SMS
- * @property {SmsStatus} smsStatus - SMS status
+ * @property {import('../enums.js').NotifySmsStatus} smsStatus - SMS status
  * @property {boolean} [contactPreference] - Preferred contact method
  * @property {string} [contactPreferenceDetails] - Contact method details
  */

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -1,6 +1,17 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import filters from '@x-govuk/govuk-prototype-filters'
 
+import {
+  Activity,
+  ConsentOutcome,
+  EventType,
+  PatientOutcome,
+  ProgrammeType,
+  ReplyDecision,
+  ScreenOutcome,
+  TriageOutcome,
+  VaccineMethod
+} from '../enums.js'
 import { getDateValueDifference, today } from '../utils/date.js'
 import {
   getInstructionOutcome,
@@ -29,74 +40,11 @@ import {
 } from '../utils/string.js'
 import { getScreenOutcome, getTriageOutcome } from '../utils/triage.js'
 
-import { EventType } from './audit-event.js'
 import { Gillick } from './gillick.js'
 import { Instruction } from './instruction.js'
 import { Patient } from './patient.js'
-import { Programme, ProgrammeType } from './programme.js'
-import { ReplyDecision } from './reply.js'
+import { Programme } from './programme.js'
 import { Session } from './session.js'
-import { VaccineMethod } from './vaccine.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const Activity = {
-  Consent: 'Get consent',
-  Triage: 'Triage health questions',
-  Register: 'Register attendance',
-  Record: 'Record vaccination',
-  DoNotRecord: 'Do not vaccinate',
-  Report: 'Report vaccination'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const ConsentOutcome = {
-  NoRequest: 'Request failed',
-  NoResponse: 'No response',
-  Inconsistent: 'Conflicting consent',
-  Given: 'Consent given',
-  Declined: 'Follow up requested',
-  Refused: 'Consent refused',
-  FinalRefusal: 'Refusal confirmed'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const TriageOutcome = {
-  Needed: 'Triage needed',
-  Completed: 'Triage completed',
-  NotNeeded: 'No triage needed'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const ScreenOutcome = {
-  Vaccinate: 'Safe to vaccinate',
-  VaccinateInjection: 'Safe to vaccinate with injected vaccine',
-  VaccinateNasal: 'Safe to vaccinate with nasal spray',
-  NeedsTriage: 'Needs triage',
-  DelayVaccination: 'Delay vaccination',
-  DoNotVaccinate: 'Do not vaccinate'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const PatientOutcome = {
-  Vaccinated: 'Vaccinated',
-  CouldNotVaccinate: 'Could not vaccinate',
-  NoOutcomeYet: 'No outcome yet'
-}
 
 /**
  * @class Patient Session
@@ -497,7 +445,7 @@ export class PatientSession {
   /**
    * Get instruction outcome
    *
-   * @returns {import('./instruction.js').InstructionOutcome} - Instruction outcome
+   * @returns {import('../enums.js').InstructionOutcome} - Instruction outcome
    */
   get instruct() {
     return getInstructionOutcome(this)
@@ -506,7 +454,7 @@ export class PatientSession {
   /**
    * Get registration outcome
    *
-   * @returns {import('./session.js').RegistrationOutcome} - Registration outcome
+   * @returns {import('../enums.js').RegistrationOutcome} - Registration outcome
    */
   get register() {
     return getRegistrationOutcome(this)
@@ -526,7 +474,7 @@ export class PatientSession {
   /**
    * Get vaccination (session) outcome
    *
-   * @returns {import('./vaccination.js').VaccinationOutcome|PatientOutcome} - Vaccination (session) outcome
+   * @returns {import('../enums.js').VaccinationOutcome|PatientOutcome} - Vaccination (session) outcome
    */
   get outcome() {
     return getSessionOutcome(this)
@@ -804,7 +752,7 @@ export class PatientSession {
    * Register attendance
    *
    * @param {import('./audit-event.js').AuditEvent} event - Event
-   * @param {import('./session.js').RegistrationOutcome} register - Registration
+   * @param {import('../enums.js').RegistrationOutcome} register - Registration
    */
   registerAttendance(event, register) {
     this.session.updateRegister(this.patient.uuid, register)

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -3,6 +3,8 @@ import filters from '@x-govuk/govuk-prototype-filters'
 
 import { getDateValueDifference, today } from '../utils/date.js'
 import {
+  getInstructionOutcome,
+  getInstructionStatus,
   getNextActivity,
   getRegistrationOutcome,
   getReportOutcome,
@@ -493,6 +495,15 @@ export class PatientSession {
   }
 
   /**
+   * Get instruction outcome
+   *
+   * @returns {import('./instruction.js').InstructionOutcome} - Instruction outcome
+   */
+  get instruct() {
+    return getInstructionOutcome(this)
+  }
+
+  /**
    * Get registration outcome
    *
    * @returns {import('./session.js').RegistrationOutcome} - Registration outcome
@@ -551,6 +562,7 @@ export class PatientSession {
       consent: getConsentStatus(this),
       triage: getTriageStatus(this),
       screen: getScreenStatus(this),
+      instruct: getInstructionStatus(this),
       register: getRegistrationStatus(this),
       outcome: getOutcomeStatus(this),
       report: getReportStatus(this)
@@ -620,6 +632,7 @@ export class PatientSession {
             this.status.screen,
             this.reason.screen
           ),
+        instruct: formatTag(this.status.instruct),
         register: formatTag(this.status.register),
         outcome: formatProgrammeStatus(this.programme, this.status.outcome),
         report: formatProgrammeStatus(this.programme, this.status.report)

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -38,7 +38,12 @@ import {
   formatProgrammeStatus,
   formatTag
 } from '../utils/string.js'
-import { getScreenOutcome, getTriageOutcome } from '../utils/triage.js'
+import {
+  getScreenOutcome,
+  getScreenOutcomesForConsentMethod,
+  getScreenVaccinationMethod,
+  getTriageOutcome
+} from '../utils/triage.js'
 
 import { Gillick } from './gillick.js'
 import { Instruction } from './instruction.js'
@@ -224,23 +229,22 @@ export class PatientSession {
     )
   }
 
-  get triageOutcomesForConsentedMethod() {
-    return [
-      ...(!this.programme.hasAlternativeVaccines
-        ? [ScreenOutcome.Vaccinate]
-        : []),
-      ...(this.programme.hasAlternativeVaccines &&
-      !this.hasConsentForInjectionOnly
-        ? [ScreenOutcome.VaccinateNasal]
-        : []),
-      ...(this.programme.hasAlternativeVaccines && this.hasConsentForInjection
-        ? [ScreenOutcome.VaccinateInjection]
-        : []),
-      'or',
-      ScreenOutcome.NeedsTriage,
-      ScreenOutcome.DelayVaccination,
-      ScreenOutcome.DoNotVaccinate
-    ]
+  /**
+   * Get screen outcomes for vaccination method(s) consented to
+   *
+   * @returns {Array<ScreenOutcome>} - Screen outcomes
+   */
+  get screenOutcomesForConsentMethod() {
+    return getScreenOutcomesForConsentMethod(this.programme, this.responses)
+  }
+
+  /**
+   * Get vaccination method(s) consented to use if safe to vaccinate
+   *
+   * @returns {import('../enums.js').ScreenVaccinationMethod|boolean} - Method
+   */
+  get screenVaccinationMethod() {
+    return getScreenVaccinationMethod(this.programme, this.responses)
   }
 
   /**

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -1,6 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import _ from 'lodash'
 
+import { EventType, NoticeType } from '../enums.js'
 import { getDateValueDifference, removeDays, today } from '../utils/date.js'
 import { tokenize } from '../utils/object.js'
 import { getPreferredNames } from '../utils/reply.js'
@@ -11,22 +12,12 @@ import {
   sentenceCaseProgrammeName
 } from '../utils/string.js'
 
-import { AuditEvent, EventType } from './audit-event.js'
+import { AuditEvent } from './audit-event.js'
 import { Cohort } from './cohort.js'
-import { NoticeType } from './notice.js'
 import { Parent } from './parent.js'
 import { PatientSession } from './patient-session.js'
 import { Record } from './record.js'
 import { Reply } from './reply.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const PatientMovement = {
-  In: 'Moved in',
-  Out: 'Moved out'
-}
 
 /**
  * @class Patient in-session record

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -1,6 +1,7 @@
 import { isAfter } from 'date-fns'
 
 import vaccines from '../datasets/vaccines.js'
+import { SchoolYear, ProgrammeStatus, ProgrammeType } from '../enums.js'
 import { isBetweenDates, today } from '../utils/date.js'
 import {
   formatLink,
@@ -10,56 +11,9 @@ import {
 
 import { Cohort } from './cohort.js'
 import { PatientSession } from './patient-session.js'
-import { SchoolTerm, SchoolYear } from './school.js'
 import { Session } from './session.js'
 import { Vaccination } from './vaccination.js'
 import { Vaccine } from './vaccine.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const ProgrammeStatus = {
-  Planned: 'Planned',
-  Current: 'Current',
-  Completed: 'Completed'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const ProgrammeType = {
-  Flu: 'Flu',
-  HPV: 'HPV',
-  TdIPV: 'TdIPV',
-  MenACWY: 'MenACWY'
-}
-
-/**
- * @readonly
- * @enum {object}
- */
-export const ProgrammePreset = {
-  SeasonalFlu: {
-    active: true,
-    primaryProgrammeTypes: [ProgrammeType.Flu],
-    term: SchoolTerm.Autumn
-  },
-  HPV: {
-    active: false,
-    adolescent: true,
-    primaryProgrammeTypes: [ProgrammeType.HPV],
-    term: SchoolTerm.Spring
-  },
-  Doubles: {
-    active: false,
-    adolescent: true,
-    primaryProgrammeTypes: [ProgrammeType.MenACWY, ProgrammeType.TdIPV],
-    catchupProgrammeTypes: [ProgrammeType.HPV],
-    term: SchoolTerm.Summer
-  }
-}
 
 export const programmeTypes = {
   [ProgrammeType.Flu]: {

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -2,6 +2,15 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 import _ from 'lodash'
 
 import vaccines from '../datasets/vaccines.js'
+import {
+  NotifyEmailStatus,
+  NotifySmsStatus,
+  ProgrammeType,
+  ReplyDecision,
+  ReplyMethod,
+  ReplyRefusal,
+  VaccineMethod
+} from '../enums.js'
 import { formatDate, today } from '../utils/date.js'
 import {
   formatLinkWithSecondaryText,
@@ -14,51 +23,11 @@ import {
 } from '../utils/string.js'
 
 import { Child } from './child.js'
-import { EmailStatus, Parent, SmsStatus } from './parent.js'
+import { Parent } from './parent.js'
 import { Patient } from './patient.js'
-import { Programme, ProgrammeType } from './programme.js'
+import { Programme } from './programme.js'
 import { Session } from './session.js'
 import { User } from './user.js'
-import { VaccineMethod } from './vaccine.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const ReplyDecision = {
-  NoResponse: 'No response',
-  Given: 'Consent given',
-  OnlyFluInjection: 'Consent given for flu injection',
-  OnlyMenACWY: 'Consent given for MenACWY only',
-  OnlyTdIPV: 'Consent given for Td/IPV only',
-  Declined: 'Follow up requested',
-  Refused: 'Consent refused'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const ReplyMethod = {
-  Website: 'Online',
-  Phone: 'By phone',
-  Paper: 'Paper form',
-  InPerson: 'In person'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const ReplyRefusal = {
-  Gelatine: 'Vaccine contains gelatine',
-  AlreadyGiven: 'Vaccine already received',
-  GettingElsewhere: 'Vaccine will be given elsewhere',
-  Medical: 'Medical reasons',
-  OutsideSchool: 'Don’t want vaccination in school',
-  Personal: 'Personal choice',
-  Other: 'Other'
-}
 
 /**
  * @class Reply
@@ -172,10 +141,11 @@ export class Reply {
     }
 
     const hasEmailGotEmail =
-      this.parent?.email && this.parent?.emailStatus === EmailStatus.Delivered
+      this.parent?.email &&
+      this.parent?.emailStatus === NotifyEmailStatus.Delivered
     const wantsSmsGotSms =
       this.parent?.sms === true &&
-      this.parent?.smsStatus === SmsStatus.Delivered
+      this.parent?.smsStatus === NotifySmsStatus.Delivered
 
     return hasEmailGotEmail || wantsSmsGotSms
   }

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -1,38 +1,11 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
+import { SchoolPhase, SchoolTerm } from '../enums.js'
 import { range } from '../utils/number.js'
 import { formatLink, formatMonospace } from '../utils/string.js'
 
 import { Address } from './address.js'
 import { Record } from './record.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const SchoolPhase = {
-  Primary: 'Primary',
-  Secondary: 'Secondary'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const SchoolTerm = {
-  Autumn: 'Autumn',
-  Spring: 'Spring',
-  Summer: 'Summer'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const SchoolYear = {
-  Y2024: '2024 to 2025',
-  Y2023: '2023 to 2024'
-}
 
 export const schoolTerms = {
   [SchoolTerm.Spring]: { from: '2025-01-06', to: '2025-04-11' },

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -443,6 +443,18 @@ export class Session {
   }
 
   /**
+   * Get patients to give instruction to
+   *
+   * @returns {Array<PatientSession>} - Patient sessions
+   */
+  get patientSessionsToInstruct() {
+    const patientSessions = this.patientSessions.filter(
+      ({ nextActivity }) => nextActivity === Activity.Record
+    )
+    return _.uniqBy(patientSessions, 'patient.nhsn')
+  }
+
+  /**
    * Get patients awaiting registration
    *
    * @returns {Array<PatientSession>} - Patient sessions

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -4,6 +4,18 @@ import { isAfter } from 'date-fns'
 import _ from 'lodash'
 
 import {
+  Activity,
+  ConsentOutcome,
+  ConsentWindow,
+  OrganisationDefaults,
+  PatientOutcome,
+  ProgrammePreset,
+  RegistrationOutcome,
+  SessionStatus,
+  SessionType,
+  TriageOutcome
+} from '../enums.js'
+import {
   removeDays,
   convertIsoDateToObject,
   convertObjectToIsoDate,
@@ -28,59 +40,10 @@ import {
 import { Batch } from './batch.js'
 import { Clinic } from './clinic.js'
 import { Consent } from './consent.js'
-import { OrganisationDefaults } from './organisation.js'
-import {
-  Activity,
-  ConsentOutcome,
-  PatientOutcome,
-  PatientSession,
-  TriageOutcome
-} from './patient-session.js'
-import { Programme, ProgrammePreset, programmeTypes } from './programme.js'
+import { PatientSession } from './patient-session.js'
+import { Programme, programmeTypes } from './programme.js'
 import { School } from './school.js'
 import { Vaccine } from './vaccine.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const ConsentWindow = {
-  Opening: 'Opening',
-  Open: 'Open',
-  Closed: 'Closed',
-  None: 'Session not scheduled'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const SessionStatus = {
-  Unplanned: 'No sessions scheduled',
-  Planned: 'Sessions scheduled',
-  Completed: 'All session dates completed',
-  Closed: 'Closed'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const SessionType = {
-  School: 'School session',
-  Clinic: 'Community clinic'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const RegistrationOutcome = {
-  Pending: 'Not registered yet',
-  Present: 'Attending session',
-  Absent: 'Absent from session',
-  Complete: 'Completed session'
-}
 
 /**
  * @class Session

--- a/app/models/upload.js
+++ b/app/models/upload.js
@@ -1,32 +1,13 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
+import { UploadStatus, UploadType } from '../enums.js'
 import { formatDate, today } from '../utils/date.js'
 import { formatWithSecondaryText, formatYearGroup } from '../utils/string.js'
 
 import { Record } from './record.js'
 import { School } from './school.js'
 import { User } from './user.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const UploadType = {
-  Cohort: 'Child records',
-  School: 'Class list records',
-  Report: 'Vaccination records'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const UploadStatus = {
-  Processing: 'Processing',
-  Complete: 'Completed',
-  Invalid: 'Invalid'
-}
 
 /**
  * @class Upload

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,25 +3,12 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 import { formatLink, formatMonospace } from '../utils/string.js'
 
 /**
- * @readonly
- * @enum {string}
- */
-export const UserRole = {
-  Nurse: 'Nurse',
-  NursePrescriber: 'Prescribing nurse',
-  Pharmacist: 'Pharmacist',
-  HCA: 'Healthcare assistant',
-  MedicalSecretary: 'Medical secretary',
-  DataConsumer: 'Data consumer'
-}
-
-/**
  * @class User
  * @property {string} uid - User ID
  * @property {string} [firstName] - First/given name
  * @property {string} [lastName] - Last/family name
  * @property {string} [email] - Email address
- * @property {UserRole} [role] - User role
+ * @property {import('../enums.js').UserRole} [role] - User role
  * @property {object} [batch] - Default batches
  */
 export class User {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -8,6 +8,8 @@ import { formatLink, formatMonospace } from '../utils/string.js'
  */
 export const UserRole = {
   Nurse: 'Nurse',
+  NursePrescriber: 'Prescribing nurse',
+  Pharmacist: 'Pharmacist',
   HCA: 'Healthcare assistant',
   MedicalSecretary: 'Medical secretary',
   DataConsumer: 'Data consumer'

--- a/app/models/vaccination.js
+++ b/app/models/vaccination.js
@@ -5,6 +5,13 @@ import _ from 'lodash'
 import schools from '../datasets/schools.js'
 import vaccines from '../datasets/vaccines.js'
 import {
+  VaccinationMethod,
+  VaccinationOutcome,
+  VaccinationProtocol,
+  VaccinationSite,
+  VaccineMethod
+} from '../enums.js'
+import {
   convertIsoDateToObject,
   convertObjectToIsoDate,
   formatDate,
@@ -27,58 +34,7 @@ import { Programme } from './programme.js'
 import { School } from './school.js'
 import { Session } from './session.js'
 import { User } from './user.js'
-import { Vaccine, VaccineMethod } from './vaccine.js'
-
-/**
- * @readonly
- * @enum {string}
- */
-export const VaccinationOutcome = {
-  Vaccinated: 'Vaccinated',
-  PartVaccinated: 'Partially vaccinated',
-  AlreadyVaccinated: 'Already had the vaccine',
-  Contraindications: 'Had contraindications',
-  Refused: 'Refused vaccine',
-  Absent: 'Absent from the session',
-  Unwell: 'Unwell',
-  NoConsent: 'Unable to contact parent',
-  LateConsent: 'Consent received too late'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const VaccinationMethod = {
-  Nasal: 'Nasal spray',
-  Intramuscular: 'Intramuscular (IM) injection',
-  Subcutaneous: 'Subcutaneous injection'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const VaccinationSite = {
-  Nose: 'Nose',
-  ArmLeftUpper: 'Left arm (upper position)',
-  ArmLeftLower: 'Left arm (lower position)',
-  ArmRightUpper: 'Right arm (upper position)',
-  ArmRightLower: 'Right arm (lower position)',
-  ThighLeft: 'Left thigh',
-  ThighRight: 'Right thigh',
-  Other: 'Other'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const VaccinationProtocol = {
-  PGD: 'Patient Group Direction (PGD)',
-  PSD: 'Patient Specific Direction (PSD)',
-  National: 'National protocol'
-}
+import { Vaccine } from './vaccine.js'
 
 /**
  * @class Vaccination

--- a/app/models/vaccine.js
+++ b/app/models/vaccine.js
@@ -11,51 +11,6 @@ import {
 import { Batch } from './batch.js'
 
 /**
- * @readonly
- * @enum {string}
- */
-export const VaccineSideEffect = {
-  AppetiteLoss: 'loss of appetite',
-  BlockedNose: 'a runny or blocked nose',
-  Bruising: 'bruising or itching at the site of the injection',
-  Dizzy: 'dizziness',
-  Drowsy: 'feeling drowsy',
-  Headache: 'a headache',
-  Irritable: 'feeling irritable',
-  PainArms: 'pain in the arms, hands, fingers',
-  PainSite: 'pain, swelling or itchiness where the injection was given',
-  Rash: 'a rash',
-  Sick: 'feeling or being sick',
-  SickFeeling: 'feeling sick (nausea)',
-  Tiredness: 'general tiredness',
-  Temperature: 'a high temperature',
-  TemperatureShiver: 'a high temperature, or feeling hot and shivery',
-  Unwell: 'generally feeling unwell'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const PreScreenQuestion = {
-  IsWell: 'are not acutely unwell',
-  IsPregnant: 'are not pregnant',
-  IsMedicated: 'are not taking any medication which prevents vaccination',
-  IsAllergic: 'have no allergies which would prevent vaccination',
-  IsVaccinated: 'have not already had this vaccination',
-  IsHappy: 'know what the vaccination is for, and are happy to have it'
-}
-
-/**
- * @readonly
- * @enum {string}
- */
-export const VaccineMethod = {
-  Nasal: 'Nasal spray',
-  Injection: 'Injection'
-}
-
-/**
  * @class Vaccine
  * @param {object} options - Options
  * @param {object} [context] - Context
@@ -66,11 +21,11 @@ export const VaccineMethod = {
  * @property {string} manufacturer - Manufacturer
  * @property {object} [leaflet] - Leaflet
  * @property {number} dose - Dosage
- * @property {VaccineMethod} method - Method
- * @property {VaccinationProtocol} delegationProtocol - Delegation protocol
+ * @property {import('../enums.js').VaccineMethod} method - Method
+ * @property {import('../enums.js').VaccinationProtocol} delegationProtocol - Delegation protocol
  * @property {Array<VaccineSideEffect>} sideEffects - Side effects
  * @property {object} healthQuestions - Health questions
- * @property {Array<PreScreenQuestion>} preScreenQuestions - Pre-screening questions
+ * @property {Array<import('../enums.js').PreScreenQuestion>} preScreenQuestions - Pre-screening questions
  */
 export class Vaccine {
   constructor(options, context) {

--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -28,6 +28,7 @@ router.post('/:session_id/edit/:view', session.updateForm)
 
 router.post('/:session_id/close', session.close)
 router.post('/:session_id/default-batch', session.updateDefaultBatch)
+router.post('/:session_id/instructions', session.giveInstructions)
 router.post('/:session_id/offline', session.downloadFile)
 router.post('/:session_id/reminders', session.sendReminders)
 

--- a/app/utils/consent.js
+++ b/app/utils/consent.js
@@ -1,4 +1,4 @@
-import { ReplyDecision } from '../models/reply.js'
+import { ReplyDecision } from '../enums.js'
 
 import { camelToKebabCase } from './string.js'
 

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -1,15 +1,15 @@
 import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
-import { InstructionOutcome } from '../models/instruction.js'
 import {
   Activity,
   ConsentOutcome,
+  InstructionOutcome,
   PatientOutcome,
+  RegistrationOutcome,
   ScreenOutcome,
-  TriageOutcome
-} from '../models/patient-session.js'
-import { RegistrationOutcome } from '../models/session.js'
-import { VaccinationOutcome } from '../models/vaccination.js'
+  TriageOutcome,
+  VaccinationOutcome
+} from '../enums.js'
 
 /**
  * Get next activity

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -1,5 +1,6 @@
 import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
+import { InstructionOutcome } from '../models/instruction.js'
 import {
   Activity,
   ConsentOutcome,
@@ -184,6 +185,28 @@ export const getScreenStatus = (patientSession) => {
 }
 
 /**
+ * Get instruction status properties
+ *
+ * @param {import('../models/patient-session.js').PatientSession} patientSession - Patient session
+ * @returns {object} - Instruction status properties
+ */
+export const getInstructionStatus = (patientSession) => {
+  let colour
+  switch (patientSession.instruct) {
+    case InstructionOutcome.Given:
+      colour = 'blue'
+      break
+    default:
+      colour = 'grey'
+  }
+
+  return {
+    colour,
+    text: patientSession.instruct
+  }
+}
+
+/**
  * Get registration status properties
  *
  * @param {import('../models/patient-session.js').PatientSession} patientSession - Patient session
@@ -276,6 +299,18 @@ export const getReportStatus = (patientSession) => {
     colour,
     text: report
   }
+}
+
+/**
+ * Get instruction outcome
+ *
+ * @param {import('../models/patient-session.js').PatientSession} patientSession - Patient session
+ * @returns {InstructionOutcome} - Instruction outcome
+ */
+export const getInstructionOutcome = (patientSession) => {
+  return patientSession.instruction
+    ? InstructionOutcome.Given
+    : InstructionOutcome.Needed
 }
 
 /**

--- a/app/utils/reply.js
+++ b/app/utils/reply.js
@@ -2,11 +2,14 @@ import { faker } from '@faker-js/faker'
 import _ from 'lodash'
 
 import { healthConditions } from '../datasets/health-conditions.js'
+import {
+  ConsentOutcome,
+  ParentalRelationship,
+  ProgrammeType,
+  ReplyDecision,
+  ReplyRefusal
+} from '../enums.js'
 import { Child } from '../models/child.js'
-import { ParentalRelationship } from '../models/parent.js'
-import { ConsentOutcome } from '../models/patient-session.js'
-import { ProgrammeType } from '../models/programme.js'
-import { ReplyDecision, ReplyRefusal } from '../models/reply.js'
 
 import { formatParentalRelationship } from './string.js'
 

--- a/app/utils/session.js
+++ b/app/utils/session.js
@@ -1,7 +1,12 @@
 import { isAfter, isBefore } from 'date-fns'
 
-import { ProgrammeType, programmeTypes } from '../models/programme.js'
-import { ConsentWindow, SessionStatus, SessionType } from '../models/session.js'
+import {
+  ConsentWindow,
+  ProgrammeType,
+  SessionStatus,
+  SessionType
+} from '../enums.js'
+import { programmeTypes } from '../models/programme.js'
 import { today } from '../utils/date.js'
 
 /**

--- a/app/utils/triage.js
+++ b/app/utils/triage.js
@@ -1,8 +1,4 @@
-import {
-  ConsentOutcome,
-  ScreenOutcome,
-  TriageOutcome
-} from '../models/patient-session.js'
+import { ConsentOutcome, ScreenOutcome, TriageOutcome } from '../enums.js'
 
 import { getRepliesWithHealthAnswers } from './reply.js'
 

--- a/app/views/patient-session/_navigation.njk
+++ b/app/views/patient-session/_navigation.njk
@@ -10,6 +10,8 @@
 
   {{ actionList({
     items: [{
+      tag: statusTag(params.patientSession.status.instruct)
+    } if session.psdProtocol, {
       tag: statusTag(params.patientSession.status.register)
     }, {
       text: __("patientSession.registration.title"),

--- a/app/views/patient-session/_triage.njk
+++ b/app/views/patient-session/_triage.njk
@@ -66,7 +66,14 @@
   {% else %}
     <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--l">
 
-    {% set hintText = (__("triage.injection.consentGiven") if patientSession.hasConsentForInjection else __("triage.injection.consentRefused")) if not patientSession.hasConsentForInjectionOnly %}
+    {% set psdRadiosHtml = radios({
+      classes: "nhsuk-radios--inline",
+      fieldset: { legend: { text: __("triage.psd.label") } },
+      items: booleanItems,
+      decorate: "triage.psd"
+    }) if permissions.canPrescribe %}
+
+    {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(patientSession.screenOutcomesForConsentMethod), ScreenOutcome.VaccinateNasal, psdRadiosHtml) if patientSession.programme.hasAlternativeVaccines else triageOutcomeItems(patientSession.screenOutcomesForConsentMethod) %}
 
     {{ radios({
       fieldset: {
@@ -76,9 +83,9 @@
         }
       },
       hint: {
-        text: hintText if patientSession.programme.hasAlternativeVaccines
-      },
-      items: triageOutcomeItems(patientSession),
+        text: patientSession.screenVaccinationMethod
+      } if patientSession.screenVaccinationMethod,
+      items: outcomeItems,
       decorate: "triage.outcome"
     }) }}
 

--- a/app/views/patient-session/form/triage.njk
+++ b/app/views/patient-session/form/triage.njk
@@ -8,11 +8,26 @@
     title: title
   }) }}
 
+  {% set psdRadiosHtml = radios({
+    classes: "nhsuk-radios--inline",
+    fieldset: { legend: { text: __("triage.psd.label") } },
+    items: booleanItems,
+    decorate: "triage.psd"
+  }) if permissions.canPrescribe %}
+
+  {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(patientSession.screenOutcomesForConsentMethod), ScreenOutcome.VaccinateNasal, psdRadiosHtml) if patientSession.programme.hasAlternativeVaccines else triageOutcomeItems(patientSession.screenOutcomesForConsentMethod) %}
+
   {{ radios({
     fieldset: {
-      legend: { text: __("triage.label", { patient: patient }) }
+      legend: {
+        classes: "nhsuk-fieldset__legend--m",
+        text: __("triage.label", { patient: patient })
+      }
     },
-    items: triageOutcomeItems(patientSession),
+    hint: {
+      text: patientSession.screenVaccinationMethod
+    } if patientSession.screenVaccinationMethod,
+    items: outcomeItems,
     decorate: "triage.outcome"
   }) }}
 

--- a/app/views/reply/form/check-answers.njk
+++ b/app/views/reply/form/check-answers.njk
@@ -24,6 +24,9 @@
         decision: {
           href: reply.uri + "/new/decision"
         },
+        alternative: {
+          href: reply.uri + "/new/decision"
+        },
         refusalReason: {
           href: reply.uri + "/new/refusal-reason"
         },

--- a/app/views/reply/form/triage.njk
+++ b/app/views/reply/form/triage.njk
@@ -8,11 +8,26 @@
     title: title
   }) }}
 
+  {% set psdRadiosHtml = radios({
+    classes: "nhsuk-radios--inline",
+    fieldset: { legend: { text: __("triage.psd.label") } },
+    items: booleanItems,
+    decorate: "triage.psd"
+  }) if permissions.canPrescribe %}
+
+  {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(screenOutcomesForConsentMethod), ScreenOutcome.VaccinateNasal, psdRadiosHtml) if patientSession.programme.hasAlternativeVaccines and reply.decision != ReplyDecision.OnlyFluInjection and permissions.canPrescribe else triageOutcomeItems(screenOutcomesForConsentMethod) %}
+
   {{ radios({
     fieldset: {
-      legend: { text: __("triage.outcome.label") }
+      legend: {
+        classes: "nhsuk-fieldset__legend--m",
+        text: __("triage.outcome.label")
+      }
     },
-    items: triageOutcomeItems(patientSession),
+    hint: {
+      text: screenVaccinationMethod
+    } if screenVaccinationMethod,
+    items: outcomeItems,
     decorate: "triage.outcome"
   }) }}
 

--- a/app/views/session/_navigation.njk
+++ b/app/views/session/_navigation.njk
@@ -26,6 +26,11 @@
         current: params.view == "screen"
       },
       {
+        text: __("session.instruct.label"),
+        href: params.session.uri + "/instruct",
+        current: params.view == "instruct"
+      } if session.psdProtocol,
+      {
         text: __("session.register.label"),
         href: params.session.uri + "/register",
         current: params.view == "register"

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -81,6 +81,12 @@
           }) | safe
         }) }}
 
+        {{ button({
+          classes: "nhsuk-button--secondary",
+          text: __("session.instructions.label"),
+          href: session.uri + "/instructions"
+        }) if view == "instruct" and (data.token.role == UserRole.NursePrescriber or data.token.role == UserRole.Pharmacist) }}
+
         {% for patientSession in results.page %}
           {% set statusHtml %}
             {% if view == "register" %}

--- a/app/views/session/form/delegation.njk
+++ b/app/views/session/form/delegation.njk
@@ -20,13 +20,13 @@
       }
     },
     items: [{
-      text: "Yes",
-      hint: { text: __("session.psdProtocol.yes.hint") },
-      value: true
-    }, {
       text: "No",
       hint: { text: __("session.psdProtocol.no.hint") },
       value: false
+    }, {
+      text: "Yes",
+      hint: { text: __("session.psdProtocol.yes.hint") },
+      value: true
     }],
     decorate: "session.psdProtocol"
   }) }}
@@ -39,13 +39,13 @@
       }
     },
     items: [{
-      text: "Yes",
-      hint: { text: __("session.nationalProtocol.yes.hint") },
-      value: true
-    }, {
       text: "No",
       hint: { text: __("session.nationalProtocol.no.hint") },
       value: false
+    }, {
+      text: "Yes",
+      hint: { text: __("session.nationalProtocol.yes.hint") },
+      value: true
     }],
     decorate: "session.nationalProtocol"
   }) if session.programmePreset === "SeasonalFlu" }}

--- a/app/views/session/instructions.njk
+++ b/app/views/session/instructions.njk
@@ -1,0 +1,26 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.instructions.title") %}
+
+{% block beforeContent %}
+  {{ breadcrumb({
+    items: [{
+      text: __("home.show.title"),
+      href: "/"
+    }, {
+      text: __("session.list.title"),
+      href: "/sessions"
+    }, {
+      text: session.location.name,
+      href: "/sessions/" + session.id
+    }]
+  }) }}
+{% endblock %}
+
+{% block form %}
+  {{ heading({
+    title: title
+  }) }}
+
+  {{ __("session.instructions.description", session.patientSessionsToInstruct.length) | nhsukMarkdown }}
+{% endblock %}

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -9,6 +9,22 @@ import organisationsData from '../app/datasets/organisations.js'
 import schoolsData from '../app/datasets/schools.js'
 import usersData from '../app/datasets/users.js'
 import vaccinesData from '../app/datasets/vaccines.js'
+import {
+  AcademicYear,
+  ConsentOutcome,
+  ConsentWindow,
+  PatientOutcome,
+  ProgrammePreset,
+  ProgrammeType,
+  NoticeType,
+  MoveSource,
+  RegistrationOutcome,
+  SchoolPhase,
+  ScreenOutcome,
+  SessionType,
+  UploadType,
+  UserRole
+} from '../app/enums.js'
 import { generateBatch } from '../app/generators/batch.js'
 import { generateCohort } from '../app/generators/cohort.js'
 import { generateConsent } from '../app/generators/consent.js'
@@ -23,31 +39,14 @@ import { generateUpload } from '../app/generators/upload.js'
 import { generateUser } from '../app/generators/user.js'
 import { generateVaccination } from '../app/generators/vaccination.js'
 import { Clinic } from '../app/models/clinic.js'
-import { AcademicYear, Cohort } from '../app/models/cohort.js'
+import { Cohort } from '../app/models/cohort.js'
 import { Instruction } from '../app/models/instruction.js'
-import { Move, MoveSource } from '../app/models/move.js'
-import { NoticeType } from '../app/models/notice.js'
+import { Move } from '../app/models/move.js'
 import { Organisation } from '../app/models/organisation.js'
-import {
-  ConsentOutcome,
-  PatientOutcome,
-  PatientSession,
-  ScreenOutcome
-} from '../app/models/patient-session.js'
-import {
-  ProgrammePreset,
-  ProgrammeType,
-  programmeTypes
-} from '../app/models/programme.js'
-import { SchoolPhase } from '../app/models/school.js'
-import {
-  ConsentWindow,
-  RegistrationOutcome,
-  Session,
-  SessionType
-} from '../app/models/session.js'
-import { UploadType } from '../app/models/upload.js'
-import { User, UserRole } from '../app/models/user.js'
+import { PatientSession } from '../app/models/patient-session.js'
+import { programmeTypes } from '../app/models/programme.js'
+import { Session } from '../app/models/session.js'
+import { User } from '../app/models/user.js'
 import { Vaccination } from '../app/models/vaccination.js'
 import {
   addDays,

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -12,6 +12,7 @@ import vaccinesData from '../app/datasets/vaccines.js'
 import { generateBatch } from '../app/generators/batch.js'
 import { generateCohort } from '../app/generators/cohort.js'
 import { generateConsent } from '../app/generators/consent.js'
+import { generateInstruction } from '../app/generators/instruction.js'
 import { generateNotice } from '../app/generators/notice.js'
 import { generateOrganisation } from '../app/generators/organisation.js'
 import { generateProgramme } from '../app/generators/programme.js'
@@ -23,6 +24,7 @@ import { generateUser } from '../app/generators/user.js'
 import { generateVaccination } from '../app/generators/vaccination.js'
 import { Clinic } from '../app/models/clinic.js'
 import { AcademicYear, Cohort } from '../app/models/cohort.js'
+import { Instruction } from '../app/models/instruction.js'
 import { Move, MoveSource } from '../app/models/move.js'
 import { NoticeType } from '../app/models/notice.js'
 import { Organisation } from '../app/models/organisation.js'
@@ -375,6 +377,7 @@ for (const patientSession of patientSessions.values()) {
 }
 
 // Screen and record
+const instructions = new Map()
 const vaccinations = new Map()
 for (const patientSession of patientSessions.values()) {
   // Update patient session to include replies in context
@@ -472,6 +475,23 @@ for (const patientSession of patientSessions.values()) {
 
       const vaccinatedInSchool = faker.datatype.boolean(0.8)
       if (vaccinatedInSchool) {
+        if (programme.type === ProgrammeType.Flu && session.psdProtocol) {
+          let instruction = generateInstruction(
+            patientSessionWithContext,
+            programme,
+            session,
+            nurses
+          )
+          instruction = new Instruction(instruction, {
+            patients: Object.fromEntries(patients),
+            programmes: Object.fromEntries(programmes)
+          })
+          instructions.set(instruction.uuid, instruction)
+
+          // GIVE INSTRUCTION for PSD
+          patientSession.giveInstruction(instruction)
+        }
+
         // REGISTER attendance (15 minutes before vaccination)
         patientSession.registerAttendance(
           {
@@ -610,6 +630,7 @@ if (vaccinatedPatient) {
 generateDataFile('.data/batches.json', batches)
 generateDataFile('.data/clinics.json', clinics)
 generateDataFile('.data/cohorts.json', cohorts)
+generateDataFile('.data/instructions.json', instructions)
 generateDataFile('.data/moves.json', moves)
 generateDataFile('.data/notices.json', notices)
 generateDataFile('.data/organisations.json', organisations)


### PR DESCRIPTION
## Add support for prescribing role

The prototype has 2 new roles:

- Prescribing nurse
- Pharmacist

Both have permission to prescribe/add PSD instructions.

> [!NOTE]
>
> How we model this with CIS2 and RBAC/workgroups is still tp be decided.

![Screenshot of CIS2 change role page.](https://github.com/user-attachments/assets/0950e155-bca5-46de-8f86-a465530c92ce)

## Enabling PSD protocol on a session

The session delegation setting added in #107 remains, though I swapped the order of the options, with the default value ‘No’ being the first. We should change this round if we want the default to be ‘Yes’.

> [!NOTE]
>
> It’s not yet been decided which roles can change these settings, is it just admins and nurses?

![Screenshot of session delegation options.](https://github.com/user-attachments/assets/4a499bf3-4242-4879-b1ba-cdcc2a91256b)

## Showing PSDs added and not added to patients in a session

If the PSD protocol is enabled for a session (and currently only for programmes which administer the nasal spray), a new ‘PSDs’ activity list is provided. It can be filtered by PSD status and year groups (as well as the standard advanced filter options).

This shows the current status of every child in the session with regards to whether they have had a PSD added to their record or not:

![Screenshot of session activity list for PSDs](https://github.com/user-attachments/assets/6931b2ca-6c09-40cd-9959-c8370aff5e56)

On a patient session page, the patient’s PSD status is shown (if the PSD is enabled for a session) before their registration status (if registration is enabled for a session):

![Screenshot of patient session page showing PSD status.](https://github.com/user-attachments/assets/a173ef74-f269-4103-b085-a2ff5e30dd46)

## Prescribing nurses and pharmacists can bulk add PSD instructions

If a user has prescriber permissions, on the PSDs page a ‘Add new PSDs’ button is shown:

![Screenshot of session activity list for PSDs showing button.](https://github.com/user-attachments/assets/9148b7a1-1aa3-4156-a3cb-912a7667c082)

This takes the prescriber to a page where they can see how many children need PSDs adding to their record, before continuing:

![Screenshot of page to bulk create PSD instructionss](https://github.com/user-attachments/assets/60a95bdf-4487-4389-8aa3-22f3286afc33)

Upon clicking continue, all patients who have consent and do not require triage get a PSD added to their record:

![Screenshot of patient session page showing updated PSD statuses.](https://github.com/user-attachments/assets/5f88d6c0-d083-4368-babf-c9cfd6572232)

## Prescribing nurses and pharmacists add a PSD instruction when triaging

When triaging a patient who is safe to vaccinate with the nasal spray, a prescriber can also choose to add a PSD. This can happen in 2 scenarios:

- Recording an initial triage outcome
- Updating triage outcome
- Recording a new consent response, and the health questions require triage

> [!NOTE]
>
> Should updating a triage outcome allow you to remove a PSD?

> [!NOTE]
>
> If a PSD has been added to a patient, and a consent response is submitted that triggers triage, the PSD should be rescinded/invalidated.

![Screenshot of patient session with option to add a PSD in triage outcome.](https://github.com/user-attachments/assets/0628e483-52e0-4ae7-9162-b73202a65121)

![Screenshot of updating a triage outcome with option to add a PSD.](https://github.com/user-attachments/assets/c5977452-622a-46dd-bfa1-5da344d4eade)

![Screenshot of performing triage on a new consent response with the option to add a PSD.](https://github.com/user-attachments/assets/aa526ceb-6d24-4e94-9ecd-179fb307b89a)

## HCA can record a nasal flu spray using PSD protocol 

During a recording session, a HCA can record a vaccination using the nasal spray using the PSD protocol, if the patient has has a PSD added to their record.

There is no need in this scenario for the HCA to record a supplier.

![Screenshot of HCA recording a vaccination for a patient session.](https://github.com/user-attachments/assets/6a147fce-364c-48d0-811c-ec5b79ae244d)

![Screenshot of check and confirm answers for a new vaccination, showing it recorded under the PSD protocol.](https://github.com/user-attachments/assets/3a0329db-b81f-4cb2-b6ca-16e6b32757e0)