### PR TITLE
Add contextual hint text for follow-up request based on refusal reason

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -833,7 +833,21 @@ export const en = {
     consultation: {
       title:
         'Would you like a member of the team to contact you to discuss alternative options?',
-      hint: 'For example, it may be possible to vaccinate your child in a community clinic.',
+      hint: {
+        [ReplyRefusal.AlreadyVaccinated]: false,
+        [ReplyRefusal.AlreadyVaccinatedMMR]: false,
+        [ReplyRefusal.Gelatine]:
+          'For example, it may be possible to use a vaccine that does not contain gelatine.',
+        [ReplyRefusal.GelatineMMR]:
+          'For example, it may be possible to use a vaccine that does not contain gelatine.',
+        [ReplyRefusal.GettingElsewhere]: false,
+        [ReplyRefusal.Medical]:
+          'We understand alternatives might not be suitable in some cases.',
+        [ReplyRefusal.Other]: false,
+        [ReplyRefusal.OutsideSchool]:
+          'For example, it may be possible to vaccinate your child in a community clinic.',
+        [ReplyRefusal.Personal]: false
+      },
       label: 'Discuss options',
       yes: 'Yes, I would like someone to contact me',
       no: 'No'

--- a/app/views/parent/form/consultation.njk
+++ b/app/views/parent/form/consultation.njk
@@ -1,6 +1,7 @@
 {% extends "_layouts/form.njk" %}
 
 {% set title = __("consent.consultation.title") %}
+{% set hint = __("consent.consultation.hint." + consent.refusalReason) %}
 
 {% block form %}
   {{ radios({
@@ -12,9 +13,7 @@
         })
       }
     },
-    hint: {
-      text: __("consent.consultation.hint")
-    },
+    hint: { text: hint } if hint,
     items: [{
       text: __("consent.consultation.yes"),
       value: true


### PR DESCRIPTION
This matches what was recently changed in production.