### PR TITLE
Update content shown for follow-up consent request

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1683,7 +1683,13 @@ export const en = {
       caption: 'Consent response from {{reply.fullName}}',
       title: 'Follow up refusal',
       decision: {
-        label: 'Does their original decision still stand?'
+        label: 'Has their decision changed after follow-up?',
+        consent: {
+          label: 'Yes – they now consent to the vaccination'
+        },
+        refuse: {
+          label: 'No – they still refuse the vaccination'
+        }
       }
     },
     invalidate: {

--- a/app/views/reply/form/follow-up.njk
+++ b/app/views/reply/form/follow-up.njk
@@ -40,7 +40,13 @@
         text: __("reply.follow-up.decision.label")
       }
     },
-    items: getBooleanItems(),
+    items: [{
+      text: __("reply.follow-up.decision.consent.label"),
+      value: false
+    }, {
+      text: __("reply.follow-up.decision.refuse.label"),
+      value: true
+    }],
     decorate: "decision"
   }) }}
 {% endblock %}


### PR DESCRIPTION
Make the options clearer, and have ‘Yes’ relate to the positive outcome:

<img width="2400" height="2400" alt="Follow up refusal." src="https://github.com/user-attachments/assets/ec950acb-3aed-49a7-86cf-d50026499faf" />
