### PR TITLE
Update vaccination flow

### DIFF
--- a/app/assets/stylesheets/components/_details.scss
+++ b/app/assets/stylesheets/components/_details.scss
@@ -1,0 +1,14 @@
+@use "../vendor/nhsuk-frontend" as *;
+
+.app-expander--compact {
+  .nhsuk-details__summary {
+    @include nhsuk-responsive-padding(4);
+    @include nhsuk-responsive-padding(4, "bottom", $adjustment: $nhsuk-focus-width);
+  }
+
+  .nhsuk-details__text {
+    @include nhsuk-responsive-padding(4, "bottom");
+    @include nhsuk-responsive-padding(4, "left");
+    @include nhsuk-responsive-padding(4, "right");
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -4,6 +4,7 @@
 @forward "button";
 @forward "card";
 @forward "count";
+@forward "details";
 @forward "environment";
 @forward "filters";
 @forward "header";

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -287,7 +287,7 @@ export const patientSessionController = {
     const { account } = request.app.locals
     const { preScreen } = request.body.patientSession
     const { data } = request.session
-    const { back, patientSession, programme } = response.locals
+    const { patientSession, programme } = response.locals
 
     // Pre-screen interview
     patientSession.preScreen({
@@ -302,7 +302,7 @@ export const patientSessionController = {
     patientSession.update(patientSession, data)
 
     response.redirect(
-      `${programme.uri}/vaccinations/new?patientSession_uuid=${patientSession.uuid}&referrer=${back}`
+      `${programme.uri}/vaccinations/new?patientSession_uuid=${patientSession.uuid}`
     )
   },
 

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -174,7 +174,7 @@ export const vaccinationController = {
         data
       )
 
-      const { patient } = PatientSession.read(
+      const patientSession = PatientSession.read(
         vaccination.patientSession_uuid,
         data
       )
@@ -205,9 +205,17 @@ export const vaccinationController = {
 
       // Update session data
       vaccination.create(vaccination, data)
-      patient.recordVaccination(vaccination)
+      patientSession.patient.recordVaccination(vaccination)
 
-      response.redirect(referrer || vaccination.uri)
+      let next = referrer || vaccination.uri
+      if (type === 'new') {
+        next =
+          patientSession.outstandingVaccinations.length === 0
+            ? `${session.uri}/record`
+            : patientSession.uri
+      }
+
+      response.redirect(next)
     }
   },
 

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -185,7 +185,13 @@ export const vaccinationController = {
       }
 
       // Update number of vaccinations given
-      data.token.vaccinations[vaccination.programme.type] += 1
+      if (data?.token?.vaccinations?.[vaccination.vaccine.snomed]) {
+        data.token.vaccinations[vaccination.vaccine.snomed] += 1
+      } else {
+        data.token.vaccinations = {
+          [vaccination.vaccine.snomed]: 1
+        }
+      }
 
       request.flash('success', __(`vaccination.${type}.success`, { session }))
 

--- a/app/globals.js
+++ b/app/globals.js
@@ -398,35 +398,45 @@ export default () => {
   }
 
   /**
-   * Get summaryList `rows` parameter for default batches
+   * Get vaccinator summary table row items
    *
-   * @returns {Array} `rows`
+   * @param {import('./models/session.js').Session} session - Session
+   * @returns {Array} Table row items
    */
-  globals.defaultBatchSummaryRows = function () {
-    const { __, defaultBatches } = this.ctx
-    const rows = []
+  globals.vaccinationTableRows = function (session) {
+    const { __, defaultBatches, data } = this.ctx
 
-    for (const defaultBatch of Object.values(defaultBatches)) {
-      rows.push({
-        key: {
-          text: defaultBatch.vaccine.brand
+    const tableRows = []
+    for (const vaccine of Object.values(session.vaccines)) {
+      const defaultBatch = defaultBatches.find(
+        ({ vaccine_snomed }) => vaccine_snomed === vaccine.snomed
+      )
+      const vaccinationCount = data?.token?.vaccinations?.[vaccine.snomed] || 0
+
+      const defaultBatchHtml = defaultBatch
+        ? `${defaultBatch.formatted.id} ${formatLink(
+            `${session.uri}/default-batch/${vaccine.snomed}`,
+            __('defaultBatch.visuallyHiddenText', vaccine.brand)
+          )}`
+        : 'Not set'
+
+      tableRows.push([
+        {
+          header: __('vaccine.label'),
+          text: vaccine.brand
         },
-        value: {
-          html: defaultBatch.formatted.id
+        {
+          header: __('user.vaccinations.label'),
+          text: vaccinationCount
         },
-        actions: {
-          items: [
-            {
-              text: __(`actions.change`),
-              visuallyHiddenText: defaultBatch.vaccine.brandWithType,
-              href: `${defaultBatch.session.uri}/default-batch/${defaultBatch.vaccine_snomed}`
-            }
-          ]
+        {
+          header: __('defaultBatch.label'),
+          html: defaultBatchHtml
         }
-      })
+      ])
     }
 
-    return rows
+    return tableRows
   }
 
   /**

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2079,7 +2079,7 @@ export const en = {
     },
     new: {
       'check-answers': {
-        title: 'Check and confirm',
+        title: 'Check your answers before saving this vaccination outcome',
         summary: 'Vaccination details',
         notGiven: 'Vaccination was not given'
       },
@@ -2091,6 +2091,7 @@ export const en = {
       notGiven: {
         title: 'Vaccination was not given'
       },
+      confirm: 'Save',
       success:
         'Vaccination outcome recorded for {{session.programmeNames.sentenceCase}}'
     },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -35,8 +35,9 @@ export const en = {
     }
   },
   defaultBatch: {
-    label:
-      'Change default batch<span class="nhsuk-u-visually-hidden"> for {{vaccine.brand}}</span> ',
+    label: 'Default batch',
+    visuallyHiddenText:
+      'Change<span class="nhsuk-u-visually-hidden"> default batch for %s</span> ',
     title: '{count, plural, one{Default batch} other{Default batches}}',
     edit: {
       title: 'Select a default batch for this session',
@@ -2056,6 +2057,9 @@ export const en = {
     },
     role: {
       label: 'Role'
+    },
+    vaccinations: {
+      label: 'Administered'
     }
   },
   vaccination: {
@@ -2239,6 +2243,7 @@ export const en = {
     }
   },
   vaccine: {
+    label: 'Vaccine',
     list: {
       label: 'Vaccines',
       title: 'Vaccines',

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,6 +1,5 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
-import { ProgrammeType } from '../enums.js'
 import { formatLink, formatMonospace } from '../utils/string.js'
 
 /**
@@ -23,13 +22,7 @@ export class User {
     this.role = options?.role
     this.canPrescribe = options?.canPrescribe || false
     this.vaccineMethods = options?.vaccineMethods || []
-    this.vaccinations = {
-      [ProgrammeType.Flu]: options?.vaccinations?.[ProgrammeType.Flu] || 0,
-      [ProgrammeType.HPV]: options?.vaccinations?.[ProgrammeType.HPV] || 0,
-      [ProgrammeType.MenACWY]:
-        options?.vaccinations?.[ProgrammeType.MenACWY] || 0,
-      [ProgrammeType.TdIPV]: options?.vaccinations?.[ProgrammeType.TdIPV] || 0
-    }
+    this.vaccinations = options?.vaccinations || {}
   }
 
   /**

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -30,42 +30,6 @@
     view: view
   }) }}
 
-  {% set instructHtml %}
-    {{ __("session.instruct.description", session.activity.instruct) | nhsukMarkdown }}
-
-    {{ actionLink({
-      text: __("session.instructions.label"),
-      href: session.uri + "/instructions"
-    }) }}
-  {% endset %}
-
-  {{ insetText({
-    html: instructHtml
-  }) if view == "instruct" and session.activity.instruct and account.canPrescribe }}
-
-  {% set recordHtml %}
-    {{ vaccinationCount(data.token.vaccinations) | nhsukMarkdown if vaccinationCount(data.token.vaccinations) }}
-
-    {% if defaultBatches.length %}
-      {{ appHeading({
-        classes: "nhsuk-u-margin-bottom-2",
-        level: 4,
-        size: "s",
-        title: __mf("defaultBatch.title", {
-          count: defaultBatches.length
-        })
-      }) }}
-
-      {{ summaryList({
-        rows: defaultBatchSummaryRows()
-      }) }}
-    {% endif %}
-  {% endset %}
-
-  {{ insetText({
-    html: recordHtml
-  }) if view == "record" and (defaultBatches.length or vaccinationCount(data.token.vaccinations)) }}
-
   {% if (view == "register" or view == "record") and not session.isActive %}
     {{ appHeading({
       level: 2,
@@ -118,6 +82,34 @@
             count: results.count
           }) | safe
         }) }}
+
+        {% set instructHtml %}
+          {{ __("session.instruct.description", session.activity.instruct) | nhsukMarkdown }}
+
+          {{ actionLink({
+            text: __("session.instructions.label"),
+            href: session.uri + "/instructions"
+          }) }}
+        {% endset %}
+
+        {{ insetText({
+          html: instructHtml
+        }) if view == "instruct" and session.activity.instruct and account.canPrescribe }}
+
+        {{ details({
+          classes: "nhsuk-expander app-expander--compact",
+          summaryText: "Your vaccinations today",
+          html: table({
+            responsive: true,
+            firstCellIsHeader: false,
+            head: [
+              { text: __("vaccine.label") },
+              { text: __("user.vaccinations.label") },
+              { text: __("defaultBatch.label") }
+            ],
+            rows: vaccinationTableRows(session)
+          }) if view == "record"
+        }) if view == "record" and session.isActive }}
 
         {% for patientSession in results.page %}
           {% set statusHtml %}

--- a/app/views/vaccination/form/check-answers.njk
+++ b/app/views/vaccination/form/check-answers.njk
@@ -1,6 +1,6 @@
 {% extends "_layouts/form.njk" %}
 
-{% set confirmButtonText = __("form.confirm") %}
+{% set confirmButtonText = __("vaccination.new.confirm") %}
 {% set title = __("vaccination.new.check-answers.title") %}
 {% set mismatchedMethods = vaccination.vaccine.method != vaccination.patientSession.vaccine.method and not patientSession.canRecordAlternativeVaccine %}
 {% set given = vaccination.outcome == "Vaccinated" or vaccination.outcome == "Partially vaccinated" %}


### PR DESCRIPTION
- Show default batches for a session, and a running count of the logged in vaccinators administered vaccinations in an expander titled ‘Your vaccinations today’. The screenshots below show this open, but it is closed by default
- Update the title and confirm button text on the check answers page for a new vaccination outcome
- If there are no outstanding vaccinations remaining for a patient in a session, return to the session record activity view after saving a vaccination outcome

<img width="2400" height="3302" alt="Screenshot of a session prior to recording a vaccination." src="https://github.com/user-attachments/assets/f2a61330-d387-45fa-aced-8af712cf78b5" />

<img width="2400" height="3538" alt="Screenshot of vaccination check answers page." src="https://github.com/user-attachments/assets/73c567f3-90c5-40bb-ae10-331eb1e718a8" />

<img width="2400" height="3536" alt="Screenshot of a session after recording a vaccination." src="https://github.com/user-attachments/assets/0a770f21-f9d7-484f-8d6d-974157150340" />