### PR TITLE
Use timeline component for session activity log

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -17,4 +17,5 @@
 @forward "summary-list";
 @forward "tables";
 @forward "tag";
+@forward "timeline";
 @forward "vaccine-method";

--- a/app/assets/stylesheets/components/_timeline.scss
+++ b/app/assets/stylesheets/components/_timeline.scss
@@ -1,0 +1,114 @@
+@use "../vendor/nhsuk-frontend" as *;
+
+$_timeline-badge-size-mobile: 16px;
+$_timeline-badge-small-size-mobile: 12px;
+$_timeline-border-width: 2px;
+
+@function dot-size($size) {
+  @if $size == "default" {
+    @return $_timeline-badge-size-mobile;
+  } @else if $size == "small" {
+    @return $_timeline-badge-small-size-mobile;
+  }
+}
+
+@function dot-ml($size) {
+  @return - calc(($size / 2) + ($_timeline-border-width / 2));
+}
+
+@function dot-mt-tablet($margin) {
+  @return $margin - 1px;
+}
+
+@mixin nhsapp-timeline-badge($size) {
+  $mt: 4px;
+  $mt-small: 6px;
+
+  height: dot-size($size);
+  margin-left: dot-ml(dot-size($size));
+  margin-right: if($size == "default", nhsuk-spacing(4), nhsuk-spacing(4) + 2px);
+  margin-top: if($size == "default", $mt, $mt-small);
+  width: dot-size($size);
+
+  @include nhsuk-media-query($from: tablet) {
+    $tablet: dot-size($size) + 4px;
+
+    height: $tablet;
+    margin-left: dot-ml($tablet);
+    margin-top: if($size == "default", dot-mt-tablet($mt), dot-mt-tablet($mt-small));
+    width: $tablet;
+  }
+}
+
+.app-timeline {
+  list-style: none;
+  padding: 0;
+
+  @include nhsuk-responsive-margin(5, "bottom");
+  @include nhsuk-responsive-padding(2, "top");
+
+  &__item {
+    display: flex;
+    margin-bottom: 0;
+    margin-left: 12px;
+    margin-top: -6px;
+    position: relative;
+
+    @include nhsuk-responsive-padding(5, "bottom");
+
+    &:last-child {
+      padding: 0;
+
+      &::before {
+        border: none;
+      }
+    }
+
+    &::before {
+      border-left: $_timeline-border-width solid $color_nhsuk-grey-3;
+      bottom: 0;
+      content: "";
+      display: block;
+      left: -$_timeline-border-width;
+      position: absolute;
+      top: nhsuk-spacing(2);
+      width: $_timeline-border-width;
+    }
+
+    &--past::before {
+      border-color: $color_nhsuk-blue;
+    }
+  }
+
+  &__badge {
+    flex-shrink: 0;
+    z-index: 1;
+
+    @include nhsapp-timeline-badge("default");
+
+    &--small {
+      @include nhsapp-timeline-badge("small");
+    }
+  }
+
+  &__header {
+    font-weight: normal;
+    margin-bottom: 0;
+
+    @include nhsuk-font-size(19);
+  }
+
+  &__content {
+    :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__description {
+    color: $nhsuk-secondary-text-color;
+    padding-top: 0;
+
+    @include nhsuk-responsive-margin(2, "bottom");
+    @include nhsuk-font-size(16);
+  }
+}

--- a/app/globals.js
+++ b/app/globals.js
@@ -81,6 +81,22 @@ export default () => {
     ]
   }
 
