### PR TITLE
Consistently use aqua-green colour for successful status outcomes

### DIFF
--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -195,7 +195,7 @@ export const getInstructionStatus = (patientSession) => {
   let colour
   switch (patientSession.instruct) {
     case InstructionOutcome.Given:
-      colour = 'blue'
+      colour = 'aqua-green'
       break
     default:
       colour = 'grey'
@@ -218,7 +218,7 @@ export const getRegistrationStatus = (patientSession) => {
   let description
   switch (patientSession.register) {
     case RegistrationOutcome.Present:
-      colour = 'blue'
+      colour = 'aqua-green'
       description = `Registered as attending today’s session at ${patientSession.session.location.name}`
       break
     case RegistrationOutcome.Absent:


### PR DESCRIPTION
We previously used a blue colour for the following statuses:

- a child has a PSD added
- a child has been registered as attending a session

This is different to other statuses which also indicate a child is ’good to go‘:

- a child has a consent given consent outcome
- a child has a safe to vaccinate triage outcome

This PR changes the status colour for registered and PSD added to use the same aqua green colour:

<img width="740" height="920" alt="Screenshot of patient session page with aqua green tags" src="https://github.com/user-attachments/assets/5f167129-7256-465d-8989-bc64aa2785da" />
  