### PR TITLE
Allow parents to say when and where a previous vaccination was given

### DIFF
--- a/app/controllers/parent.js
+++ b/app/controllers/parent.js
@@ -175,11 +175,11 @@ export const parentController = {
       [`/${session_id}/${consent_uuid}/new/refusal-reason`]: {
         [`/${session_id}/${consent_uuid}/new/refusal-reason-details`]: {
           data: 'consent.refusalReason',
-          values: [
-            ReplyRefusal.AlreadyVaccinated,
-            ReplyRefusal.GettingElsewhere,
-            ReplyRefusal.Medical
-          ]
+          values: [ReplyRefusal.GettingElsewhere, ReplyRefusal.Medical]
+        },
+        [`/${session_id}/${consent_uuid}/new/previous-dose`]: {
+          data: 'consent.refusalReason',
+          value: ReplyRefusal.AlreadyVaccinated
         },
         [`/${session_id}/${consent_uuid}/new/first-dose-country`]: {
           data: 'consent.refusalReason',
@@ -194,7 +194,11 @@ export const parentController = {
       [`/${session_id}/${consent_uuid}/new/consultation`]: {
         [`/${session_id}/${consent_uuid}/new/check-answers`]: true
       },
-      // First and second dose journey
+      // Previous single dose journey
+      [`/${session_id}/${consent_uuid}/new/previous-dose`]: {
+        [`/${session_id}/${consent_uuid}/new/check-answers`]: true
+      },
+      // Previous multi-dose journey
       [`/${session_id}/${consent_uuid}/new/first-dose-country`]: {},
       [`/${session_id}/${consent_uuid}/new/first-dose-date`]: {},
       [`/${session_id}/${consent_uuid}/new/second-dose-country`]: {},
@@ -322,7 +326,7 @@ export const parentController = {
   showForm(request, response) {
     let { view } = request.params
     const { consent } = response.locals
-    let key
+    let key = kebabToCamelCase(view)
 
     // All health questions use the same view
     if (view.startsWith('health-question-')) {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -895,8 +895,11 @@ export const en = {
       }
     },
     previousDose: {
+      label: 'Details of %s vaccination',
+      title: 'When and where did your child get their %s vaccination?',
       country: {
         label: 'Country',
+        title: 'Which country was the vaccination given in?',
         england: 'England',
         scotland: 'Scotland',
         wales: 'Wales',
@@ -908,6 +911,7 @@ export const en = {
       },
       createdAt: {
         label: 'Date',
+        title: 'When was the vaccination given?',
         hint: 'If you do not know the exact date of the vaccination, leave the day field empty and enter your best guess for the month'
       },
       scheduled: {

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -112,7 +112,11 @@ export class Reply {
           : stringToBoolean(options?.invalid) || false
     }
 
-    if (this.decision === ReplyDecision.AlreadyVaccinated) {
+    if (
+      [ReplyDecision.AlreadyVaccinated, ReplyDecision.Refused].includes(
+        this.decision
+      )
+    ) {
       this.firstDose = options?.firstDose && new Vaccination(options.firstDose)
 
       if (options?.firstDose?.scheduled) {

--- a/app/views/parent/form/check-answers.njk
+++ b/app/views/parent/form/check-answers.njk
@@ -179,41 +179,62 @@
     )
   }) if consent.given }}
 
-  {{ summaryList({
-    card: {
-      heading: __("consent.firstDose.label"),
-      headingSize: "m"
-    },
-    rows: summaryRows(consent, {
-      createdAt: {
-        label: __("consent.previousDose.createdAt.label"),
-        value: consent.firstDose.formatted.createdAt_date,
-        href: editPath("first-dose-date")
+  {% if SessionPresetName.MMR in session.presetNames and consent.decision == ReplyDecision.AlreadyVaccinated %}
+    {{ summaryList({
+      card: {
+        heading: __("consent.firstDose.label"),
+        headingSize: "m"
       },
-      country: {
-        label: __("consent.previousDose.country.label"),
-        value: consent.firstDose.formatted.country,
-        href: editPath("first-dose-country")
-      }
-    })
-  }) if consent.decision == ReplyDecision.AlreadyVaccinated }}
+      rows: summaryRows(consent, {
+        createdAt: {
+          label: __("consent.previousDose.createdAt.label"),
+          value: consent.firstDose.formatted.createdAt_date,
+          href: editPath("first-dose-date")
+        },
+        country: {
+          label: __("consent.previousDose.country.label"),
+          value: consent.firstDose.formatted.country,
+          href: editPath("first-dose-country")
+        }
+      })
+    }) }}
 
-  {{ summaryList({
-    card: {
-      heading: __("consent.secondDose.label"),
-      headingSize: "m"
-    },
-    rows: summaryRows(consent, {
-      createdAt: {
-        label: __("consent.previousDose.createdAt.label"),
-        value: consent.secondDose.formatted.createdAt_date,
-        href: editPath("second-dose-date")
+    {{ summaryList({
+      card: {
+        heading: __("consent.secondDose.label"),
+        headingSize: "m"
       },
-      country: {
-        label: __("consent.previousDose.country.label"),
-        value: consent.secondDose.formatted.country,
-        href: editPath("second-dose-country")
-      }
-    })
-  }) if consent.decision == ReplyDecision.AlreadyVaccinated }}
+      rows: summaryRows(consent, {
+        createdAt: {
+          label: __("consent.previousDose.createdAt.label"),
+          value: consent.secondDose.formatted.createdAt_date,
+          href: editPath("second-dose-date")
+        },
+        country: {
+          label: __("consent.previousDose.country.label"),
+          value: consent.secondDose.formatted.country,
+          href: editPath("second-dose-country")
+        }
+      })
+    }) }}
+  {% elif consent.refusalReason == ReplyRefusal.AlreadyVaccinated %}
+    {{ summaryList({
+      card: {
+        heading: __("consent.previousDose.label", session.programmes[0].nameSentenceCase),
+        headingSize: "m"
+      },
+      rows: summaryRows(consent, {
+        createdAt: {
+          label: __("consent.previousDose.createdAt.label"),
+          value: consent.firstDose.formatted.createdAt_date,
+          href: editPath("previous-dose")
+        },
+        country: {
+          label: __("consent.previousDose.country.label"),
+          value: consent.firstDose.formatted.country,
+          href: editPath("previous-dose")
+        }
+      })
+    }) }}
+  {% endif %}
 {% endblock %}

--- a/app/views/parent/form/previous-dose.njk
+++ b/app/views/parent/form/previous-dose.njk
@@ -1,0 +1,73 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("consent.previousDose.title", session.programmes[0].nameSentenceCase) %}
+
+{% block form %}
+  {{ appHeading({
+    title: title
+  }) }}
+
+  {{ dateInput({
+    fieldset: {
+      legend: {
+        text: __("consent.previousDose.createdAt.title"),
+        size: "m"
+      }
+    },
+    hint: { text: __("consent.previousDose.createdAt.hint") },
+    decorate: "consent.firstDose.createdAt_"
+  }) }}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        text: __("consent.previousDose.country.title"),
+        size: "m"
+      }
+    },
+    items: [
+      {
+        text: __("consent.previousDose.country.england")
+      },
+      {
+        text: __("consent.previousDose.country.scotland")
+      },
+      {
+        text: __("consent.previousDose.country.wales")
+      },
+      {
+        text: __("consent.previousDose.country.ni")
+      },
+      {
+        divider: "or"
+      },
+      {
+        text: __("consent.previousDose.country.other"),
+        value: "Other",
+        conditional: {
+          html: select({
+            label: { text: __("consent.previousDose.countryOther.title") },
+            items: otherCountryItems(Country, consent.previousDose.countryOther),
+            decorate: "consent.firstDose.countryOther",
+            attributes: {
+              "data-module": "app-autocomplete"
+            }
+          })
+        }
+      }
+    ],
+    decorate: "consent.firstDose.country"
+  }) }}
+
+  {{ input({
+    type: "hidden",
+    value: VaccinationOutcome.AlreadyVaccinated,
+    decorate: "consent.firstDose.outcome"
+  }) }}
+
+  {{ input({
+    type: "hidden",
+    value: session.programmes[0].sequenceDefault,
+    decorate: "consent.firstDose.sequence"
+  }) }}
+{% endblock %}


### PR DESCRIPTION
[MAV-3306](https://nhsd-jira.digital.nhs.uk/browse/MAV-3306)

Following up #244, update the parent consent flow so that, if a parent refuses a vaccination due to their child having previously had it, ask for a (structured) date and country of vaccination. This replaces the current design where we ask for this information as free text.

Unlike the flow for MMR(V), we do not:

- offer this as an initial refusal reason (because we’re not asking for consent for a catch-up)
- ask if the vaccination was given at a child’s age (because this is relevant for flu, and other programmes can start to be administered from a wider age range)

<img width="2400" height="2454" alt="When and where did your child get their HPV vaccination?" src="https://github.com/user-attachments/assets/3c10c656-cd38-4765-842c-e6dc28a7efd5" />

<img width="2400" height="3772" alt="Check and confirm" src="https://github.com/user-attachments/assets/94a42668-f10c-4545-a2b0-e146c8d3831f" />