### PR TITLE
Calculate academic year in which a session takes place

### DIFF
--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -90,8 +90,8 @@ export const sessionController = {
 
     // Filter by programme
     if (programme_ids) {
-      results = results.filter(({ programme_ids }) =>
-        programme_ids.some((id) => programme_ids.includes(id))
+      results = results.filter((session) =>
+        session.programme_ids.some((id) => programme_ids.includes(id))
       )
     }
 

--- a/app/enums.js
+++ b/app/enums.js
@@ -3,8 +3,8 @@
  * @enum {string}
  */
 export const AcademicYear = {
-  Y2024: '2024/25',
-  Y2025: '2025/26'
+  Y2024: '2024 to 2025',
+  Y2025: '2025 to 2026'
 }
 
 /**
@@ -235,7 +235,7 @@ export const ProgrammePreset = {
     term: SchoolTerm.Autumn
   },
   HPV: {
-    active: false,
+    active: true,
     adolescent: true,
     primaryProgrammeTypes: [ProgrammeType.HPV],
     term: SchoolTerm.Spring

--- a/app/generators/session.js
+++ b/app/generators/session.js
@@ -1,16 +1,14 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
-import { isAfter } from 'date-fns'
 
 import {
   OrganisationDefaults,
   ProgrammePreset,
   ProgrammeType,
-  SessionStatus,
   SessionType
 } from '../enums.js'
 import { schoolTerms } from '../models/school.js'
 import { Session } from '../models/session.js'
-import { addDays, removeDays, setMidday, today } from '../utils/date.js'
+import { addDays, removeDays, setMidday } from '../utils/date.js'
 
 /**
  * Generate fake session
@@ -33,44 +31,17 @@ export function generateSession(programmePreset, user, options) {
 
   const { clinic_id, school_urn } = options
   const term = schoolTerms[preset.term]
-
-  let status
-  if (isAfter(today(), term.to)) {
-    status = SessionStatus.Completed
-  } else {
-    status = faker.helpers.arrayElement([
-      SessionStatus.Completed,
-      SessionStatus.Planned,
-      SessionStatus.Unplanned
-    ])
-  }
-
   const dates = []
-  let firstSessionDate
-  let openAt
-  const tomorrow = addDays(today(), 1)
-  switch (status) {
-    case SessionStatus.Planned:
-      // Earliest date is tomorrow
-      // Latest date is the last day of term
-      firstSessionDate = faker.date.between({
-        from: tomorrow,
-        to: term.to
-      })
-      break
-    case SessionStatus.Completed:
-      // Earliest date is first day of term
-      // Latest date is the last day of term
-      firstSessionDate = faker.date.between({
-        from: term.from,
-        to: term.to
-      })
-      break
-    case SessionStatus.Unplanned:
-    default:
-      firstSessionDate = undefined
-  }
+  const hasDatesScheduled = faker.datatype.boolean(0.5)
 
+  let firstSessionDate =
+    hasDatesScheduled &&
+    faker.date.between({
+      from: term.from,
+      to: term.to
+    })
+
+  let openAt
   if (firstSessionDate) {
     // Clinic sessions happen after the school term has finished
     if (clinic_id) {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1594,6 +1594,9 @@ export const en = {
     isClosed: {
       label: 'Closed'
     },
+    academicYear: {
+      label: 'Academic year'
+    },
     consent: {
       label: 'Consent',
       title: 'Review consent responses'

--- a/app/middleware/rollover.js
+++ b/app/middleware/rollover.js
@@ -1,0 +1,11 @@
+import { isBetweenDates, today } from '../utils/date.js'
+
+export const rollover = (request, response, next) => {
+  response.app.locals.isRollover = isBetweenDates(
+    today(),
+    '2025-07-01',
+    '2025-08-31'
+  )
+
+  next()
+}

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -9,8 +9,8 @@ import { Record } from './record.js'
 
 export const schoolTerms = {
   [SchoolTerm.Spring]: { from: '2025-01-06', to: '2025-04-11' },
-  [SchoolTerm.Summer]: { from: '2025-04-28', to: '2025-07-21' },
-  [SchoolTerm.Autumn]: { from: '2025-09-03', to: '2025-12-13' }
+  [SchoolTerm.Summer]: { from: '2025-04-28', to: '2025-07-20' },
+  [SchoolTerm.Autumn]: { from: '2025-09-01', to: '2025-12-19' }
 }
 
 /**

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -4,6 +4,7 @@ import { isAfter } from 'date-fns'
 import _ from 'lodash'
 
 import {
+  AcademicYear,
   Activity,
   ConsentOutcome,
   ConsentWindow,
@@ -222,6 +223,27 @@ export class Session {
     if (this.lastDate) {
       return removeDays(this.lastDate, 1)
     }
+  }
+
+  /**
+   * Get academic year
+   *
+   * @returns {AcademicYear} - Academic year
+   */
+  get academicYear() {
+    // For a scheduled session, infer the date from the first scheduled data
+    if (this.firstDate) {
+      const year = this.firstDate.getFullYear()
+      const month = this.firstDate.getMonth() + 1
+      const startYear = month >= 9 ? year : year - 1
+
+      return AcademicYear[`Y${startYear}`]
+    }
+
+    // Otherwise, return the latest academic year
+    const academicYears = Object.values(AcademicYear)
+
+    return academicYears.at(-1)
   }
 
   /**

--- a/app/routes.js
+++ b/app/routes.js
@@ -8,6 +8,7 @@ import { navigation } from './middleware/navigation.js'
 import { notification } from './middleware/notification.js'
 import { permission } from './middleware/permission.js'
 import { referrer } from './middleware/referrer.js'
+import { rollover } from './middleware/rollover.js'
 import { users } from './middleware/users.js'
 import { accountRoutes } from './routes/account.js'
 import { batchRoutes } from './routes/batch.js'
@@ -37,7 +38,7 @@ const router = express.Router({ strict: true })
 router.use(enumeration)
 router.use(environment)
 router.use(internationalisation)
-router.use(flash(), navigation, notification, users, permission)
+router.use(flash(), navigation, notification, rollover, users, permission)
 router.use(referrer)
 
 router.use('/', homeRoutes)

--- a/app/views/_macros/session-search.njk
+++ b/app/views/_macros/session-search.njk
@@ -37,6 +37,18 @@
       decorate: "q"
     }) }}
 
+    {{ radios({
+      fieldset: {
+        legend: {
+          classes: "nhsuk-fieldset__legend--s",
+          text: __("session.academicYear.label")
+        }
+      },
+      id: "academicYear",
+      name: "academicYear",
+      items: academicYearItems
+    }) if academicYearItems }}
+
     {{ checkboxes({
       fieldset: {
         legend: {

--- a/app/views/session/_navigation.njk
+++ b/app/views/session/_navigation.njk
@@ -5,7 +5,7 @@
 {% macro sessionNavigation(params) %}
   {{ heading({
     title: params.session.location.name,
-    summary: params.session.programmeNames.titleCase
+    summary: params.session.programmeNames.titleCase + " (" + session.academicYear + ")"
   }) }}
 
   {{ secondaryNavigation({

--- a/app/views/session/show.njk
+++ b/app/views/session/show.njk
@@ -2,7 +2,7 @@
 
 {% extends "_layouts/default.njk" %}
 
-{% set title = session.location.name %}
+{% set title = session.location.name + " (" + session.academicYear + ")" %}
 
 {% block beforeContent %}
   {{ breadcrumb({


### PR DESCRIPTION
Show a filter for academic year on the sessions view **only during rollover**, that is, while there are still sessions taking place for the current academic year, and sessions for the next academic year need to managed prior to 1 September:

![Screenshot of sessions page with academic year filter.](https://github.com/user-attachments/assets/a41818b4-dedf-472b-ac6a-f2afd7982b16)

Show a session’s academic year in it’s summary description below title:

![Screenshot of a session page.](https://github.com/user-attachments/assets/d2d8eb9c-c43c-4ca3-b624-0209678e59df)

