### PR TITLE
Configure a 7 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
+
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: 'monthly'
+      interval: monthly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
We're doing this to protect us against hypothetical supply chain attacks, 7 days feels like enough time for any bad dependencies to be yanked before we upgrade to them.