### PR TITLE
Use action links more consistently

### DIFF
--- a/app/views/consent/match.njk
+++ b/app/views/consent/match.njk
@@ -40,10 +40,9 @@
 
         {{ link(consentPath + "?referrer=" + consentPath + "/match", "View full consent response") | nhsukMarkdown }}
 
-        {{ button({
+        {{ actionLink({
           href: consentPath + "/add",
-          text: __("consent.add.label"),
-          variant: "secondary"
+          text: __("consent.add.label")
         }) }}
       {% endcall %}
     </div>

--- a/app/views/school/sessions.njk
+++ b/app/views/school/sessions.njk
@@ -70,10 +70,9 @@
     view: "sessions"
   }) }}
 
-  {{ button({
+  {{ actionLink({
     text: __("session.new.label"),
-    href: "/sessions/new",
-    variant: "secondary"
+    href: "/sessions/new"
   }) }}
 
   {% if activeSession %}

--- a/app/views/school/show.njk
+++ b/app/views/school/show.njk
@@ -28,14 +28,12 @@
     view: "show"
   }) }}
 
-  {{ button({
+  {{ actionLink({
     href: "/uploads/new?type=" + UploadType.School + "&school_id=" + school.id,
-    text: __("session.upload-class-list.title"),
-    variant: "secondary"
+    text: __("session.upload-class-list.title")
   } if not school.homeOrUnknown else {
     href: school.uri + "/invite-to-clinic",
-    text: __("session.inviteToClinic.label"),
-    variant: "secondary"
+    text: __("session.inviteToClinic.label")
   }) }}
 
   <div class="nhsuk-grid-row">

--- a/app/views/session/_session-activity-summary.njk
+++ b/app/views/session/_session-activity-summary.njk
@@ -20,10 +20,20 @@
   {% set sessionActivityRows = sessionActivityRows | push(sessionActivityRow("record")) %}
 {% endif %}
 
-{{ summaryList({
-  card: {
+{% if sessionActivityRows.length > 0 or session.isCompleted %}
+  {% call card({
     heading: __("session.activity.label"),
     headingLevel: 3
-  },
-  rows: sessionActivityRows | removeLastSummaryBorder
-}) if sessionActivityRows.length > 0 }}
+  }) %}
+    {{ summaryList({
+      rows: sessionActivityRows | removeLastSummaryBorder
+    }) if sessionActivityRows.length > 0 and not session.isCompleted }}
+
+    {{ actionLink({
+      text: __("session.inviteToClinic.label"),
+      href: session.uri + "/invite-to-clinic",
+      variant: "secondary"
+    }) if session.isCompleted }}
+  {% endcall %}
+{% endif %}
+

--- a/app/views/session/show.njk
+++ b/app/views/session/show.njk
@@ -20,44 +20,37 @@
     {% include "session/_session-vaccinated-summary.njk" %}
   {% endif %}
 
-  {% if not session.isUnplanned and not session.isCompleted %}
+  {% if not session.isUnplanned %}
     {% include "session/_session-activity-summary.njk" %}
   {% endif %}
 
-  {{ summaryList({
-    card: {
-      heading: __("session.summary"),
-      headingLevel: 3
-    },
-    rows: summaryRows(session, {
-      location: {},
-      school_id: {},
-      status: {},
-      patients: {},
-      programmes: {},
-      yearGroups: {},
-      consentWindow: {},
-      consentForms: {},
-      mmrConsent: {}
-    })
-  }) }}
-
-  {{ appButtonGroup({
-    buttons: [
-      {
+  {% call card({
+    heading: __("session.summary"),
+    headingLevel: 3,
+    actions: {
+      items: [{
         text: __("session.schedule.title") if session.isUnplanned else __("session.edit.title"),
-        href: session.uri + "/edit",
-        variant: "secondary"
-      },
-      {
-        text: __("session.inviteToClinic.label"),
-        href: session.uri + "/invite-to-clinic",
-        variant: "secondary"
-      } if session.isCompleted
-    ],
-    links: [{
+        href: session.uri + "/edit"
+      }]
+    }
+  }) %}
+    {{ summaryList({
+      rows: summaryRows(session, {
+        location: {},
+        school_id: {},
+        status: {},
+        patients: {},
+        programmes: {},
+        yearGroups: {},
+        consentWindow: {},
+        consentForms: {},
+        mmrConsent: {}
+      })
+    }) }}
+
+    {{ actionLink({
       text: __("session.offline.title"),
       href: session.uri + "/offline"
-    }] if session.isPlanned or session.isActive
-  }) }}
+    }) if session.isPlanned or session.isActive }}
+  {% endcall %}
 {% endblock %}

--- a/app/views/upload/list.njk
+++ b/app/views/upload/list.njk
@@ -16,10 +16,9 @@
   <div class="nhsuk-u-reading-width">
     {{ __("upload.list.introduction") | nhsukMarkdown }}
 
-    {{ button({
+    {{ actionLink({
       text: __("upload.new.label"),
-      href: "/uploads/new",
-      variant: "secondary"
+      href: "/uploads/new"
     }) }}
   </div>
 


### PR DESCRIPTION
Buttons are typically used for submitting data or performing an action, whereas links are used to take you to a new page.

As such, we’ve started using the [action link](https://service-manual.nhs.uk/design-system/components/action-link) component when linking to the start of a journey. This PR uses this component for remaining links that would benefit from this link styling.

- School → Children → **Import class lists**
- School → Children → **Invite to clinic**
- School → Sessions → **Add new session**
- Sessions → Session → **Record offline**
- Sessions → Session → **Send clinic invitations**
- Unmatched responses → Match → **Create new record**
- Uploads → **Upload records**

It also rearranges links on the session overview page to make ‘Record offline’ and ‘Send clinic invitations’ links more prominent, for example for a completed session:

<img width="2400" height="4254" alt="Flu session at Cardinal Wiseman Catholic School." src="https://github.com/user-attachments/assets/322f13bd-8ebd-4cfc-9070-8900bd7d3be9" />
