### PR TITLE
Add option to review previously archived record on import

### DIFF
--- a/app/controllers/review.js
+++ b/app/controllers/review.js
@@ -46,7 +46,9 @@ export const reviewController = {
   },
 
   show(request, response) {
-    response.render('review/show')
+    const view = request.params.view || 'show'
+
+    response.render(`review/${view}`)
   },
 
   list(request, response) {
@@ -59,7 +61,12 @@ export const reviewController = {
 
     // Doesn’t change any values, but shows a confirmation message
     if (decision === 'duplicate') {
-      request.flash('success', __('upload.review.success'))
+      request.flash('success', __('review.duplicate.success'))
+    }
+
+    // Doesn’t change any values, but shows a confirmation message
+    if (decision === 'restore') {
+      request.flash('success', __('review.archived.success'))
     }
 
     response.redirect(back)

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -994,7 +994,7 @@ export const en = {
       post16: 'Children over 16 years old'
     },
     archiveReason: {
-      label: 'Reason for archival'
+      label: 'Reason archived'
     },
     archiveReasonOther: {
       label: 'Give details'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1504,6 +1504,50 @@ export const en = {
       label: 'Confirm consent refusal?'
     }
   },
+  review: {
+    label: 'Issue to review',
+    title: 'This record needs reviewing',
+    archived: {
+      label: 'Archived record',
+      title: 'Do you want to restore this previously archived record?',
+      hint: 'This record was previously archived because: %s',
+      description: 'Record was previously archived',
+      confirm: 'Resolve archived record',
+      success: 'Previously archived record restored'
+    },
+    duplicate: {
+      label: 'Duplicate record',
+      title: 'Review duplicate child record',
+      description:
+        'A field in a duplicate record does not match an existing child record',
+      record: 'Duplicate child record',
+      vaccination: 'Duplicate vaccination record',
+      confirm: 'Resolve duplicate record',
+      success: 'Record updated with values from duplicate record'
+    },
+    original: {
+      label: 'Existing record',
+      record: 'Existing child record',
+      vaccination: 'Existing vaccination record'
+    },
+    decision: {
+      label: 'Which record do you want to keep?',
+      duplicate: {
+        label: 'Use duplicate record',
+        hint: 'The duplicate record will replace the existing child record.'
+      },
+      original: {
+        label: 'Keep previously imported record',
+        hint: 'The existing record will be kept and the duplicate record will be discarded.'
+      },
+      restore: {
+        label: 'Yes, restore this record'
+      },
+      ignore: {
+        label: 'No, keep this record archived'
+      }
+    }
+  },
   school: {
     list: {
       title: 'Schools',
@@ -2092,37 +2136,6 @@ export const en = {
       label: 'Import records',
       success: 'Records imported for processing'
     },
-    review: {
-      title: 'Review duplicate child record',
-      duplicate: {
-        label: 'Duplicate record',
-        record: 'Duplicate child record',
-        vaccination: 'Duplicate vaccination record'
-      },
-      original: {
-        label: 'Existing record',
-        record: 'Existing child record',
-        vaccination: 'Existing vaccination record'
-      },
-      decision: {
-        label: 'Which record do you want to keep?',
-        duplicate: {
-          label: 'Use duplicate record',
-          hint: 'The duplicate record will replace the existing child record.'
-        },
-        original: {
-          label: 'Keep previously imported record',
-          hint: 'The existing record will be kept and the duplicate record will be discarded.'
-        }
-      },
-      confirm: 'Resolve duplicate',
-      success: 'Record updated with values from duplicate record',
-      issue: {
-        label: 'Issue to review',
-        title: 'This record needs reviewing',
-        text: 'A field in a duplicate record does not match an existing child record'
-      }
-    },
     file: {
       title: 'Import {{type}}',
       label: 'Upload file',
@@ -2221,11 +2234,6 @@ export const en = {
         one: '%s record imported',
         other: '[0] No records imported|%s records imported'
       }
-    },
-    issue: {
-      label: 'Issue to review',
-      title: 'This record needs reviewing',
-      text: 'A field in a duplicate record does not match that in a previously imported record'
     }
   },
   manual: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1506,7 +1506,6 @@ export const en = {
   },
   review: {
     label: 'Issue to review',
-    title: 'This record needs reviewing',
     archived: {
       label: 'Archived record',
       title: 'Do you want to restore this previously archived record?',

--- a/app/routes/review.js
+++ b/app/routes/review.js
@@ -8,7 +8,9 @@ router.get('/', review.readAll, review.list)
 
 router.param('upload_id', review.read)
 
-router.get('/:upload_id/:nhsn', review.show)
+router.get('/:upload_id/:nhsn{/:view}', review.show)
 router.post('/:upload_id/:nhsn', review.update)
+
+router.post('/:upload_id/:nhsn/archived', review.update)
 
 export const reviewRoutes = router

--- a/app/views/review/archived.njk
+++ b/app/views/review/archived.njk
@@ -1,0 +1,28 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("review.archived.title") %}
+{% set confirmButtonText = __("review.archived.confirm") %}
+
+{% block form %}
+  {{ radios({
+    fieldset: {
+      legend: {
+        html: appHeading({
+          caption: patient.fullName,
+          title: title
+        })
+      }
+    },
+    hint: {
+      text: __("review.archived.hint", ArchiveRecordReason.Error)
+    },
+    items: [{
+      text: __("review.decision.restore.label"),
+      value: "restore"
+    }, {
+      text: __("review.decision.ignore.label"),
+      value: "ignore"
+    }],
+    decorate: "decision"
+  }) }}
+{% endblock %}

--- a/app/views/review/list.njk
+++ b/app/views/review/list.njk
@@ -21,8 +21,8 @@
             html: patient.fullName or "Not provided"
           },
           {
-            header: __("upload.issue.label"),
-            html: __("upload.issue.text")
+            header: __("review.label"),
+            html: __("review.duplicate.description")
           },
           {
             header: __("actions.label"),
@@ -44,7 +44,7 @@
       responsive: true,
       head: [
         { text: __("patient.label") },
-        { text: __("upload.issue.label") },
+        { text: __("review.label") },
         { text: __("actions.label") }
       ],
       rows: reviewRows

--- a/app/views/review/show.njk
+++ b/app/views/review/show.njk
@@ -10,12 +10,6 @@
     title: title
   }) }}
 
