### PR TITLE
Post user research updates for managing and recording (flu) sessions 

### DIFF
--- a/app/assets/stylesheets/components/_vaccine-method.scss
+++ b/app/assets/stylesheets/components/_vaccine-method.scss
@@ -20,7 +20,7 @@
   }
 
   &[data-method="Nasal spray"]::before {
-    border: $nhsuk-border-width solid currentcolor;
+    border: 0.25em solid currentcolor;
     border-radius: 100%;
     height: 1em;
     width: 1em;

--- a/app/assets/stylesheets/vendor/nhsuk-frontend/components/_index.scss
+++ b/app/assets/stylesheets/vendor/nhsuk-frontend/components/_index.scss
@@ -1,3 +1,4 @@
+@forward "nhsuk-frontend/packages/components/action-link";
 @forward "nhsuk-frontend/packages/components/back-link";
 @forward "nhsuk-frontend/packages/components/breadcrumb";
 @forward "nhsuk-frontend/packages/components/button";
@@ -25,7 +26,6 @@
 @forward "nhsuk-frontend/packages/components/warning-callout";
 
 // Ignored components
-// - action-link
 // - character-count
 // - contents-list
 // - do-dont-list

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -172,18 +172,18 @@ export const patientSessionController = {
 
     // Use different values for pre-screening questions
     // `IsWell` and `IsPregnant` should persist per patient
-    response.locals.preScreenQuestionItems = Object.entries(
-      vaccine.preScreenQuestions
-    ).map(([key, text]) => {
-      let value = `${programme.id}-${key}`
-      if (text === PreScreenQuestion.IsWell) {
-        value = `${nhsn}-is-well`
-      } else if (text === PreScreenQuestion.IsPregnant) {
-        value = `${nhsn}-is-pregnant`
-      }
+    response.locals.preScreenQuestionItems =
+      vaccine &&
+      Object.entries(vaccine.preScreenQuestions).map(([key, text]) => {
+        let value = `${programme.id}-${key}`
+        if (text === PreScreenQuestion.IsWell) {
+          value = `${nhsn}-is-well`
+        } else if (text === PreScreenQuestion.IsPregnant) {
+          value = `${nhsn}-is-pregnant`
+        }
 
-      return { text, value }
-    })
+        return { text, value }
+      })
 
     next()
   },

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -517,7 +517,7 @@ export const sessionController = {
       patientSession.update(patientSession, data)
     }
 
-    request.flash('success', __(`session.instructions.success`, { session }))
+    request.flash('success', __(`session.instructions.success`))
 
     response.redirect(`${session.uri}/instruct`)
   },

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -111,6 +111,7 @@ export const sessionController = {
       programme_id,
       q,
       vaccineMethod,
+      instruct,
       yearGroup
     } = request.query
     const { data } = request.session
@@ -150,6 +151,13 @@ export const sessionController = {
     if (vaccineMethod && vaccineMethod !== 'none') {
       results = results.filter(
         (patientSession) => patientSession.vaccine?.method === vaccineMethod
+      )
+    }
+
+    // Filter by instruction outcome
+    if (instruct && instruct !== 'none') {
+      results = results.filter(
+        (patientSession) => patientSession.instruct === instruct
       )
     }
 
@@ -239,10 +247,11 @@ export const sessionController = {
       }))
     }
 
-    // Vaccination method filter options (if session administering alternative)
+    // Vaccination method and instruction outcome filter options
+    // (if session administering alternative)
     if (
       session.offersAlternativeVaccine &&
-      ['register', 'record', 'report'].includes(view)
+      ['register', 'record', 'outcome'].includes(view)
     ) {
       response.locals.vaccineMethodItems = [
         {
@@ -254,6 +263,19 @@ export const sessionController = {
           text: value,
           value,
           checked: vaccineMethod === value
+        }))
+      ]
+
+      response.locals.instructItems = [
+        {
+          text: 'Any',
+          value: 'none',
+          checked: !instruct || instruct === 'none'
+        },
+        ...Object.values(InstructionOutcome).map((value) => ({
+          text: value,
+          value,
+          checked: instruct === value
         }))
       ]
     }

