### PR TITLE
Make ‘Follow-up requested’ a sub-status ‘Has refusal’

### DIFF
--- a/app/enums.js
+++ b/app/enums.js
@@ -331,8 +331,7 @@ export const PatientConsentStatus = {
   Scheduled: 'Request scheduled',
   NoDetails: 'No contact details',
   NotDelivered: 'Request failed',
-  NoResponse: 'No response',
-  FollowUp: 'Follow-up requested'
+  NoResponse: 'No response'
 }
 
 /**
@@ -352,6 +351,7 @@ export const PatientDueStatus = {
  */
 export const PatientRefusedStatus = {
   Conflict: 'Conflicting consent',
+  FollowUp: 'Follow-up requested',
   Refusal: 'Consent refused'
 }
 

--- a/app/globals.js
+++ b/app/globals.js
@@ -435,8 +435,8 @@ export default () => {
       },
       followUp: {
         view: 'report',
-        key: 'patientConsent',
-        value: PatientConsentStatus.FollowUp
+        key: 'patientRefused',
+        value: PatientRefusedStatus.FollowUp
       },
       resolveConsent: {
         view: 'report',

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -43,7 +43,6 @@ import {
 import {
   getConsentOutcomeStatus,
   getInstructionOutcomeStatus,
-  getPatientConsentStatus,
   getRegistrationStatus,
   getScreenOutcomeStatus,
   getVaccinationOutcomeStatus
@@ -492,7 +491,7 @@ export class PatientSession {
       case ConsentOutcome.NoResponse:
         return PatientConsentStatus.NoResponse
       case ConsentOutcome.Declined:
-        return PatientConsentStatus.FollowUp
+        return PatientRefusedStatus.FollowUp
       case ConsentOutcome.Refused:
         return PatientRefusedStatus.Refusal
     }
@@ -537,6 +536,8 @@ export class PatientSession {
     switch (this.consent) {
       case ConsentOutcome.Inconsistent:
         return PatientRefusedStatus.Conflict
+      case ConsentOutcome.Declined:
+        return PatientRefusedStatus.FollowUp
       case ConsentOutcome.Refused:
       case ConsentOutcome.FinalRefusal:
         return PatientRefusedStatus.Refusal
@@ -828,7 +829,6 @@ export class PatientSession {
   get status() {
     return {
       consent: getConsentOutcomeStatus(this.consent),
-      patientConsent: getPatientConsentStatus(this.patientConsent),
       screen: getScreenOutcomeStatus(this.screen),
       instruct: getInstructionOutcomeStatus(this.instruct),
       register: getRegistrationStatus(this.register),
@@ -855,8 +855,7 @@ export class PatientSession {
 
     return {
       programme: this.programme?.nameTag,
-      consent: formatTag(this.status.consent),
-      patientConsent: formatTag(this.status.patientConsent),
+      consent: this.consent && formatTag(this.status.consent),
       screen: this.screen && formatTag(this.status.screen),
       instruct: this.session?.psdProtocol && formatTag(this.status.instruct),
       register: formatTag(this.status.register),

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -162,11 +162,19 @@ export const getReportOutcome = (patientSession) => {
     [
       ConsentOutcome.NotDelivered,
       ConsentOutcome.NoResponse,
-      ConsentOutcome.NoResponse,
-      ConsentOutcome.Declined
+      ConsentOutcome.NoResponse
     ].includes(patientSession.consent)
   ) {
     return PatientStatus.Consent
+  } else if (
+    [
+      ConsentOutcome.Declined,
+      ConsentOutcome.Inconsistent,
+      ConsentOutcome.Refused,
+      ConsentOutcome.FinalRefusal
+    ].includes(patientSession.consent)
+  ) {
+    return PatientStatus.Refused
   }
 
   return PatientStatus.Ineligible

--- a/app/utils/status.js
+++ b/app/utils/status.js
@@ -19,7 +19,6 @@ import {
  */
 export function getConsentOutcomeStatus(consent) {
   let colour
-  let icon
   switch (consent) {
     case ConsentOutcome.NoResponse:
       colour = 'grey'
@@ -27,32 +26,26 @@ export function getConsentOutcomeStatus(consent) {
     case ConsentOutcome.NotDelivered:
     case ConsentOutcome.Inconsistent:
       colour = 'orange'
-      icon = 'cross'
       break
     case ConsentOutcome.Given:
     case ConsentOutcome.GivenForAlternativeInjection:
     case ConsentOutcome.GivenForIntranasal:
       colour = 'green'
-      icon = 'tick'
       break
     case ConsentOutcome.Declined:
       colour = 'yellow'
-      icon = 'info'
       break
     case ConsentOutcome.Refused:
       colour = 'red'
-      icon = 'cross'
       break
     case ConsentOutcome.FinalRefusal:
       colour = 'red'
-      icon = 'cross'
       break
     default:
   }
 
   return {
     colour,
-    icon,
     text: consent
   }
 }
@@ -76,39 +69,6 @@ export function getDownloadStatus(status) {
   return {
     colour,
     text: status
-  }
-}
-
-/**
- * Get consent outcome status properties
- *
- * @param {PatientConsentStatus} patientConsent - Patient consent status
- * @returns {object} Status properties
- */
-export function getPatientConsentStatus(patientConsent) {
-  let colour
-  let text = patientConsent
-  switch (patientConsent) {
-    case PatientConsentStatus.NoResponse:
-    case PatientConsentStatus.NotScheduled:
-    case PatientConsentStatus.Scheduled:
-      colour = 'grey'
-      break
-    case PatientConsentStatus.NoDetails:
-    case PatientConsentStatus.NotDelivered:
-      colour = 'orange'
-      break
-    case ConsentOutcome.Refused:
-      colour = 'red'
-      break
-    default:
-      text = ConsentOutcome.Given
-      colour = 'green'
-  }
-
-  return {
-    colour,
-    text
   }
 }
 

--- a/app/utils/status.js
+++ b/app/utils/status.js
@@ -2,7 +2,6 @@ import {
   ConsentOutcome,
   DownloadStatus,
   InstructionOutcome,
-  PatientConsentStatus,
   PatientStatus,
   RegistrationOutcome,
   ReplyDecision,
@@ -98,9 +97,6 @@ export function getPatientConsentStatus(patientConsent) {
     case PatientConsentStatus.NoDetails:
     case PatientConsentStatus.NotDelivered:
       colour = 'orange'
-      break
-    case PatientConsentStatus.FollowUp:
-      colour = 'yellow'
       break
     case ConsentOutcome.Refused:
       colour = 'red'


### PR DESCRIPTION
[MAV-6744](https://nhsd-jira.digital.nhs.uk/browse/MAV-6744)

Parents who select certain refusal reasons (Vaccine contains gelatine, Medical reasons, Personal choice, Other) are asked ‘Would you like a member of the team to contact you to discuss alternative options?’. Where a parent selects ‘yes’, the child is given a sub-status of ‘Follow-up requested’. 

Currently, this is a sub-status of ‘Needs consent’, but it would be more logical to make it a sub-status of ‘Has a refusal’, since the parent can only request follow-up when they refuse the vaccine.