### PR TITLE
Update sync status behaviour and content to match product

### DIFF
--- a/app/datasets/programmes.js
+++ b/app/datasets/programmes.js
@@ -18,7 +18,8 @@ export default {
       hint: 'with information available in different languages and alternative formats, including BSL and Braille'
     },
     yearGroups: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-    vaccine_smomeds: ['43208811000001106', '40085011000001101']
+    vaccine_smomeds: ['43208811000001106', '40085011000001101'],
+    nhseSyncable: true
   },
   [ProgrammeType.HPV]: {
     type: ProgrammeType.HPV,
@@ -40,7 +41,8 @@ export default {
     sequenceDefault: '1P',
     yearGroups: [8],
     catchupYearGroups: [9, 10, 11],
-    vaccine_smomeds: ['33493111000001108']
+    vaccine_smomeds: ['33493111000001108'],
+    nhseSyncable: true
   },
   [ProgrammeType.TdIPV]: {
     type: ProgrammeType.TdIPV,
@@ -62,7 +64,8 @@ export default {
     sequenceDefault: '2B',
     yearGroups: [9],
     catchupYearGroups: [10, 11],
-    vaccine_smomeds: ['7374311000001101']
+    vaccine_smomeds: ['7374311000001101'],
+    nhseSyncable: false
   },
   [ProgrammeType.MenACWY]: {
     type: ProgrammeType.MenACWY,
@@ -82,6 +85,7 @@ export default {
     },
     yearGroups: [9],
     catchupYearGroups: [10, 11],
-    vaccine_smomeds: ['39779611000001104']
+    vaccine_smomeds: ['39779611000001104'],
+    nhseSyncable: false
   }
 }

--- a/app/enums.js
+++ b/app/enums.js
@@ -458,6 +458,7 @@ export const VaccinationProtocol = {
  * @enum {string}
  */
 export const VaccinationSyncStatus = {
+  CannotSync: 'Cannot sync',
   NotSynced: 'Not synced',
   Pending: 'Pending',
   Synced: 'Synced',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2310,7 +2310,7 @@ export const en = {
       hint: 'For example, 13 15'
     },
     syncStatus: {
-      label: 'Sync with NHS England'
+      label: 'Synced with NHS England?'
     },
     createdBy: {
       label: 'Vaccinator',

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -248,6 +248,16 @@ export class Programme {
   }
 
   /**
+   * Get whether vaccination records for this programme are syncable
+   * with the NHS England immunisation API
+   *
+   * @returns {boolean} - Whether vaccination records for programme are syncable
+   */
+  get nhseSyncable() {
+    return programmes[this.type].nhseSyncable
+  }
+
+  /**
    * Read all
    *
    * @param {object} context - Context


### PR DESCRIPTION
To match the changes and agreed content in:
https://github.com/nhsuk/manage-vaccinations-in-schools/pull/4056

- Added cannot sync status
- Used cannot sync for no NHS number and programme not syncable
- Merge two functions to allow different text for different statuses and avoid repeating logic
- Pre-calculate syncStatus in formatted function to avoid running twice for different fields