--- a/app/generators/session.js
+++ b/app/generators/session.js
@@ -2,6 +2,7 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 import { isAfter } from 'date-fns'
 
 import {
+  OrganisationDefaults,
   ProgrammePreset,
   ProgrammeType,
   SessionStatus,
@@ -46,6 +47,7 @@ export function generateSession(programmePreset, user, options) {
 
   const dates = []
   let firstSessionDate
+  let openAt
   const tomorrow = addDays(today(), 1)
   switch (status) {
     case SessionStatus.Planned:
@@ -95,6 +97,11 @@ export function generateSession(programmePreset, user, options) {
         dates.push(subsequentDate)
       }
     }
+
+    openAt = removeDays(
+      firstSessionDate,
+      OrganisationDefaults.SessionOpenWeeks * 7
+    )
   }
 
   const sessionHasCatchups = faker.datatype.boolean(0.5)
@@ -105,6 +112,7 @@ export function generateSession(programmePreset, user, options) {
     createdAt: removeDays(term.from, 60),
     createdBy_uid: user.uid,
     dates,
+    openAt,
     registration: true,
     programmePreset,
     psdProtocol,

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1584,7 +1584,9 @@ export const en = {
     },
     instruct: {
       label: 'PSDs',
-      title: 'Review PSDs'
+      title: 'Review PSDs',
+      description:
+        'There are %s children with consent for the nasal flu vaccine who do not require triage and do not yet have a PSD in place.'
     },
     register: {
       label: 'Register',
@@ -1687,10 +1689,11 @@ export const en = {
     },
     instructions: {
       label: 'Add new PSDs',
-      title: 'Add new PSDs',
-      description:
-        'There are %s children with consent for the nasal flu vaccine who do not require triage and do not yet have a PSD in place.\n\nYou can add a PSD instruction for these children now.',
-      success: '{{session.patientsToInstruct.length}} PSDs added'
+      title: 'Are you sure you want to add %s new PSDs?',
+      description: 'This operation cannot be undone.',
+      confirm: 'Yes, add PSDs',
+      cancel: 'No, return to session',
+      success: 'PSDs added'
     },
     reminders: {
       label: 'Send reminders',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1072,7 +1072,7 @@ export const en = {
       title: 'Child record'
     },
     events: {
-      title: 'Session activity and notes',
+      title: 'Notes and session activity',
       count: {
         one: '%s event',
         other: '[0] No events|%s events'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -540,7 +540,7 @@ export const en = {
     alternative: {
       title:
         'If your child cannot have the nasal spray, do you agree to them having the injected vaccine instead?',
-      label: 'Consent given for injected vaccine',
+      label: 'Consent given for injected vaccine?',
       hint: 'We may decide the nasal spray vaccine is not suitable. In this case, we may offer the injected vaccine instead.'
     },
     consultation: {
@@ -1449,7 +1449,7 @@ export const en = {
       label: 'Decision'
     },
     alternative: {
-      label: 'Consent given for injected vaccine',
+      label: 'Consent given for injected vaccine?',
       title:
         'Do they also agree to the injected vaccine if the nasal spray is not suitable?',
       hint: 'For example, if the child is heavily congested on the day of the vaccination'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1209,6 +1209,11 @@ export const en = {
         label: 'Pre-screening notes'
       }
     },
+    record: {
+      title: 'Record {{session.programmeNames.sentenceCase}} vaccination',
+      titleWithMethod:
+        'Record {{session.programmeNames.sentenceCase}} vaccination with {{method}}'
+    },
     vaccination: {
       title: 'Record as already vaccinated'
     },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -103,7 +103,7 @@ export const en = {
     },
     action: {
       title: 'Are you sure you want to %s this batch?',
-      description: 'This operation cannot be undone.',
+      description: 'This cannot be undone.',
       cancel: 'No, return to vaccines',
       confirm: 'Yes, %s this batch'
     },
@@ -169,7 +169,7 @@ export const en = {
     },
     action: {
       title: 'Are you sure you want to %s this clinic?',
-      description: 'This operation cannot be undone.',
+      description: 'This cannot be undone.',
       confirm: 'Yes, %s this clinic',
       cancel: 'No, return to clinics'
     },
@@ -362,7 +362,7 @@ export const en = {
       caption: 'Consent response from {{consent.fullName}}',
       title: 'Archive response',
       description:
-        'The unmatched response will be hidden. This operation cannot be undone.',
+        'The unmatched response will be hidden. This cannot be undone.',
       confirm: 'Archive response',
       success: 'Consent response from {{consent.fullName}} archived'
     },
@@ -789,7 +789,7 @@ export const en = {
     },
     action: {
       title: 'Are you sure you want to %s the notice on this patient?',
-      description: 'This operation cannot be undone.',
+      description: 'This cannot be undone.',
       confirm: 'Yes, %s this notice',
       cancel: 'No, return to notices'
     }
@@ -1377,7 +1377,7 @@ export const en = {
       label: 'Mark as invalid',
       caption: 'Consent response from {{reply.fullName}}',
       title: 'Mark response as invalid',
-      description: 'This operation cannot be undone.',
+      description: 'This cannot be undone.',
       confirm: 'Mark response as invalid',
       success: 'Consent response from {{reply.fullName}} marked as invalid'
     },
@@ -1690,7 +1690,7 @@ export const en = {
     instructions: {
       label: 'Add new PSDs',
       title: 'Are you sure you want to add %s new PSDs?',
-      description: 'This operation cannot be undone.',
+      description: 'This cannot be undone.',
       confirm: 'Yes, add PSDs',
       cancel: 'No, return to session',
       success: 'PSDs added'
@@ -2045,7 +2045,7 @@ export const en = {
     },
     action: {
       title: 'Are you sure you want to %s?',
-      description: 'This operation cannot be undone.',
+      description: 'This cannot be undone.',
       cancel: 'No, return to import',
       confirm: 'Yes, %s'
     },
@@ -2488,7 +2488,7 @@ export const en = {
     },
     action: {
       title: 'Are you sure you want to %s this vaccine?',
-      description: 'This operation cannot be undone.',
+      description: 'This cannot be undone.',
       confirm: 'Yes, %s this vaccine',
       cancel: 'No, return to vaccine'
     },

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -539,12 +539,7 @@ export class PatientSession {
       this.consent === ConsentOutcome.Given &&
       this.programme.alternativeVaccine
     ) {
-      if (this.hasConsentForInjectionOnly) {
-        consent = 'Injection'
-      } else {
-        consent = 'Nasal spray'
-        consent += this.hasConsentForInjection ? ' (or injection)' : ''
-      }
+      consent = this.vaccine?.method
     }
 
     return {

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -343,18 +343,13 @@ export class Reply {
       decisionStatus = formatTagWithSecondaryText(this.status, 'Invalid')
     } else if (this.confirmed) {
       decisionStatus = formatTagWithSecondaryText(this.status, 'Confirmed')
-    } else if (this.programme?.type === ProgrammeType.Flu) {
-      if (this.decision === ReplyDecision.OnlyFluInjection) {
-        decisionStatus = formatTagWithSecondaryText(
-          this.status,
-          VaccineMethod.Injection
-        )
-      } else if (this.decision === ReplyDecision.Given) {
-        const description = this.alternative
-          ? `${VaccineMethod.Nasal} (or injection)`
+    } else if (this.programme.alternativeVaccine) {
+      const vaccineMethod =
+        this.decision === ReplyDecision.OnlyFluInjection
+          ? VaccineMethod.Injection
           : VaccineMethod.Nasal
-        decisionStatus = formatTagWithSecondaryText(this.status, description)
-      }
+
+      decisionStatus = formatTagWithSecondaryText(this.status, vaccineMethod)
     }
 
     return {

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -7,14 +7,14 @@ import {
   Activity,
   ConsentOutcome,
   ConsentWindow,
+  InstructionOutcome,
   OrganisationDefaults,
   PatientOutcome,
   ProgrammePreset,
   RegistrationOutcome,
   SessionStatus,
   SessionType,
-  TriageOutcome,
-  VaccineMethod
+  TriageOutcome
 } from '../enums.js'
 import {
   removeDays,
@@ -449,9 +449,9 @@ export class Session {
    * @returns {Array<PatientSession>} - Patient sessions
    */
   get patientsToInstruct() {
-    const patientSessions = this.patientSessions
-      .filter(({ vaccine }) => vaccine?.method === VaccineMethod.Nasal)
-      .filter(({ nextActivity }) => nextActivity === Activity.Record)
+    const patientSessions = this.patientSessions.filter(
+      ({ instruct }) => instruct === InstructionOutcome.Needed
+    )
     return _.uniqBy(patientSessions, 'patient.nhsn')
   }
 

--- a/app/views/_macros/heading.njk
+++ b/app/views/_macros/heading.njk
@@ -1,7 +1,8 @@
+{%- from "macros/attributes.njk" import nhsukAttributes -%}
 {% macro heading(params) -%}
 {%- set level = params.level or 1 -%}
 {%- set size = params.size or "l" -%}
-<h{{level}} class="nhsuk-heading-{{ size }}{%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.summary %} nhsuk-u-margin-bottom-2{% endif %}">
+<h{{level}} class="nhsuk-heading-{{ size }}{%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.summary %} nhsuk-u-margin-bottom-2{% endif %}" {{- nhsukAttributes(params.attributes) }}>
   {%- if params.caption -%}
   <span class="nhsuk-caption-{{ size }}">{{ params.caption }}</span>
   {%- endif -%}

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -61,6 +61,18 @@
       items: vaccineMethodItems
     }) if vaccineMethodItems }}
 
+    {{ radios({
+      fieldset: {
+        legend: {
+          classes: "nhsuk-fieldset__legend--s",
+          text: __("patientSession.instruct.label")
+        }
+      },
+      id: "instruct",
+      name: "instruct",
+      items: instructItems
+    }) if instructItems }}
+
     {{ checkboxes({
       fieldset: {
         legend: {

--- a/app/views/batch/action.njk
+++ b/app/views/batch/action.njk
@@ -4,7 +4,7 @@
 
 {% block form %}
   {{ heading({
-    caption: vaccine.brand + ", " + batch.id,
+    caption: batch.vaccine.brand + ", " + batch.id,
     title: title
   }) }}
 

--- a/app/views/patient-session/_consent.njk
+++ b/app/views/patient-session/_consent.njk
@@ -81,7 +81,8 @@
             tel: {},
             email: {},
             createdAt: {},
-            decisionStatus: {}
+            decisionStatus: {},
+            alternative: {}
           })
         })
       }) }}

--- a/app/views/patient-session/_record.njk
+++ b/app/views/patient-session/_record.njk
@@ -1,7 +1,20 @@
 {{ heading({
+  classes: "app-vaccine-method",
   level: 3,
   size: "m",
-  title: "Record vaccination"
+  title: __("patientSession.record.titleWithMethod", {
+    session: session,
+    method: patientSession.vaccine.method | lower
+  }),
+  attributes: {
+    "data-method": patientSession.vaccine.method
+  }
+} if patientSession.programme.alternativeVaccine else {
+  level: 3,
+  size: "m",
+  title: __("patientSession.record.title", {
+    session: session
+  })
 }) }}
 
 {% set preScreenDescriptionHtml %}

--- a/app/views/reply/show.njk
+++ b/app/views/reply/show.njk
@@ -36,6 +36,7 @@
           createdAt: {},
           method: {},
           decisionStatus: {},
+          alternative: {},
           refusalReason: {},
           refusalReasonDetails: {},
           note: {

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -81,11 +81,18 @@
           }) | safe
         }) }}
 
-        {{ button({
-          classes: "nhsuk-button--secondary",
-          text: __("session.instructions.label"),
-          href: session.uri + "/instructions"
-        }) if view == "instruct" and (data.token.role == UserRole.NursePrescriber or data.token.role == UserRole.Pharmacist) }}
+        {% set instructionsHtml %}
+          {{ __("session.instruct.description", session.patientsToInstruct.length) | nhsukMarkdown }}
+
+          {{ actionLink({
+            text: __("session.instructions.label"),
+            href: session.uri + "/instructions"
+          }) }}
+        {% endset %}
+
+        {{ insetText({
+          html: instructionsHtml
+        }) if view == "instruct" and (data.token.role == UserRole.NursePrescriber or data.token.role == UserRole.Pharmacist) and session.patientsToInstruct.length > 0 }}
 
         {% for patientSession in results.page %}
           {% set statusHtml %}

--- a/app/views/session/instructions.njk
+++ b/app/views/session/instructions.njk
@@ -1,6 +1,6 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("session.instructions.title") %}
+{% set title = __("session.instructions.title", session.patientsToInstruct.length) %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -23,4 +23,16 @@
   }) }}
 
   {{ __("session.instructions.description", session.patientsToInstruct.length) | nhsukMarkdown }}