+  globals.timelineItems = function (auditEvents) {
+    const { filters } = this.ctx.settings.nunjucksEnv
+    const timelineItems = []
+
+    for (const auditEvent of Object.values(auditEvents)) {
+      timelineItems.push({
+        headingText: auditEvent.name,
+        isPastItem: auditEvent.isPastEvent,
+        html: auditEvent.formatted?.note,
+        description: filters.safe(auditEvent.formatted.createdAtAndBy)
+      })
+    }
+
+    return timelineItems
+  }
+
   /**
    * Get user form field items
    *

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -1,3 +1,5 @@
+import { isBefore } from 'date-fns'
+
 import { ScreenOutcome } from '../enums.js'
 import { formatDate, today } from '../utils/date.js'
 import {
@@ -47,6 +49,15 @@ export class AuditEvent {
     } catch (error) {
       console.error('Upload.createdBy', error.message)
     }
+  }
+
+  /**
+   * Is past event
+   *
+   * @returns {boolean} Is past event
+   */
+  get isPastEvent() {
+    return isBefore(this.createdAt, today())
   }
 
   /**

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -140,13 +140,9 @@ export class PatientSession {
    * @returns {object} Events grouped by date
    */
   get auditEventLog() {
-    const auditEvents = this.auditEvents.sort((a, b) =>
-      getDateValueDifference(b.createdAt, a.createdAt)
-    )
-
-    return Object.groupBy(auditEvents, (auditEvent) => {
-      return auditEvent.formatted.createdAt
-    })
+    return this.auditEvents
+      .sort((a, b) => getDateValueDifference(b.createdAt, a.createdAt))
+      .reverse()
   }
 
   /**

--- a/app/views/_layouts/default.njk
+++ b/app/views/_layouts/default.njk
@@ -18,6 +18,7 @@
 {% from "_macros/search-input.njk" import appSearchInput with context %}
 {% from "_macros/secondary-navigation.njk" import appSecondaryNavigation %}
 {% from "_macros/status.njk" import appStatus %}
+{% from "_macros/timeline.njk" import appTimeline %}
 {% from "_macros/sub-navigation.njk" import appSubNavigation %}
 
 {% block head %}

--- a/app/views/_macros/timeline.njk
+++ b/app/views/_macros/timeline.njk
@@ -1,0 +1,36 @@
+{% macro _timelineItem(params, item) %}
+  {% set headingLevel = params.headingLevel if params.headingLevel else 3 %}
+  {% set headingBold = "nhsuk-u-font-weight-bold" if item.active else "" %}
+  {% set isPastItem = "app-timeline__item--past" if item.isPastItem else "" %}
+
+  <li class="app-timeline__item {{ isPastItem | trim }}">
+    {% if item.active or item.isPastItem %}
+      <svg class="app-timeline__badge" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
+        <circle cx="14" cy="14" r="13" fill="#005EB8"/>
+      </svg>
+    {% else %}
+      <svg class="app-timeline__badge app-timeline__badge--small" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
+        <circle cx="7" cy="7" r="6" fill="white" stroke="#AEB7BD" stroke-width="2"/>
+      </svg>
+    {% endif %}
+    <div class="app-timeline__content">
+      <h{{ headingLevel }} class="app-timeline__header {{ headingBold }}">{{ item.headingText }}</h{{ headingLevel }}>
+      {% if item.description %}
+        <p class="app-timeline__description">{{ item.description }}</p>
+      {% endif %}
+      {% if item.html %}
+        {{ item.html | safe | trim }}
+      {% elif item.text %}
+        <p class="nhsuk-body">{{ item.text }}</p>
+      {% endif %}
+    </div>
+  </li>
+{% endmacro %}
+
+{% macro appTimeline(params) %}
+<ol class="app-timeline{% if params.classes %} {{ params.classes }}{% endif %}">
+  {% for item in params.items %}
+    {% if item %}{{ _timelineItem(params, item) }}{% endif %}
+  {% endfor %}
+</ol>
+{% endmacro %}

--- a/app/views/patient-session/events.njk
+++ b/app/views/patient-session/events.njk
@@ -59,15 +59,7 @@
     {% endfor %}
   {% endif %}
 
-  {% for group, auditEvents in patientSession.auditEventLog %}
-    <h3 class="nhsuk-heading-xs nhsuk-u-secondary-text-color nhsuk-u-font-weight-normal">{{ group }}</h3>
-
-    {% for auditEvent in auditEvents %}
-      {{ card({
-        heading: auditEvent.name,
-        headingLevel: 4,
-        descriptionHtml: appEvent({ auditEvent: auditEvent, showProgrammes: true })
-      }) if auditEvent.name != EventType.Pinned }}
-    {% endfor %}
-  {% endfor %}
+  {{ appTimeline({
+    items: timelineItems(patientSession.auditEventLog)
+  }) }}
 {% endblock %}


### PR DESCRIPTION
Using the timeline component (adapted ever so slightly from that used in the NHS App) means we can show a more condensed timeline of events.

This will be useful when it comes to updating how we show programme-specific timelines in the global patient record (the activity log in that view remains unchanged for now).

<img width="2400" height="3504" alt="Session activity log." src="https://github.com/user-attachments/assets/ca71c1fb-cf37-44f9-8dbd-eb3a577caa31" />
