### PR TITLE
Add option to display prominent session notes

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use "../vendor/nhsuk-frontend" as *;
 @use "../core" as app;
 
@@ -42,9 +43,24 @@
     }
   }
 
+  &--yellow {
+    background-color: color.mix($color_nhsuk-white, $color_nhsuk-warm-yellow, 80%);
+    border-color: $color_nhsuk-warm-yellow;
+
+    .nhsuk-card__heading--feature {
+      background-color: $color_nhsuk-warm-yellow;
+      color: $nhsuk-text-color;
+    }
+
+    blockquote {
+      border-color: $color_nhsuk-warm-yellow;
+    }
+  }
+
   &--green,
   &--grey,
-  &--red {
+  &--red,
+  &--yellow {
     .nhsuk-card__link,
     .nhsuk-card__link:hover {
       color: inherit;

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -1,5 +1,6 @@
 import {
   Activity,
+  AuditEventType,
   ConsentOutcome,
   ConsentWindow,
   InstructionOutcome,
@@ -20,6 +21,7 @@ import { PatientSession } from '../models/patient-session.js'
 import { Programme } from '../models/programme.js'
 import { Vaccination } from '../models/vaccination.js'
 import { today } from '../utils/date.js'
+import { stringToBoolean } from '../utils/string.js'
 
 export const patientSessionController = {
   read(request, response, next, nhsn) {
@@ -393,11 +395,14 @@ export const patientSessionController = {
   },
 
   note(request, response) {
-    const { note } = request.body
+    let { note, pinned } = request.body
     const { data } = request.session
     const { __, back, patientSession } = response.locals
 
+    pinned = stringToBoolean(pinned)
+
     patientSession.saveNote({
+      name: pinned ? AuditEventType.Pinned : AuditEventType.Note,
       note,
       createdBy_uid: data.token?.uid || '000123456789'
     })

--- a/app/enums.js
+++ b/app/enums.js
@@ -41,6 +41,7 @@ export const AuditEventType = {
   Decision: 'Decision',
   Note: 'Session note',
   Notice: 'Notice',
+  Pinned: 'Pinned session note',
   Reminder: 'Reminder'
 }
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -766,7 +766,13 @@ export const en = {
       label: 'Date'
     },
     note: {
-      label: 'Note'
+      label: 'Note',
+      hint: 'Notes are visible to all users, and cannot be edited or deleted'
+    },
+    pinned: {
+      label: 'Pinned',
+      title: 'Do you want to pin this note?',
+      hint: 'Pinned notes show at the top of session pages and on search results within a session'
     },
     outcome: {
       label: 'Outcome'
@@ -1114,7 +1120,7 @@ export const en = {
       title: 'Child record'
     },
     events: {
-      title: 'Notes and session activity',
+      title: 'Session notes and activity',
       count: {
         one: '%s event',
         other: '[0] No events|%s events'
@@ -1123,12 +1129,16 @@ export const en = {
     notes: {
       label: 'Notes',
       new: {
-        title: 'Add a note',
-        label: 'Note',
-        hint: 'Notes are visible to all users, and cannot be edited or deleted',
-        confirm: 'Save note',
-        success: 'Note added'
+        title: 'Add a session note',
+        confirm: 'Save session note',
+        success: 'Session note added'
       }
+    },
+    pinnedNotes: {
+      label: 'Session notes'
+    },
+    pinnedNote: {
+      label: 'Session note'
     },
     consent: {
       title: 'Consent for %s',

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -62,7 +62,7 @@ import { Session } from './session.js'
  * @property {string} [createdBy_uid] - User who created patient session
  * @property {Date} [updatedAt] - Updated date
  * @property {Gillick} [gillick] - Gillick assessment
- * @property {Array<AuditEvent>} [notes] - Session notes
+ * @property {Array<AuditEvent>} [notes] - Notes
  * @property {boolean} alternative - Administer alternative vaccine
  * @property {string} patient_uuid - Patient UUID
  * @property {string} instruction_uuid - Instruction UUID
@@ -161,15 +161,15 @@ export class PatientSession {
   }
 
   /**
-   * Get latest session note
+   * Get pinned session notes
    *
-   * @returns {import('./audit-event.js').AuditEvent} - Audit event
+   * @returns {Array<import('./audit-event.js').AuditEvent>} - Audit event
    */
-  get latestNote() {
+  get pinnedNotes() {
     return this.auditEvents
       .filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
+      .filter(({ name }) => name === AuditEventType.Pinned)
       .sort((a, b) => getDateValueDifference(b.createdAt, a.createdAt))
-      .find(({ type }) => type === AuditEventType.Note)
   }
 
   /**
@@ -832,14 +832,13 @@ export class PatientSession {
   }
 
   /**
-   * Save session note
+   * Save note
    *
    * @param {import('./audit-event.js').AuditEvent} event - Event
    */
   saveNote(event) {
     this.patient.addEvent({
-      type: AuditEventType.Note,
-      name: 'Note',
+      name: event.name,
       note: event.note,
       createdBy_uid: event.createdBy_uid,
       programme_ids: this.session.programme_ids

--- a/app/views/patient-session/_navigation.njk
+++ b/app/views/patient-session/_navigation.njk
@@ -1,4 +1,6 @@
+{% from "nhsuk/components/warning-callout/macro.njk" import warningCallout %}
 {% from "_macros/action-list.njk" import appActionList %}
+{% from "_macros/event.njk" import appEvent %}
 {% from "_macros/heading.njk" import appHeading %}
 {% from "_macros/secondary-navigation.njk" import appSecondaryNavigation %}
 

--- a/app/views/patient-session/_note.njk
+++ b/app/views/patient-session/_note.njk
@@ -1,13 +1,23 @@
 {% set cardDescriptionHtml %}
   {{ textarea({
     label: {
-      text: __("patientSession.notes.new.label")
+      text: __("event.note.label")
     },
     hint: {
-      text: __("patientSession.notes.new.hint")
+      text: __("event.note.hint")
     },
     rows: 5,
     decorate: "note"
+  }) }}
+
+  {{ radios({
+    classes: "nhsuk-radios--inline",
+    fieldset: {
+      legend: { text: __("event.pinned.title") }
+    },
+    hint: { text: __("event.pinned.hint") },
+    items: booleanItems,
+    decorate: "pinned"
   }) }}
 
   {{ button({

--- a/app/views/patient-session/_record.njk
+++ b/app/views/patient-session/_record.njk
@@ -166,6 +166,7 @@
   heading: __("patientSession.preScreen.label", {
     patient: patient
   }),
+  headingClasses: "nhsuk-heading-m",
   headingLevel: 4,
   descriptionHtml: preScreenDescriptionHtml
 }) }}

--- a/app/views/patient-session/events.njk
+++ b/app/views/patient-session/events.njk
@@ -47,6 +47,18 @@
 
   {% include "patient-session/_note.njk" %}
 
+  {% if patientSession.pinnedNotes.length %}
+    {% for auditEvent in patientSession.pinnedNotes %}
+      {{ card({
+        classes: "app-card--yellow",
+        heading: auditEvent.name,
+        headingLevel: 4,
+        feature: true,
+        descriptionHtml: appEvent({ auditEvent: auditEvent, showProgrammes: true })
+      }) }}
+    {% endfor %}
+  {% endif %}
+
   {% for group, auditEvents in patientSession.auditEventLog %}
     <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color nhsuk-u-font-weight-normal">{{ group }}</h3>
 
@@ -54,11 +66,8 @@
       {{ card({
         heading: auditEvent.name,
         headingLevel: 4,
-        descriptionHtml: appEvent({ auditEvent: auditEvent, showProgrammes: true }),
-        attributes: {
-          id: auditEvent.uuid
-        }
-      }) }}
+        descriptionHtml: appEvent({ auditEvent: auditEvent, showProgrammes: true })
+      }) if auditEvent.name != EventType.Pinned }}
     {% endfor %}
   {% endfor %}
 {% endblock %}

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -72,6 +72,16 @@
     </div>
 
     <div class="app-grid-column-patient-session">
+      {% for auditEvent in patientSession.pinnedNotes %}
+        {{ card({
+          classes: "nhsuk-u-margin-top-3 app-card--yellow",
+          heading: auditEvent.name,
+          headingLevel: 4,
+          feature: true,
+          descriptionHtml: appEvent({ auditEvent: auditEvent, showProgrammes: true })
+        }) }}
+      {% endfor %}
+
       {% include "patient-session/_consent.njk" %}
 
       {% if options.canTriage %}

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -149,14 +149,14 @@
                   href: (patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view) if view == "register" and patientSession.register != RegistrationOutcome.Pending
                 } if view != "record",
                 notes: {
-                  label: __("patientSession.notes.label"),
+                  label: __("patientSession.pinnedNote.label"),
                   value: appEvent({
-                    auditEvent: patientSession.latestNote,
+                    auditEvent: patientSession.pinnedNotes[0],
                     showProgrammes: false,
                     truncate: 300,
                     patientSession: patientSession
                   })
-                } if patientSession.latestNote
+                } if patientSession.pinnedNotes[0]
               })
             }) }}
 


### PR DESCRIPTION
Notes that can be added separate to any other activity are now called ‘Session notes’ and they can be optionally pinned.

## Adding new session note

- New option asks if the note should be pinned

<img width="1634" height="1136" alt="Screenshot of new session note form." src="https://github.com/user-attachments/assets/f9de585e-12d1-4b0a-b683-57221f7eeb9e" />

## Session notes and activity

- ‘Notes and session activity’ is renamed ‘Session notes and activity’
- Session notes now have the name ‘Session note’
- Pinned session notes now appear in their own section, at the top of the log, and have a yellow background

<img width="2400" height="6830" alt="Screenshot of session notes and activity." src="https://github.com/user-attachments/assets/5153eb1c-a71c-4261-8847-4b23536a349a" />

## Patient session with pinned session note(s)

- A patient session shows any notes above other cards in the patient session column
- A patient session can show multiple pinned notes
- These notes appear across all programmes in a session

<img width="2400" height="4596" alt="Screenshot of patient session with a pinned session note." src="https://github.com/user-attachments/assets/4e0570bc-02bb-4936-868b-f6b287987c5e" />

<img width="2400" height="5022" alt="Screenshot of a patient session with multiple pinned session notes." src="https://github.com/user-attachments/assets/721aba0c-3121-4860-9fa2-d928c6490d48" />

## Patient cards in session search results

- Only pinned notes now show in patient session cards, and only the latest pinned note is displayed

<img width="2400" height="4606" alt="Screenshot of a pinned session note on a patient card." src="https://github.com/user-attachments/assets/778e1bd2-6a51-47ca-956c-902582fbf697" />

