### PR TITLE
Show uploaded file name for imports

### DIFF
--- a/app/controllers/upload.js
+++ b/app/controllers/upload.js
@@ -68,6 +68,7 @@ export const uploadController = {
         programme_id,
         type,
         createdBy_uid: account.uid,
+        fileName: 'example.csv',
         ...(type === UploadType.School &&
           urn && {
             school_urn: urn

--- a/app/generators/upload.js
+++ b/app/generators/upload.js
@@ -1,6 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
+import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
-import { UploadStatus } from '../enums.js'
+import { UploadStatus, UploadType } from '../enums.js'
 import { Upload } from '../models/upload.js'
 import { today } from '../utils/date.js'
 
@@ -13,8 +14,14 @@ import { today } from '../utils/date.js'
  * @param {import('../models/school.js').School} [school] - School
  * @returns {Upload} Upload
  */
-export function generateUpload(patient_uuids, user, type, school) {
+export function generateUpload(
+  patient_uuids,
+  user,
+  type = UploadType.Cohort,
+  school
+) {
   const createdAt = faker.date.recent({ days: 14, refDate: today() })
+  const fileName = `${prototypeFilters.slugify(type)}-${faker.number.int(5)}.csv`
 
   let validations
   let status = UploadStatus.Complete
@@ -38,6 +45,7 @@ export function generateUpload(patient_uuids, user, type, school) {
   return new Upload({
     createdAt,
     createdBy_uid: user.uid,
+    fileName,
     status,
     type,
     validations,

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1950,6 +1950,9 @@ export const en = {
     createdBy: {
       label: 'Imported by'
     },
+    fileName: {
+      label: 'Uploaded file'
+    },
     programme: {
       label: 'Programme'
     },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1327,17 +1327,14 @@ export const en = {
       label: 'Archived record',
       title: 'Do you want to restore this previously archived record?',
       hint: 'This record was previously archived. %s.',
-      description: 'Record was previously archived',
+      description: 'Uploaded %s record was previously archived',
       confirm: 'Resolve archived record',
       success: 'Previously archived record restored'
     },
     duplicate: {
-      label: 'Duplicate record',
-      title: 'Review duplicate child record',
-      description:
-        'A field in a duplicate record does not match an existing child record',
-      record: 'Duplicate child record',
-      vaccination: 'Duplicate vaccination record',
+      label: 'Uploaded record',
+      title: 'Uploaded %s record duplicates an existing record',
+      description: 'Uploaded %s record duplicates an existing record',
       confirm: 'Resolve duplicate record',
       success: 'Record updated with values from duplicate record'
     },
@@ -1349,12 +1346,12 @@ export const en = {
     decision: {
       label: 'Which record do you want to keep?',
       duplicate: {
-        label: 'Use duplicate record',
-        hint: 'The duplicate record will replace the existing child record.'
+        label: 'Use uploaded %s record',
+        hint: 'The uploaded record will replace the existing record'
       },
       original: {
-        label: 'Keep previously imported record',
-        hint: 'The existing record will be kept and the duplicate record will be discarded.'
+        label: 'Keep existing %s record',
+        hint: 'The existing record will be kept and the uploaded record will be discarded'
       },
       restore: {
         label: 'Yes, restore this record'

--- a/app/models/upload.js
+++ b/app/models/upload.js
@@ -3,7 +3,11 @@ import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
 import { UploadStatus, UploadType } from '../enums.js'
 import { formatDate, today } from '../utils/date.js'
-import { formatWithSecondaryText, formatYearGroup } from '../utils/string.js'
+import {
+  formatLink,
+  formatWithSecondaryText,
+  formatYearGroup
+} from '../utils/string.js'
 
 import { Patient } from './patient.js'
 import { School } from './school.js'
@@ -20,6 +24,7 @@ import { User } from './user.js'
  * @property {Date} [createdAt] - Created date
  * @property {string} [createdBy_uid] - User who created upload
  * @property {Date} [updatedAt] - Updated date
+ * @property {string} [fileName] - Original file name
  * @property {Array<string>} [patient_uuids] - Patient record UUIDs
  * @property {number} [devoid] - Exact duplicate records found
  */
@@ -32,6 +37,7 @@ export class Upload {
     this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
     this.createdBy_uid = options?.createdBy_uid
     this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
+    this.fileName = options?.fileName
     this.validations = options?.validations || []
     this.patient_uuids = options?.patient_uuids || []
 
@@ -174,6 +180,20 @@ export class Upload {
         this.type === UploadType.School
           ? formatWithSecondaryText(this.type, this.schoolName)
           : this.type
+    }
+  }
+
+  /**
+   * Get formatted links
+   *
+   * @returns {object} Formatted links
+   */
+  get link() {
+    return {
+      summary: formatWithSecondaryText(
+        formatLink(this.uri, this.formatted.createdAt),
+        this.fileName
+      )
     }
   }
 

--- a/app/views/review/list.njk
+++ b/app/views/review/list.njk
@@ -11,44 +11,78 @@
     view: "reviews"
   }) }}
 
-  {% if pendingReviews %}
-    {% set reviewRows = [] %}
-    {% for id, pendingPatients in pendingReviews %}
-      {% for patient in pendingPatients %}
+  {% if reviews.length %}
+    {% for upload in reviews %}
+      {% set reviewRows = [] %}
+      {% set type = "vaccination" if upload.type == UploadType.Report else "child" %}
+      {% for patient in upload.duplicates %}
         {% set reviewRows = reviewRows | push([
           {
             header: __("patient.fullName.label"),
-            html: patient.fullName or "Not provided"
+            html: patient.fullName
           },
           {
             header: __("review.label"),
-            html: __("review.duplicate.description")
+            html: __("review.duplicate.description", type)
           },
           {
             header: __("actions.label"),
             html: appActionList({
               items: [{
                 text: __("actions.review"),
-                href: "/uploads/reviews/" + id + "/" + patient.nhsn + "?referrer=/uploads/reviews/"
+                href: "/uploads/reviews/" + upload.id + "/" + patient.nhsn
               }]
             })
           }
         ]) %}
       {% endfor %}
-    {% endfor %}
 
-    {{ table({
-      id: "reviews",
-      heading: __mf("review.count", { count: reviews.length }),
-      panel: true,
-      responsive: true,
-      head: [
-        { text: __("patient.label") },
-        { text: __("review.label") },
-        { text: __("actions.label") }
-      ],
-      rows: reviewRows
-    }) }}
+      {% set cardDescriptionHtml %}
+        {{ summaryList({
+          rows: summaryRows(upload, {
+            createdBy: {},
+            fileName: {},
+            type: {},
+            school: {}
+          })
+        }) }}
+
+        {{ table({
+          heading: upload.formatted.createdAt,
+          caption: __mf("review.count", { count: reviewRows.length }),
+          responsive: true,
+          head: [
+            {
+              text: __("patient.label"),
+              attributes: {
+                width: "30%"
+              }
+            },
+            {
+              text: __("review.label"),
+              attributes: {
+                width: "60%"
+              } },
+            {
+              text: __("actions.label"),
+              attributes: {
+                width: "10%"
+              }
+            }
+          ],
+          rows: reviewRows
+        }) }}
+      {% endset %}
+
+      {{ card({
+        heading: upload.formatted.createdAt,
+        feature: true,
+        descriptionHtml: cardDescriptionHtml,
+        attributes: {
+          id: upload.id
+        }
+      }) }}
+    {% endfor %}
   {% else %}
     {{ __mf("review.count", { count: 0 }) | nhsukMarkdown }}
   {% endif %}

--- a/app/views/review/show.njk
+++ b/app/views/review/show.njk
@@ -1,7 +1,8 @@
 {% extends "_layouts/form.njk" %}
 
 {% set gridColumns = "full" %}
-{% set title = __("review.duplicate.title") %}
+{% set type = "vaccination" if upload.type == UploadType.Report else "child" %}
+{% set title = __("review.duplicate.title", type) %}
 {% set confirmButtonText = __("review.duplicate.confirm") %}
 
 {% block form %}
@@ -13,21 +14,7 @@
   <div class="nhsuk-grid-row nhsuk-card-group">
     <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
       {% set descriptionHtml %}
-        {{ summaryList({
-          rows: summaryRows(duplicatePatient, {
-            nhsn: {},
-            fullName: {},
-            dob: {
-              value: duplicatePatient.formatted.dob | highlightDifference(patient.formatted.dob)
-            },
-            gender: {},
-            postalCode: {},
-            school: {}
-          })
-        }) }}
-
-        {% if duplicatePatient.vaccinations[0] %}
-          <h3 class="nhsuk-heading-s">{{ __("review.duplicate.vaccination") }}</h3>
+        {% if upload.type == UploadType.Report %}
           {{ summaryList({
             rows: summaryRows(duplicatePatient.vaccinations[0], {
               outcome: {},
@@ -46,6 +33,19 @@
               protocol: {}
             })
           }) }}
+        {% else %}
+          {{ summaryList({
+            rows: summaryRows(duplicatePatient, {
+              nhsn: {},
+              fullName: {},
+              dob: {
+                value: duplicatePatient.formatted.dob | highlightDifference(patient.formatted.dob)
+              },
+              gender: {},
+              postalCode: {},
+              school: {}
+            })
+          }) }}
         {% endif %}
       {% endset %}
 
@@ -58,19 +58,7 @@
     </div>
     <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
       {% set descriptionHtml %}
-        {{ summaryList({
-          rows: summaryRows(patient, {
-            nhsn: {},
-            fullName: {},
-            dob: {},
-            gender: {},
-            postalCode: {},
-            school: {}
-          })
-        }) }}
-
-        {% if patient.vaccinations[0] %}
-          <h3 class="nhsuk-heading-s">{{ __("review.original.vaccination") }}</h3>
+        {% if upload.type == UploadType.Report %}
           {{ summaryList({
             rows: summaryRows(patient.vaccinations[0], {
               outcome: {},
@@ -85,6 +73,17 @@
               createdBy: {},
               updatedAt: {},
               protocol: {}
+            })
+          }) }}
+        {% else %}
+          {{ summaryList({
+            rows: summaryRows(patient, {
+              nhsn: {},
+              fullName: {},
+              dob: {},
+              gender: {},
+              postalCode: {},
+              school: {}
             })
           }) }}
         {% endif %}
@@ -110,11 +109,11 @@
       }
     },
     items: [{
-      text: __("review.decision.duplicate.label"),
+      text: __("review.decision.duplicate.label", type),
       hint: { text: __("review.decision.duplicate.hint") },
       value: "duplicate"
     }, {
-      text: __("review.decision.original.label"),
+      text: __("review.decision.original.label", type),
       hint: { text: __("review.decision.original.hint") },
       value: "original"
     }],

--- a/app/views/upload/list.njk
+++ b/app/views/upload/list.njk
@@ -17,7 +17,7 @@
       {% set uploadRows = uploadRows | push([
         {
           header: __("upload.createdAt.label"),
-          html: link(upload.uri, upload.formatted.createdAt)
+          html: upload.link.summary
         },
         {
           header: __("upload.type.label"),

--- a/app/views/upload/show.njk
+++ b/app/views/upload/show.njk
@@ -64,6 +64,7 @@
 
   {% set reviewRows = [] %}
   {% for patient in upload.duplicates %}
+    {% set type = "vaccination" if upload.type == UploadType.Report else "child" %}
     {% set reviewRows = reviewRows | push([
       {
         header: __("patient.fullName.label"),
@@ -71,7 +72,7 @@
       },
       {
         header: __("review.label"),
-        html: __("review.duplicate.description")
+        html: __("review.duplicate.description", type)
       },
       {
         header: __("actions.label"),
@@ -92,7 +93,7 @@
       },
       {
         header: __("review.label"),
-        text: __("review.archived.description")
+        text: __("review.archived.description", type)
       },
       {
         header: __("actions.label"),
@@ -113,9 +114,23 @@
     headingLevel: 2,
     responsive: true,
     head: [
-      { text: __("patient.label") },
-      { text: __("review.label") },
-      { text: __("actions.label") }
+      {
+        text: __("patient.label"),
+        attributes: {
+          width: "30%"
+        }
+      },
+      {
+        text: __("review.label"),
+        attributes: {
+          width: "60%"
+        } },
+      {
+        text: __("actions.label"),
+        attributes: {
+          width: "10%"
+        }
+      }
     ],
     rows: reviewRows
   }) if reviewRows.length }}
@@ -125,7 +140,10 @@
     {% set patientRows = patientRows | push([
       {
         header: __("patient.fullName.label"),
-        html: patient.vaccination.link.fullNameAndNhsn if upload.type == UploadType.Report else patient.formatted.fullNameAndNhsn
+        html: patient.vaccination.link.fullNameAndNhsn if upload.type == UploadType.Report else patient.formatted.fullNameAndNhsn,
+        attributes: {
+          width: "30%"
+        }
       },
       {
         header: __("patient.dob.label"),

--- a/app/views/upload/show.njk
+++ b/app/views/upload/show.njk
@@ -44,6 +44,7 @@
       rows: summaryRows(upload, {
         createdAt: {},
         createdBy: {},
+        fileName: {},
         type: {},
         school: {},
         yearGroups: {},
@@ -52,8 +53,7 @@
         duplicates: {}
       })
     }) }}
-
-    {{ link(upload.uri + "/bulk-remove-relationships", __("upload.removeRelationships.label")) | nhsukMarkdown }}
+    {{ link(upload.uri + "/bulk-remove-relationships", __("upload.removeRelationships.label")) | nhsukMarkdown if upload.status == UploadStatus.Complete }}
   {% endset %}
 
   {{ card({


### PR DESCRIPTION
Show the original file name for an upload to help distinguish imports and trace the source of imported data. Show the file name on:

- the list of imports, below the date link
- on an import summary, both after initial import, and when reviewing a previous import

<img width="2400" height="2400" alt="Screenshot of a list of imports." src="https://github.com/user-attachments/assets/daffe04b-3131-4007-b940-d7ba45e71d36" />

<img width="720" height="610" alt="Screenshot of import being processed." src="https://github.com/user-attachments/assets/6c344596-2b22-44e0-80f0-5b21ea82cc62" />

<img width="700" height="490" alt="Screenshot of import that has been completed." src="https://github.com/user-attachments/assets/5bfc45ea-b6e3-4216-9b1e-bd45dfac0b0f" />

Also groups import issues by offending upload, showing additional details about who uploaded a file, what the original file name was, and what type of upload it was.

<img width="2400" height="4800" alt="Screenshot of a list of import issues." src="https://github.com/user-attachments/assets/760f94d6-487a-4891-91f3-01e30c553d20" />

