### PR TITLE
Show hint text on nurse-facing health answers

### DIFF
--- a/app/globals.js
+++ b/app/globals.js
@@ -361,12 +361,16 @@ export default () => {
         healthQuestions[key].labelWithOptions || healthQuestions[key].label
 
       keyText = parentFacing
-        ? keyText.replace('the child', 'your child')
-        : keyText
+        ? healthQuestions[key].label.replace('the child', 'your child')
+        : `<p class="nhsuk-body nhsuk-u-margin-bottom-1">${healthQuestions[key].label}</p>`
+
+      if (!parentFacing && healthQuestions[key].hint) {
+        keyText += `<p class="nhsuk-hint nhsuk-u-font-size-16 nhsuk-u-margin-bottom-2">${healthQuestions[key].hint}</p>`
+      }
 
       summaryRows.push({
-        border: undefined,
-        key: { text: keyText },
+        classes: undefined,
+        key: { html: keyText },
         value: { html },
         ...(edit && {
           actions: {


### PR DESCRIPTION
Gets a bit busy (which is why I’ve made the left border on responses blue to pull them out a bit more). Too much? 

<img width="1140" height="971" alt="Screenshot of health answers showing hint text." src="https://github.com/user-attachments/assets/73edc107-49e4-4d59-bbac-8989e0195d53" />
