### PR TITLE
Show parent in consent response

### DIFF
--- a/app/assets/stylesheets/components/_summary-list.scss
+++ b/app/assets/stylesheets/components/_summary-list.scss
@@ -23,4 +23,8 @@
     margin-bottom: 0;
     padding-bottom: 0;
   }
+
+  .nhsuk-summary-list__value {
+    padding-top: nhsuk-spacing(1);
+  }
 }

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -384,6 +384,7 @@ export class Reply {
       fullNameAndRelationship: this.selfConsent
         ? this.relationship
         : formatParent(this.parent, false),
+      parent: formatParent(this.parent, true),
       tel: this.parent.tel,
       email: this.parent.email,
       programme: this.programme?.nameTag,

--- a/app/views/consent/match.njk
+++ b/app/views/consent/match.njk
@@ -11,7 +11,6 @@
   {{ super() }}
 
   {{ appHeading({
-    caption: __("consent.match.caption", { parent: consent.parent } ),
     title: title
   }) }}
 
@@ -21,10 +20,16 @@
         {{ summaryList({
           classes: "nhsuk-u-margin-bottom-4 nhsuk-summary-list--no-border app-summary-list--full-width",
           rows: summaryRows(consent.child, {
-            fullName: {},
+            fullAndPreferredNames: {
+              label: __("consent.child.fullAndPreferredNames.label")
+            },
             dob: {},
             postalCode: {},
-            school: {}
+            school: {},
+            parent: {
+              label: __("consent.parent.label"),
+              value: consent.formatted.parent
+            }
           })
         }) }}
 


### PR DESCRIPTION
- Remove parent’s name from heading caption
- Show parent name and telephone number in left-hand consent response
- Tweak full-width summary list styles to reduce space between key and value

<img width="2400" height="2400" alt="Screenshot of updated consent matching page." src="https://github.com/user-attachments/assets/fa1571bf-fd5b-4ab8-8df4-3bbeb98ac64c" />
