### PR TITLE
Update session overview content and add eligible children filter

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1555,11 +1555,12 @@ export const en = {
       title: 'Schedule sessions',
       description: 'Add dates for this school.'
     },
-    cohort: {
-      label: 'Eligible cohort'
-    },
     patients: {
       label: 'Children',
+      eligible: 'Eligible children',
+      hint: 'Due vaccination, not vaccinated elsewhere',
+      description:
+        'Children due a vaccination this year who have not been vaccinated at another location',
       count:
         '{count, plural, =0 {No children} one {# child} other {# children}}'
     },

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -57,6 +57,10 @@
         }
       },
       items: [{
+        text: __("session.patients.eligible"),
+        hint: { text: __("session.patients.hint") },
+        checked: true
+      }, {
         text: __("session.activity.stillToVaccinate.label"),
         hint: { text: __("session.activity.stillToVaccinate.hint") },
         value: "stillToVaccinate"

--- a/app/views/programme/show.njk
+++ b/app/views/programme/show.njk
@@ -29,6 +29,15 @@
   <div class="nhsuk-grid-row nhsuk-card-group">
     <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
       {{ appDataCard({
+        heading: PatientOutcome.NoOutcomeYet,
+        headingLevel: 3,
+        colour: "grey",
+        data: programme.report(PatientOutcome.NoOutcomeYet).length,
+        href: programme.uri + "/patients?report=" + PatientOutcome.NoOutcomeYet if not isDataConsumer
+      }) }}
+    </div>
+    <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+      {{ appDataCard({
         heading: PatientOutcome.Vaccinated,
         headingLevel: 3,
         colour: "green",
@@ -43,15 +52,6 @@
         colour: "red",
         data: programme.report(PatientOutcome.CouldNotVaccinate).length,
         href: programme.uri + "/patients?report=" + PatientOutcome.CouldNotVaccinate if not isDataConsumer
-      }) }}
-    </div>
-    <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-      {{ appDataCard({
-        heading: PatientOutcome.NoOutcomeYet,
-        headingLevel: 3,
-        colour: "grey",
-        data: programme.report(PatientOutcome.NoOutcomeYet).length,
-        href: programme.uri + "/patients?report=" + PatientOutcome.NoOutcomeYet if not isDataConsumer
       }) }}
     </div>
   </div>

--- a/app/views/session/_session-programme-summary.njk
+++ b/app/views/session/_session-programme-summary.njk
@@ -1,16 +1,18 @@
 {% for programme in session.primaryProgrammes %}
   {{ appHeading({
     title: programme.name,
+    summary: __("session.patients.description"),
     level: 3,
     size: "m"
   }) }}
   <div class="nhsuk-grid-row nhsuk-card-group">
     <div class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
       {{ appDataCard({
-        heading: __("session.cohort.label"),
+        heading: __("session.patients.eligible"),
         colour: "blue",
         compact: session.primaryProgrammes.length > 1,
-        data: session.patients.length
+        data: session.patients.length,
+        href: session.uri + "/report?programme_id=" + programme.id
       }) }}
     </div>
     <div class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">

--- a/app/views/session/_session-programme-summary.njk
+++ b/app/views/session/_session-programme-summary.njk
@@ -15,6 +15,16 @@
     </div>
     <div class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
       {{ appDataCard({
+        heading: PatientOutcome.NoOutcomeYet,
+        headingLevel: 3,
+        colour: "grey",
+        compact: session.primaryProgrammes.length > 1,
+        data: session.activity.noOutcomeYet,
+        href: session.uri + "/report?report=" + PatientOutcome.NoOutcomeYet + "&programme_id=" + programme.id
+      }) }}
+    </div>
+    <div class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
+      {{ appDataCard({
         heading: PatientOutcome.Vaccinated,
         headingLevel: 3,
         colour: "green",
@@ -31,16 +41,6 @@
         compact: session.primaryProgrammes.length > 1,
         data: session.activity.couldNotVaccinate,
         href: session.uri + "/report?report=" + PatientOutcome.CouldNotVaccinate + "&programme_id=" + programme.id
-      }) }}
-    </div>
-    <div class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
-      {{ appDataCard({
-        heading: PatientOutcome.NoOutcomeYet,
-        headingLevel: 3,
-        colour: "grey",
-        compact: session.primaryProgrammes.length > 1,
-        data: session.activity.noOutcomeYet,
-        href: session.uri + "/report?report=" + PatientOutcome.NoOutcomeYet + "&programme_id=" + programme.id
       }) }}
     </div>
   </div>


### PR DESCRIPTION
- Change order of programme outcome stats
- Add hint text below programme name indicating the provenance of these numbers
- Link ‘Eligible children’ data card to filtered view on ‘Children’ tab

<img width="1125" height="440" alt="Screenshot of programme counts on session overview page." src="https://github.com/user-attachments/assets/ae57e202-8ed4-4d20-9352-ed9535aced4e" />

<img width="330" height="440" alt="Screenshot of eligible children filter on Children tab." src="https://github.com/user-attachments/assets/de3aa2ab-e154-4b5c-aac6-8ec22da4e467" />
