### PR TITLE
Fix the editing of school sessions

### DIFF
--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -498,11 +498,13 @@ export const sessionController = {
     if (!session) {
       // NB: response.locals.session was set in read()
       session = Session.create(response.locals.session, data.wizard)
-      response.locals.session.vaccinationPeriods.forEach(
-        (vaccinationPeriod) => {
-          ClinicVaccinationPeriod.create(vaccinationPeriod, data.wizard)
-        }
-      )
+      if (session.type === SessionType.Clinic) {
+        response.locals.session.vaccinationPeriods.forEach(
+          (vaccinationPeriod) => {
+            ClinicVaccinationPeriod.create(vaccinationPeriod, data.wizard)
+          }
+        )
+      }
     }
 
     // Set up the transaction metadata that controls how some clinic values are entered
@@ -526,15 +528,17 @@ export const sessionController = {
       }
     }
 
+    // Give access to the data needed for the summaryRows
     response.locals.session = new Session(session, data)
 
-    // Generate summary info for the edit page
-    response.locals.vaccinationPeriodsSummary = getVaccinationPeriodsSummary(
-      session.vaccination_period_ids.map((period_id) =>
-        ClinicVaccinationPeriod.findOne(period_id, data.wizard)
-      ),
-      session.appointmentLength
-    )
+    if (session.type === SessionType.Clinic) {
+      response.locals.vaccinationPeriodsSummary = getVaccinationPeriodsSummary(
+        session.vaccination_period_ids.map((period_id) =>
+          ClinicVaccinationPeriod.findOne(period_id, data.wizard)
+        ),
+        session.appointmentLength
+      )
+    }
 
     // Show back link to session page
     response.locals.back = session.uri

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -94,7 +94,7 @@ export class Session {
     if (this.type === SessionType.Clinic) {
       this.clinic_id = options?.clinic_id
       this.registration = false
-      this.vaccination_period_ids = options?.vaccination_period_ids
+      this.vaccination_period_ids = options?.vaccination_period_ids || []
       this.appointmentLength = options?.appointmentLength
     }
 

--- a/app/views/session/edit.njk
+++ b/app/views/session/edit.njk
@@ -19,9 +19,7 @@
         headingSize: "m"
       },
       rows: summaryRows(session, {
-        type: {
-          href: session.uri + "/edit/type" if session.consentWindow == ConsentWindow.Opening
-        },
+        type: {},
         clinic: {
           href: session.uri + "/edit/clinic"
         },


### PR DESCRIPTION
Restrict iteration of vaccination periods to when we're editing clinic sessions, as the array of IDs was undefined rather than empty.

But also, create an empty array in the Session ctor too, to guard against future issues.

One final change was to prevent changing a school session to a clinic session. I've never known this to work, and it feels a highly unlikely thing to want to do, so let's not offer it. (To be fair, changing school kinda breaks stuff too (leaving children from one school in another school's session), but let's not go there. Hopefully no-one does that.)