### PR TITLE
Ask user if want to send parent confirmation of their refusal when getting verbal consent

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -95,7 +95,7 @@ export const patientSessionController = {
         !session.isActive &&
         consent === ConsentOutcome.NoResponse,
       // Get verbal consent
-      canRespond: session.consentWindow === ConsentWindow.Open && !consentGiven,
+      canRespond: !consentGiven,
       // Perform Gillick assessment
       canGillick:
         programme.type !== ProgrammeType.Flu &&

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -200,6 +200,10 @@ export const replyController = {
               ReplyRefusal.Medical
             ]
           },
+          [`/${reply_uuid}/${type}/refusal-notification`]: {
+            data: 'reply.refusalReason',
+            value: ReplyRefusal.Personal
+          },
           [`/${reply_uuid}/${type}/check-answers`]: true
         },
         [`/${reply_uuid}/${type}/refusal-reason-details`]: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1409,11 +1409,16 @@ export const en = {
       label: 'Child'
     },
     parent: {
+      label: 'Parent',
       title: {
         new: 'Details for parent or guardian',
         edit: 'Details for {{parent.formatted.fullNameAndRelationship}}'
       },
-      label: 'Parent'
+      notify: {
+        title:
+          'Do you want to send {{parent.formatted.fullName}} an email and text message confirming their decision?',
+        label: 'Notify parent'
+      }
     },
     programme: {
       label: 'Programme',

--- a/app/views/patient-session/_consent.njk
+++ b/app/views/patient-session/_consent.njk
@@ -11,7 +11,7 @@
   {% if not isVaccinated %}
     {% if session.consentWindow == ConsentWindow.Opening %}
       {{ session.formatted.consentWindow | nhsukMarkdown }}
-    {% elif session.consentWindow == ConsentWindow.Open %}
+    {% elif session.consentWindow != ConsentWindow.Open %}
       {{ patientSession.status.consent.description | nhsukMarkdown }}
     {% endif %}
 

--- a/app/views/reply/form/refusal-notification.njk
+++ b/app/views/reply/form/refusal-notification.njk
@@ -1,0 +1,19 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("reply.parent.notify.title", { parent: reply.parent }) %}
+
+{% block form %}
+  {{ radios({
+    fieldset: {
+      legend: {
+        html: appHeading({
+          classes: "nhsuk-fieldset__legend--l",
+          caption: patient.fullName,
+          title: title
+        })
+      }
+    },
+    items: booleanItems,
+    decorate: "reply.parent.notify"
+  }) }}
+{% endblock %}


### PR DESCRIPTION
Shown when getting a verbal consent response from a parent and they have:

- refused consent
- given a refusal reason of ‘Personal choice’

<img width="740" height="405" alt="Screenshot of question." src="https://github.com/user-attachments/assets/1d0b3823-615f-4eac-afec-8de6ccacc5eb" />