-  {{ warningCallout({
-    heading: __("review.title"),
-    headingLevel: 2,
-    text: __("review.duplicate.description")
-  }) }}
-
   <div class="nhsuk-grid-row nhsuk-card-group">
     <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
       {% set descriptionHtml %}

--- a/app/views/review/show.njk
+++ b/app/views/review/show.njk
@@ -1,21 +1,19 @@
 {% extends "_layouts/form.njk" %}
 
 {% set gridColumns = "full" %}
-{% set title = __("upload.review.title") %}
-{% set confirmButtonText = __("upload.review.confirm") %}
+{% set title = __("review.duplicate.title") %}
+{% set confirmButtonText = __("review.duplicate.confirm") %}
 
 {% block form %}
-  {{ super() }}
-
   {{ appHeading({
     caption: patient.fullName,
     title: title
   }) }}
 
   {{ warningCallout({
-    heading: __("upload.issue.title"),
+    heading: __("review.title"),
     headingLevel: 2,
-    text: __("upload.issue.text")
+    text: __("review.duplicate.description")
   }) }}
 
   <div class="nhsuk-grid-row nhsuk-card-group">
@@ -35,7 +33,7 @@
         }) }}
 
         {% if duplicatePatient.vaccinations[0] %}
-          <h3 class="nhsuk-heading-s">{{ __("upload.review.duplicate.vaccination") }}</h3>
+          <h3 class="nhsuk-heading-s">{{ __("review.duplicate.vaccination") }}</h3>
           {{ summaryList({
             rows: summaryRows(duplicatePatient.vaccinations[0], {
               outcome: {},
@@ -59,7 +57,7 @@
 
       {{ card({
         feature: true,
-        heading: __("upload.review.duplicate.label"),
+        heading: __("review.duplicate.label"),
         headingClasses: "nhsuk-heading-m",
         descriptionHtml: descriptionHtml
       }) }}
@@ -78,7 +76,7 @@
         }) }}
 
         {% if patient.vaccinations[0] %}
-          <h3 class="nhsuk-heading-s">{{ __("upload.review.original.vaccination") }}</h3>
+          <h3 class="nhsuk-heading-s">{{ __("review.original.vaccination") }}</h3>
           {{ summaryList({
             rows: summaryRows(patient.vaccinations[0], {
               outcome: {},
@@ -100,7 +98,7 @@
 
       {{ card({
         feature: true,
-        heading: __("upload.review.original.label"),
+        heading: __("review.original.label"),
         headingClasses: "nhsuk-heading-m",
         descriptionHtml: descriptionHtml
       }) }}
@@ -114,16 +112,16 @@
     fieldset: {
       legend: {
         classes: "nhsuk-fieldset__legend--m",
-        text: __("upload.review.decision.label")
+        text: __("review.decision.label")
       }
     },
     items: [{
-      text: __("upload.review.decision.duplicate.label"),
-      hint: { text: __("upload.review.decision.duplicate.hint") },
+      text: __("review.decision.duplicate.label"),
+      hint: { text: __("review.decision.duplicate.hint") },
       value: "duplicate"
     }, {
-      text: __("upload.review.decision.original.label"),
-      hint: { text: __("upload.review.decision.original.hint") },
+      text: __("review.decision.original.label"),
+      hint: { text: __("review.decision.original.hint") },
       value: "original"
     }],
     decorate: "decision"

--- a/app/views/upload/show.njk
+++ b/app/views/upload/show.njk
@@ -62,16 +62,16 @@
     descriptionHtml: cardDescriptionHtml
   }) }}
 
-  {% set duplicatePatientRows = [] %}
+  {% set reviewRows = [] %}
   {% for patient in upload.duplicates %}
-    {% set duplicatePatientRows = duplicatePatientRows | push([
+    {% set reviewRows = reviewRows | push([
       {
         header: __("patient.fullName.label"),
         html: patient.fullName
       },
       {
-        header: __("upload.issue.label"),
-        html: __("upload.issue.text")
+        header: __("review.label"),
+        html: __("review.duplicate.description")
       },
       {
         header: __("actions.label"),
@@ -83,21 +83,42 @@
         })
       }
     ]) %}
+
+    {# Add an example of an archived record needing review #}
+    {% set reviewRows = reviewRows | push([
+      {
+        header: __("patient.label"),
+        html: "ABBOTT, Hector"
+      },
+      {
+        header: __("review.label"),
+        text: __("review.archived.description")
+      },
+      {
+        header: __("actions.label"),
+        html: appActionList({
+          items: [{
+            text: __("actions.review"),
+            href: "/uploads/reviews/" + upload.id + "/" + patient.nhsn + "/archived"
+          }]
+        })
+      }
+    ]) %}
   {% endfor %}
 
   {{ table({
-    id: "duplicate-patients",
+    id: "reviews",
     panel: true,
-    heading: upload.formatted.duplicates,
+    heading: __n("upload.reviews.count", reviewRows.length),
     headingLevel: 2,
     responsive: true,
     head: [
       { text: __("patient.label") },
-      { text: __("upload.issue.label") },
+      { text: __("review.label") },
       { text: __("actions.label") }
     ],
-    rows: duplicatePatientRows
-  }) if upload.duplicates.length }}
+    rows: reviewRows
+  }) if reviewRows.length }}
 
   {% set patientRows = [] %}
   {% for patient in upload.patients %}


### PR DESCRIPTION
## Archived patient record

When a child is archived:

- the user is returned to the page and a confirmation banner is displayed that says ‘This record has been archived’

For an archived child, the global child page:
- shows an ‘Archived’ tag
- no longer displays the edit and archive buttons
- the child record summary displays a new row ‘Reason archived’ below the child’s NHS number

<img width="2400" height="2400" alt="Screenshot of an archived patient record." src="https://github.com/user-attachments/assets/24bd386b-6ee0-4216-8a76-80cc165b2490" />

## Reviewing an imported record for a record that was previously archived 

- Heading above review items changed to ‘X imported records need review’

<img width="2400" height="3200" alt="Screenshot of upload page." src="https://github.com/user-attachments/assets/aabadf36-459c-4542-917c-3a671d8530bd" />

- Reviewing a previously archived record asks you in you want to restore the record. It also shows the previous reason why it was archived.

<img width="2400" height="1794" alt="Screenshot of reviewing an archived record." src="https://github.com/user-attachments/assets/6a473069-0517-4dc7-96f8-0336b1c1468f" />

- After restoring, a confirmation banner is shown on the upload page.

<img width="2400" height="3600" alt="upload-confirm-restore" src="https://github.com/user-attachments/assets/f7750c9a-0b85-4bde-ba53-9b05ed335fbd" />

## Review duplicate record

- Remove superfluous warning callout

<img width="2400" height="4032" alt="Screenshot of review duplicate page." src="https://github.com/user-attachments/assets/895a7699-404a-42db-9ce0-950c7cde4ff4" />