+{% endblock %}
+
+{% block afterForm %}
+  {{ buttonGroup({
+    buttons: [{
+      text: __("session.instructions.confirm")
+    }],
+    links: [{
+      text: __("session.instructions.cancel"),
+      href: session.uri + "/instruct"
+    }]
+  }) }}
 {% endblock %}

--- a/app/views/vaccine/action.njk
+++ b/app/views/vaccine/action.njk
@@ -4,7 +4,7 @@
 
 {% block form %}
   {{ heading({
-    caption: vaccine.brandWithName,
+    caption: vaccine.brand,
     title: __("vaccine.action.title", type)
   }) }}
 


### PR DESCRIPTION
## Show simple consent status in lists, show alternative in detail

We now show a simpler consent status, showing only the vaccine method consented to when consent has been given.

If consent has been given for the nasal spray, on the patient session page and when showing the full consent response, we show a second summary row, ‘Consent given for injected vaccine’.

### Session activity list

![Screenshot of consent outcome on session activity list.](https://github.com/user-attachments/assets/9f167e5c-02d9-417b-a871-efb16e6647c0)

### Patient session

![Screenshot of consent decision on patient session.](https://github.com/user-attachments/assets/4532d61a-cf23-4d51-b679-46d983740edb)

### Nurse-facing consent response

![Screenshot of consent decision on nurse-facing consent response.](https://github.com/user-attachments/assets/7c05f76f-ef62-47c6-acc4-b3100f65255c)

## Show vaccine method name and icon on patient session record heading

![Screenshot of heading for recording vaccination with a nasal spray.](https://github.com/user-attachments/assets/df0a5fad-e8db-4140-9f34-fcd0195f2b8e)

![Screenshot of heading for recording vaccination with an injection.](https://github.com/user-attachments/assets/20cbfcd6-66aa-47a5-b6c5-62f5c2993e3e)

## Update flow for adding PSDs to use confirmation step

We now show the contextual message for adding PSDs to the session activity view, with the proceeding page acting as a confirmation screen.

![Screenshot of session activity view for PSDs.](https://github.com/user-attachments/assets/35cd9699-0e96-448d-97e2-9d28f526df06)

![Screenshot of PSD confirmation screen.](https://github.com/user-attachments/assets/ab72d8cc-6852-4cb7-b954-101750e1fd52)

## Relabel ‘Session activity and notes’ to ‘Notes and session activity’

![Screenshot of ‘Notes and session’ activity link.](https://github.com/user-attachments/assets/d1b57a3e-5479-41c0-9998-4d3d0020e29e)
