### PR TITLE
Recording nasal spray or injected vaccine, and changing method and site values

### DIFF
--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -115,12 +115,12 @@ export const parentController = {
     response.locals.consent = consent
 
     const programmes = consent.session ? consent.session.primaryProgrammes : []
-    const { hasAlternativeVaccines } = consent?.session
+    const { offersAlternativeVaccine } = consent?.session
 
     // If programme has alternative vaccine, and given consent has been given
     // for the default, ask for consent for the alternative as well
     const getConsentForAlternativeVaccine =
-      hasAlternativeVaccines && consent.decision === ReplyDecision.Given
+      offersAlternativeVaccine && consent.decision === ReplyDecision.Given
 
     const journey = {
       [`/${session_id}`]: {},
@@ -223,7 +223,7 @@ export const parentController = {
             ? ReplyDecision.OnlyTdIPV
             : ReplyDecision.OnlyMenACWY
       }))
-    } else if (hasAlternativeVaccines) {
+    } else if (offersAlternativeVaccine) {
       // Flu: Ask which vaccine the parent would prefer
       response.locals.decisionItems = [
         {

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -241,7 +241,7 @@ export const sessionController = {
 
     // Vaccination method filter options (if session administering alternative)
     if (
-      session.hasAlternativeVaccines &&
+      session.offersAlternativeVaccine &&
       ['register', 'record', 'report'].includes(view)
     ) {
       response.locals.vaccineMethodItems = [
@@ -271,7 +271,7 @@ export const sessionController = {
 
     // Screen/register/outcome status filter options (select one)
     for (const activity of ['screen', 'instruct', 'register', 'outcome']) {
-      const screenOutcomes = session.hasAlternativeVaccines
+      const screenOutcomes = session.offersAlternativeVaccine
         ? Object.values(ScreenOutcome).filter(
             (outcome) => outcome !== ScreenOutcome.Vaccinate
           )

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -263,6 +263,7 @@ export const vaccinationController = {
 
       response.locals.injectionSiteItems = Object.entries(VaccinationSite)
         .filter(([, value]) => value !== VaccinationSite.Nose)
+        .filter(([, value]) => value !== VaccinationSite.Other)
         .map(([key, value]) => ({
           text: VaccinationSite[key],
           value

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -73,7 +73,7 @@ export const vaccinationController = {
     // Check for default batch
     const defaultBatchId = session.defaultBatch_ids?.[vaccine.snomed]
 
-    const readyToVaccine = ready === 'true'
+    const readyToVaccine = ['true', 'alternative'].includes(ready)
     const injectionSiteGiven = [
       VaccinationSite.ArmLeftUpper,
       VaccinationSite.ArmRightUpper

--- a/app/emails/consent/record-vaccinated-many.njk
+++ b/app/emails/consent/record-vaccinated-many.njk
@@ -7,7 +7,7 @@ We suggest you record the following details {% if consent.child.school.phase == 
 {% for programme in session.primaryProgrammes %}
 > Vaccination: {{ programme.name }}<br>
 > Vaccine: {{ programme.vaccines[0].brand }}<br>
-{% if programme.hasAlternativeVaccines %}
+{% if programme.alternativeVaccine %}
 > Method: {{ programme.vaccines[0].method }}<br>
 {% endif %}
 > Date of vaccination: {{ session.formatted.firstDate }}<br>

--- a/app/emails/consent/record-vaccinated-many.njk
+++ b/app/emails/consent/record-vaccinated-many.njk
@@ -7,6 +7,9 @@ We suggest you record the following details {% if consent.child.school.phase == 
 {% for programme in session.primaryProgrammes %}
 > Vaccination: {{ programme.name }}<br>
 > Vaccine: {{ programme.vaccines[0].brand }}<br>
+{% if programme.hasAlternativeVaccines %}
+> Method: {{ programme.vaccines[0].method }}<br>
+{% endif %}
 > Date of vaccination: {{ session.formatted.firstDate }}<br>
 > Batch number: AB1234
 {% endfor %}

--- a/app/emails/consent/record-vaccinated.njk
+++ b/app/emails/consent/record-vaccinated.njk
@@ -6,7 +6,7 @@ We suggest you record the following details {% if consent.child.school.phase == 
 
 > Vaccination: {{ programme.name }}<br>
 > Vaccine: {{ programme.vaccines[0].brand }}<br>
-{%- if programme.hasAlternativeVaccines %}
+{%- if programme.alternativeVaccine %}
 > Method: {{ programme.vaccines[0].method }}<br>
 {%- endif %}
 > Date of vaccination: {{ session.formatted.firstDate }}<br>

--- a/app/emails/consent/record-vaccinated.njk
+++ b/app/emails/consent/record-vaccinated.njk
@@ -6,6 +6,9 @@ We suggest you record the following details {% if consent.child.school.phase == 
 
 > Vaccination: {{ programme.name }}<br>
 > Vaccine: {{ programme.vaccines[0].brand }}<br>
+{%- if programme.hasAlternativeVaccines %}
+> Method: {{ programme.vaccines[0].method }}<br>
+{%- endif %}
 > Date of vaccination: {{ session.formatted.firstDate }}<br>
 > Batch number: AB1234
 

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -54,7 +54,7 @@ export function generateConsent(
     { value: ReplyDecision.Declined, weight: 3 },
     { value: ReplyDecision.Refused, weight: 1 },
     ...(programme.type === ProgrammeType.Flu
-      ? [{ value: ReplyDecision.OnlyFluInjection, weight: 3 }]
+      ? [{ value: ReplyDecision.OnlyFluInjection, weight: 1 }]
       : [])
   ])
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1575,25 +1575,25 @@ export const en = {
       title: 'Delegation'
     },
     nationalProtocol: {
-      label: 'Use National protocol',
+      label: 'Use national protocol',
       title:
         'Can healthcare assistants administer the injected flu vaccine using the national protocol?',
       yes: {
         label: 'Yes',
-        hint: 'Healthcare assistants can administer an injected vaccine when supplied by a nurse'
+        hint: 'Healthcare assistants can administer an injected flu vaccine when supplied by a nurse'
       },
       no: {
         label: 'No',
-        hint: 'Only nurses can administer the injected vaccine'
+        hint: 'Only nurses can administer the injected flu vaccine'
       }
     },
     psdProtocol: {
-      label: 'Use Patient Specific Direction',
+      label: 'Use patient specific direction (PSD)',
       title:
-        'Can healthcare assistants administer the nasal spray using Patient Specific Direction (PSD)?',
+        'Can healthcare assistants administer the flu nasal spray vaccine using a patient specific direction (PSD)?',
       yes: {
         label: 'Yes',
-        hint: 'Healthcare assistants can supply and administer a nasal spray when instructed by a prescriber'
+        hint: 'Healthcare assistants can administer the nasal spray vaccine to children who are covered by a PSD'
       },
       no: {
         label: 'No',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1192,7 +1192,8 @@ export const en = {
           'Is {{patient.firstName}} ready for their {{session.programmeNames.sentenceCase}} {{method}}?',
         hint: 'Pre-screening checks must be completed for vaccination to go ahead',
         yes: 'Yes',
-        no: 'No'
+        no: 'No',
+        alternative: 'No — but they can have the injected flu vaccine instead'
       },
       injectionSite: {
         error: 'Select an injection site',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2366,10 +2366,13 @@ export const en = {
         'How was the {{session.programmeNames.sentenceCase}} vaccination given?'
     },
     method: {
-      label: 'Method'
+      label: 'Method',
+      title:
+        'How was the {{session.programmeNames.sentenceCase}} vaccination given?'
     },
     site: {
-      label: 'Site'
+      label: 'Site',
+      title: 'Which injection site was used?'
     },
     programme: {
       label: 'Programme'
@@ -2411,7 +2414,7 @@ export const en = {
       }
     },
     vaccine_snomed: {
-      title: 'Vaccine',
+      title: 'What vaccine was given?',
       label: 'Vaccine'
     },
     review: {

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -264,7 +264,7 @@ export class PatientSession {
     const hasScreenedForInjection =
       this.screen === ScreenOutcome.VaccinateInjection
 
-    return this.hasConsentForInjection || hasScreenedForInjection
+    return this.hasConsentForInjectionOnly || hasScreenedForInjection
       ? VaccineMethod.Injection
       : VaccineMethod.Nasal
   }
@@ -592,7 +592,8 @@ export class PatientSession {
       },
       nextActivityPerProgramme: formatList(nextActivityPerProgramme),
       outstandingVaccinations: filters.formatList(outstandingVaccinations),
-      vaccineMethod: formatVaccineMethod(this.vaccineMethod)
+      vaccineMethod:
+        this.vaccineMethod && formatVaccineMethod(this.vaccineMethod)
     }
   }
 

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -63,6 +63,7 @@ import { Session } from './session.js'
  * @property {Date} [updatedAt] - Updated date
  * @property {Gillick} [gillick] - Gillick assessment
  * @property {Array<AuditEvent>} [notes] - Session notes
+ * @property {boolean} alternative - Administer alternative vaccine
  * @property {string} patient_uuid - Patient UUID
  * @property {string} instruction_uuid - Instruction UUID
  * @property {string} programme_id - Programme ID
@@ -77,6 +78,7 @@ export class PatientSession {
     this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
     this.gillick = options?.gillick && new Gillick(options.gillick)
     this.notes = options?.notes || []
+    this.alternative = options?.alternative || false
     this.patient_uuid = options?.patient_uuid
     this.instruction_uuid = options?.instruction_uuid
     this.programme_id = options?.programme_id
@@ -259,6 +261,11 @@ export class PatientSession {
   get vaccineMethod() {
     if (this.programme.type !== ProgrammeType.Flu) {
       return VaccineMethod.Injection
+    }
+
+    // Administered vaccine was the alternative
+    if (this.alternative) {
+      return this.programme.alternativeVaccine.method
     }
 
     const hasScreenedForInjection =
@@ -471,7 +478,7 @@ export class PatientSession {
    * @returns {import('./vaccination.js').Vaccination} - Vaccination
    */
   get lastRecordedVaccination() {
-    if (this.vaccinations.length > 0) {
+    if (this.vaccinations?.length > 0) {
       return this.vaccinations.at(-1)
     }
   }

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -534,7 +534,7 @@ export class PatientSession {
       consent = this.consentRefusalReasons.join('<br>')
     } else if (
       this.consent === ConsentOutcome.Given &&
-      this.programme.hasAlternativeVaccines
+      this.programme.alternativeVaccine
     ) {
       if (this.hasConsentForInjectionOnly) {
         consent = 'Injection'

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -1,7 +1,12 @@
 import { isAfter } from 'date-fns'
 
 import vaccines from '../datasets/vaccines.js'
-import { SchoolYear, ProgrammeStatus, ProgrammeType } from '../enums.js'
+import {
+  SchoolYear,
+  ProgrammeStatus,
+  ProgrammeType,
+  VaccineMethod
+} from '../enums.js'
 import { isBetweenDates, today } from '../utils/date.js'
 import {
   formatLink,
@@ -197,13 +202,17 @@ export class Programme {
   }
 
   /**
-   * Check if programme offers an alternative vaccine
-   * For example, the flu programme offer both nasal and injection vaccines
+   * Alternative vaccine for a programme
+   * For example, flu programme offers nasal spray with injection as alternative
    *
-   * @returns {boolean} Has alternative vaccines
+   * @returns {Vaccine|undefined} Alternative vaccine
    */
-  get hasAlternativeVaccines() {
-    return this.vaccine_smomeds.length > 1
+  get alternativeVaccine() {
+    if (this.vaccines.length > 1) {
+      return this.vaccines.find(
+        ({ method }) => method === VaccineMethod.Injection
+      )
+    }
   }
 
   /**

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -612,10 +612,12 @@ export class Session {
    *
    * @returns {boolean} Has alternative vaccines
    */
-  get hasAlternativeVaccines() {
-    return this.programmes
-      .flatMap(({ hasAlternativeVaccines }) => hasAlternativeVaccines)
-      .find((value) => value)
+  get offersAlternativeVaccine() {
+    const programmesWithAlternativeVaccine = this.programmes.filter(
+      ({ alternativeVaccine }) => alternativeVaccine
+    )
+
+    return programmesWithAlternativeVaccine.length > 0
   }
 
   /**

--- a/app/models/vaccination.js
+++ b/app/models/vaccination.js
@@ -169,31 +169,48 @@ export class Vaccination {
   /**
    * Get method
    *
-   * @returns {string|undefined} - Method
+   * @returns {VaccinationMethod|undefined} - Method
    */
   get method() {
     if (!this.vaccine || !this.given) return
 
     if (this.vaccine.method === VaccineMethod.Nasal) {
-      return VaccinationMethod.Nasal
+      this.injectionMethod = VaccinationMethod.Nasal
     }
 
-    return this.injectionMethod || ''
+    if (
+      this.vaccine.method === VaccineMethod.Injection &&
+      this.injectionMethod === VaccinationMethod.Nasal
+    ) {
+      // Change previously set injection site to intramuscular (good default)
+      this.injectionMethod = VaccinationMethod.Intramuscular
+    }
+
+    return this.injectionMethod
   }
 
   /**
    * Get anatomical site
    *
-   * @returns {string|undefined} - Anatomical site
+   * @returns {VaccinationSite|undefined} - Anatomical site
    */
   get site() {
     if (!this.vaccine || !this.given) return
 
-    if (this.vaccine.method === VaccineMethod.Nasal) {
-      return VaccinationSite.Nose
+    if (this.method === VaccinationMethod.Nasal) {
+      // Method is nasal, so site is ‘Nose’
+      this.injectionSite = VaccinationSite.Nose
     }
 
-    return this.injectionSite || ''
+    if (
+      this.method !== VaccinationMethod.Nasal &&
+      this.injectionSite === VaccinationSite.Nose
+    ) {
+      // Reset any previously set injection site as can no longer be ‘Nose’
+      this.injectionSite = null
+    }
+
+    return this.injectionSite
   }
 
   /**

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -309,6 +309,12 @@ export const getReportStatus = (patientSession) => {
  * @returns {InstructionOutcome|boolean} - Instruction outcome
  */
 export const getInstructionOutcome = (patientSession) => {
+  // Need consent response(s) before we can determine the chosen method
+  // We only want to instruct on patients being vaccinated using nasal spray
+  if (patientSession.consent !== ConsentOutcome.Given) {
+    return false
+  }
+
   if (patientSession.vaccineMethod === VaccineMethod.Nasal) {
     return patientSession.instruction
       ? InstructionOutcome.Given

--- a/app/utils/triage.js
+++ b/app/utils/triage.js
@@ -25,11 +25,11 @@ export const getScreenOutcomesForConsentMethod = (programme, replies) => {
   )
 
   return [
-    ...(!programme?.hasAlternativeVaccines ? [ScreenOutcome.Vaccinate] : []),
-    ...(programme?.hasAlternativeVaccines && !hasConsentForInjectionOnly
+    ...(!programme?.alternativeVaccine ? [ScreenOutcome.Vaccinate] : []),
+    ...(programme?.alternativeVaccine && !hasConsentForInjectionOnly
       ? [ScreenOutcome.VaccinateNasal]
       : []),
-    ...(programme?.hasAlternativeVaccines && hasConsentForInjection
+    ...(programme?.alternativeVaccine && hasConsentForInjection
       ? [ScreenOutcome.VaccinateInjection]
       : []),
     'or',
@@ -55,7 +55,7 @@ export const getScreenVaccinationMethod = (programme, replies) => {
     ({ decision }) => decision === ReplyDecision.OnlyFluInjection
   )
 
-  if (programme?.hasAlternativeVaccines) {
+  if (programme?.alternativeVaccine) {
     if (hasConsentForInjectionOnly) {
       return ScreenVaccinationMethod.InjectionOnly
     } else if (!hasConsentForInjection) {

--- a/app/views/patient-session/_record.njk
+++ b/app/views/patient-session/_record.njk
@@ -74,6 +74,23 @@
 
   <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--l">
 
+  {% set vaccinationSiteHtml = radios({
+    fieldset: {
+      legend: { text: __("patientSession.preScreen.injectionSite.label") }
+    },
+    items: vaccinationSiteItems,
+    decorate: "patientSession.preScreen.injectionSite",
+    _validate: {
+      conditional: {
+        dependentOn: {
+          name: "[patientSession][preScreen][ready]",
+          value: true
+        },
+        message: __("patientSession.preScreen.injectionSite.error")
+      }
+    }
+  }) %}
+
   {{ radios({
     fieldset: {
       legend: {
@@ -93,28 +110,26 @@
           text: __("patientSession.preScreen.ready.hint")
         },
         conditional: {
-          html: radios({
-            fieldset: {
-              legend: { text: __("patientSession.preScreen.injectionSite.label") }
-            },
-            items: vaccinationSiteItems,
-            decorate: "patientSession.preScreen.injectionSite",
-            _validate: {
-              conditional: {
-                dependentOn: {
-                  name: "[patientSession][preScreen][ready]",
-                  value: true
-                },
-                message: __("patientSession.preScreen.injectionSite.error")
-              }
-            }
-          })
-        } if vaccinationSiteItems
+          html: vaccinationSiteHtml
+        } if patientSession.vaccine.method === VaccineMethod.Injection
       },
       {
         text: __("patientSession.preScreen.ready.no"),
         value: false
-      }
+      },
+      {
+        divider: "or"
+      } if canRecordAlternativeVaccine,
+      {
+        text: __("patientSession.preScreen.ready.alternative"),
+        value: "alternative",
+        hint: {
+          text: __("patientSession.preScreen.ready.hint")
+        },
+        conditional: {
+          html: vaccinationSiteHtml
+        }
+      } if canRecordAlternativeVaccine
     ],
     decorate: "patientSession.preScreen.ready",
     _validate: {

--- a/app/views/patient-session/_triage.njk
+++ b/app/views/patient-session/_triage.njk
@@ -73,7 +73,7 @@
       decorate: "triage.psd"
     }) if permissions.canPrescribe %}
 
-    {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(patientSession.screenOutcomesForConsentMethod), ScreenOutcome.VaccinateNasal, psdRadiosHtml) if patientSession.programme.hasAlternativeVaccines else triageOutcomeItems(patientSession.screenOutcomesForConsentMethod) %}
+    {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(patientSession.screenOutcomesForConsentMethod), ScreenOutcome.VaccinateNasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine else triageOutcomeItems(patientSession.screenOutcomesForConsentMethod) %}
 
     {{ radios({
       fieldset: {

--- a/app/views/patient-session/form/triage.njk
+++ b/app/views/patient-session/form/triage.njk
@@ -15,7 +15,7 @@
     decorate: "triage.psd"
   }) if permissions.canPrescribe %}
 
-  {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(patientSession.screenOutcomesForConsentMethod), ScreenOutcome.VaccinateNasal, psdRadiosHtml) if patientSession.programme.hasAlternativeVaccines else triageOutcomeItems(patientSession.screenOutcomesForConsentMethod) %}
+  {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(patientSession.screenOutcomesForConsentMethod), ScreenOutcome.VaccinateNasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine else triageOutcomeItems(patientSession.screenOutcomesForConsentMethod) %}
 
   {{ radios({
     fieldset: {

--- a/app/views/reply/form/decision.njk
+++ b/app/views/reply/form/decision.njk
@@ -19,7 +19,7 @@
     },
     items: [
       {
-        text: __('reply.decision.nasal.label') if programme.hasAlternativeVaccines else __('reply.decision.yes.label'),
+        text: __('reply.decision.nasal.label') if programme.alternativeVaccine else __('reply.decision.yes.label'),
         value: ReplyDecision.Given,
         conditional: {
           html: radios({
@@ -32,12 +32,12 @@
             items: booleanItems,
             decorate: "reply.alternative"
           })
-        } if programme.hasAlternativeVaccines
+        } if programme.alternativeVaccine
       },
       {
         text: __('reply.decision.injection.label'),
         value: ReplyDecision.OnlyFluInjection
-      } if programme.hasAlternativeVaccines,
+      } if programme.alternativeVaccine,
       {
         text: __('reply.decision.no.label'),
         value: ReplyDecision.Refused

--- a/app/views/reply/form/triage.njk
+++ b/app/views/reply/form/triage.njk
@@ -15,7 +15,7 @@
     decorate: "triage.psd"
   }) if permissions.canPrescribe %}
 
-  {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(screenOutcomesForConsentMethod), ScreenOutcome.VaccinateNasal, psdRadiosHtml) if patientSession.programme.hasAlternativeVaccines and reply.decision != ReplyDecision.OnlyFluInjection and permissions.canPrescribe else triageOutcomeItems(screenOutcomesForConsentMethod) %}
+  {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(screenOutcomesForConsentMethod), ScreenOutcome.VaccinateNasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine and reply.decision != ReplyDecision.OnlyFluInjection and permissions.canPrescribe else triageOutcomeItems(screenOutcomesForConsentMethod) %}
 
   {{ radios({
     fieldset: {

--- a/app/views/vaccination/edit.njk
+++ b/app/views/vaccination/edit.njk
@@ -21,13 +21,13 @@
           href: "edit/outcome"
         },
         vaccine_snomed: {
-          href: "edit/vaccine"
+          href: "edit/vaccine" if programme.hasAlternativeVaccines
         },
         method: {
-          href: "edit/injection" if vaccination.vaccine.method == VaccineMethod.Injection
+          href: "edit/method" if vaccination.method != VaccinationMethod.Nasal
         },
         site: {
-          href: "edit/injection" if vaccination.vaccine.method == VaccineMethod.Injection
+          href: "edit/site" if vaccination.method != VaccinationMethod.Nasal
         },
         dose: {
           href: "edit/dose"

--- a/app/views/vaccination/edit.njk
+++ b/app/views/vaccination/edit.njk
@@ -21,7 +21,7 @@
           href: "edit/outcome"
         },
         vaccine_snomed: {
-          href: "edit/vaccine" if programme.hasAlternativeVaccines
+          href: "edit/vaccine" if programme.alternativeVaccine
         },
         method: {
           href: "edit/method" if vaccination.method != VaccinationMethod.Nasal

--- a/app/views/vaccination/form/administer.njk
+++ b/app/views/vaccination/form/administer.njk
@@ -6,29 +6,11 @@
   {{ heading({
     caption: vaccination.patient.fullName,
     title: title
-  }) if patientSession.vaccine.method == VaccineMethod.Injection }}
+  }) }}
 
   {{ input({
     type: "hidden",
     value: "full",
-    decorate: "vaccination.dosage"
-  }) if patientSession.vaccine.method == VaccineMethod.Injection else radios({
-    fieldset: {
-      legend: {
-        html: heading({
-          classes: "nhsuk-fieldset__legend--l",
-          caption: vaccination.patient.fullName,
-          title: __("vaccination.dosage.title")
-        })
-      }
-    },
-    items: [{
-      text: __("vaccination.dosage.full"),
-      value: "full"
-    }, {
-      text: __("vaccination.dosage.half"),
-      value: "half"
-    }],
     decorate: "vaccination.dosage"
   }) }}
 
@@ -41,7 +23,7 @@
     },
     items: injectionMethodItems,
     decorate: "vaccination.injectionMethod"
-  }) if patientSession.vaccine.method == VaccineMethod.Injection }}
+  }) }}
 
   {{ radios({
     fieldset: {
@@ -52,5 +34,5 @@
     },
     items: injectionSiteItems,
     decorate: "vaccination.injectionSite"
-  }) if patientSession.vaccine.method == VaccineMethod.Injection }}
+  }) }}
 {% endblock %}

--- a/app/views/vaccination/form/check-answers.njk
+++ b/app/views/vaccination/form/check-answers.njk
@@ -15,15 +15,17 @@
     descriptionHtml: summaryList({
       rows: summaryRows(vaccination, {
         programme: {},
-        vaccine_snomed: {},
+        vaccine_snomed: {
+          href: vaccination.uri + "/new/vaccine" if programme.hasAlternativeVaccines
+        },
         method: {
-          href: vaccination.uri + "/new/administer" if vaccination.vaccine.method == VaccineMethod.Injection
+          href: vaccination.uri + "/new/method" if vaccination.method != VaccinationMethod.Nasal
         },
         site: {
-          href: vaccination.uri + "/new/administer" if vaccination.vaccine.method == VaccineMethod.Injection
+          href: vaccination.uri + "/new/site" if vaccination.method != VaccinationMethod.Nasal
         },
         dose: {
-          href: vaccination.uri + "/new/administer" if vaccination.vaccine.method == VaccineMethod.Nasal else vaccination.uri + "/new/dose"
+          href: vaccination.uri + "/new/dose"
         },
         sequence: {
           href: vaccination.uri + "/new/sequence"

--- a/app/views/vaccination/form/check-answers.njk
+++ b/app/views/vaccination/form/check-answers.njk
@@ -16,7 +16,7 @@
       rows: summaryRows(vaccination, {
         programme: {},
         vaccine_snomed: {
-          href: vaccination.uri + "/new/vaccine" if programme.hasAlternativeVaccines
+          href: vaccination.uri + "/new/vaccine" if programme.alternativeVaccine
         },
         method: {
           href: vaccination.uri + "/new/method" if vaccination.method != VaccinationMethod.Nasal

--- a/app/views/vaccination/form/dose.njk
+++ b/app/views/vaccination/form/dose.njk
@@ -14,5 +14,23 @@
     },
     suffix: "ml",
     decorate: "vaccination.dose"
+  }) if vaccination.method == VaccinationMethod.Injection else radios({
+    fieldset: {
+      legend: {
+        html: heading({
+          classes: "nhsuk-fieldset__legend--l",
+          caption: vaccination.patient.fullName,
+          title: __("vaccination.dosage.title")
+        })
+      }
+    },
+    items: [{
+      text: __("vaccination.dosage.full"),
+      value: "full"
+    }, {
+      text: __("vaccination.dosage.half"),
+      value: "half"
+    }],
+    decorate: "vaccination.dosage"
   }) }}
 {% endblock %}

--- a/app/views/vaccination/form/method.njk
+++ b/app/views/vaccination/form/method.njk
@@ -1,0 +1,19 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("vaccination.method.title") %}
+
+{% block form %}
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--l",
+        html: heading({
+          caption: vaccination.patient.fullName,
+          title: title
+        })
+      }
+    },
+    items: injectionMethodItems,
+    decorate: "vaccination.injectionMethod"
+  }) }}
+{% endblock %}

--- a/app/views/vaccination/form/site.njk
+++ b/app/views/vaccination/form/site.njk
@@ -1,0 +1,19 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("vaccination.site.title") %}
+
+{% block form %}
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--l",
+        html: heading({
+          caption: vaccination.patient.fullName,
+          title: title
+        })
+      }
+    },
+    items: injectionSiteItems,
+    decorate: "vaccination.injectionSite"
+  }) }}
+{% endblock %}

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -400,7 +400,7 @@ for (const patientSession of patientSessions.values()) {
           { value: ScreenOutcome.NeedsTriage, weight: 2 },
           { value: ScreenOutcome.DelayVaccination, weight: 2 },
           { value: ScreenOutcome.DoNotVaccinate, weight: 1 },
-          ...(patientSessionWithContext.programme.hasAlternativeVaccines
+          ...(patientSessionWithContext.programme.alternativeVaccine
             ? [{ value: ScreenOutcome.VaccinateNasal, weight: 7 }]
             : [{ value: ScreenOutcome.Vaccinate, weight: 7 }])
         ])

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -396,15 +396,19 @@ for (const patientSession of patientSessions.values()) {
     for (const response of patientSessionWithContext.responsesWithTriageNotes) {
       const triaged = faker.datatype.boolean(0.3)
       if (triaged) {
-        const outcome = faker.helpers.weightedArrayElement([
+        let outcome = faker.helpers.weightedArrayElement([
           { value: ScreenOutcome.NeedsTriage, weight: 2 },
           { value: ScreenOutcome.DelayVaccination, weight: 2 },
           { value: ScreenOutcome.DoNotVaccinate, weight: 1 },
-          // TODO: Account for consent only given for injected vaccine
           ...(patientSessionWithContext.programme.hasAlternativeVaccines
             ? [{ value: ScreenOutcome.VaccinateNasal, weight: 7 }]
             : [{ value: ScreenOutcome.Vaccinate, weight: 7 }])
         ])
+
+        // Account for cases where consent given for injected vaccine only
+        if (patientSessionWithContext.hasConsentForInjectionOnly) {
+          outcome = ScreenOutcome.VaccinateInjection
+        }
 
         let note = response.triageNote
 


### PR DESCRIPTION
This PR makes a number of changes and improvements prior to the next round of research with nurses and prescribers.

- Updates some content and labelling around delegation
- Removes ‘Other’ as an injection method on the page you reach after selecting ‘Other’
- Correctly calculates the determined vaccine method for a patient session (in turn returning the correct patients who need a PSD)
- Reduces the number of generated consent responses that give consent only for the injected flu vaccine

It also adds the following improvements.

## Allow editing vaccine, injection site and method

For programmes that can administer multiple vaccines that use different methods, it may be necessary to change or edit:

- the vaccine
- the injection method (if the vaccine is an injectable)
- the injection site (if the vaccine is an injectable)

If the vaccine is a nasal spray, the method and site cannot be edited as these have fixed values of ‘Nasal spray’ and ‘Nose’ respectively.

### Recording a vaccination with an injected vaccine

When recording an injection, you are asked to pick from the 2 common injection sites, or you can select ‘Other’:

![Screenshot of pre-screening form on patient session page.](https://github.com/user-attachments/assets/203743ea-dbea-40e7-932b-604f995c183e)

Selecting ‘Other’ allows you to record a different injection method and site: 

![Screenshot of form to choose another method and site option.](https://github.com/user-attachments/assets/6086d3cb-ea2b-4eef-9a96-869e1a113bb7)

You edit these values separately when checking and confirming a new vaccination, or editing an existing vaccination:

![Screenshot of check and confirm page for an injected vaccine.](https://github.com/user-attachments/assets/0f5e89e2-4154-4329-b660-69af2c0139a2)

![Screenshot of vaccination method form for an injected vaccine.](https://github.com/user-attachments/assets/cfd91ce3-95a5-4686-a945-522e0dc1674c)

![Screenshot of vaccination site form for an injected vaccine.](https://github.com/user-attachments/assets/5d90f828-9312-4986-a91f-e86619cba5b2)

For an injected vaccines, we ask for the dosage amount in ml:

![Screenshot of dosage form for an injected vaccine.](https://github.com/user-attachments/assets/b29e9be6-3bde-46ab-af59-b887afcc6a57)

### Recording a vaccination with a nasal spray

For a nasal spray, you cannot edit the method or site:

![Screenshot of check and confirm page for a nasal spray.](https://github.com/user-attachments/assets/b130f1db-fb6d-4da5-af4c-60f9449b86b5)

For dosage, you can only select full or half dose (one nostril or both):

![Screenshot of dosage form for a nasal spray.](https://github.com/user-attachments/assets/f0afb9f5-c871-4894-9e27-d6b1154cffe5)

### Changing from an injected vaccine to a nasal spray

If a programme has multiple vaccines, you can select a different vaccine:

![Screenshot of vaccine form.](https://github.com/user-attachments/assets/31805862-e271-441a-86bf-13afcb757c1d)

- If you change from injected to nasal spray, the method and site values are changed to ‘Nasal spray’ and ‘Nose’ 
- If you change from a nasal spray to an injected vaccine, the method value is changed to ‘Intramuscular (IM) injection’, and a site value needs to be added:

![Screenshot of check and confirm page for when need to record an injection site.](https://github.com/user-attachments/assets/d3b26715-21be-4eff-af54-66528425c625)

## Allow recording of a vaccination with injected vaccine instead of nasal flu spray

If:

- the parent(s) have given consent for the injected vaccine as an alternative
- AND there is not a triage outcome that stipulates a nasal spray should be administered
- AND the vaccinator has permission to administer an injected vaccine

show the option to record an injected vaccine instead. Selecting this option presents the vaccinator with common site options, with ‘Other’ taking them to a screen to change the injection method and anatomical site:

![Screenshot of a patient session with the ability to record an alternative vaccine.](https://github.com/user-attachments/assets/7cd58123-4ba1-4a5d-8b2d-46f42bee694b)

## Show vaccination method on confirmation email

Finally, a parent facing change. If a programme uses multiple vaccines with different methods, show the vaccine’s method in the confirmation email:

![Screenshot of vaccination confirmation email showing vaccine method.](https://github.com/user-attachments/assets/4f531615-f08d-45e7-9f17-fea1ce3501b0) 