### PR TITLE
Stop trying to be clever with NHS numbers

### DIFF
--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -267,12 +267,19 @@ export function formatMillilitres(string) {
  * Format monospaced
  *
  * @param {string|number} string - String
+ * @param {boolean} [noWrap=false] - Prevent wrapping
  * @returns {string|undefined} Formatted HTML
  */
-export function formatMonospace(string) {
+export function formatMonospace(string, noWrap = false) {
   if (!string) return
 
-  return `<span class="app-u-monospace">${string}</span>`
+  const classes = ['app-u-monospace']
+
+  if (noWrap) {
+    classes.push('nhsuk-u-nowrap')
+  }
+
+  return `<span class="${classes.join(' ')}">${string}</span>`
 }
 
 /**
@@ -291,15 +298,13 @@ export function formatNhsNumber(string, invalid) {
   const isNhsNumber = string.match(/^\d{10}$/)
 
   if (isNhsNumber) {
-    string = string
-      .toString()
-      .replaceAll(/(\d{3})(\d{3})(\d{4})/g, '$1&nbsp;&zwj;$2&nbsp;&zwj;$3')
+    string = string.toString().replaceAll(/(\d{3})(\d{3})(\d{4})/g, '$1 $2 $3')
 
     if (invalid) {
       string = `<s>${string}</s>`
     }
 
-    return formatMonospace(string)
+    return formatMonospace(string, true)
   }
 
   return null

--- a/app/views/_layouts/default.njk
+++ b/app/views/_layouts/default.njk
@@ -22,6 +22,9 @@
 {% from "_macros/sub-navigation.njk" import subNavigation %}
 
 {% block head %}
+  {# Prevent NHS numbers from being treated as phone numbers #}
+  <meta name="format-detection" content="telephone=no">
+
   {% set assetsName = assetsName | default("application") %}
   <link rel="stylesheet" href="/assets/{{ assetsName }}.css" media="all">
   <script src="/assets/{{ assetsName }}.js" type="module"></script>


### PR DESCRIPTION
- Follow NHS [digital service manual guidance for showing NHS numbers](https://service-manual.nhs.uk/design-system/patterns/ask-for-nhs-numbers)
- Use `nhsuk-u-nowrap` class to prevent wrapping
- Disable phone number detection