### PR TITLE
Clinic invites: new patient filter and invite-to-clinic pages

### DIFF
--- a/app/controllers/consent.js
+++ b/app/controllers/consent.js
@@ -153,13 +153,14 @@ export const consentController = {
     const patientSession = PatientSession.create(
       {
         patient_uuid: patient.uuid,
+        programme_id: consent.programme_id,
         session_id: consent.session_id
       },
       data
     )
 
     // Add to session
-    patient.addToSession(patientSession.session)
+    patient.addToSession(patientSession)
 
     // Invite parent to give consent
     patient.requestConsent(patientSession)

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -285,13 +285,10 @@ export const patientSessionController = {
   },
 
   invite(request, response) {
-    const { account } = request.app.locals
     const { __, back, patient, patientSession } = response.locals
 
-    patient.requestConsent({
-      patientSession,
-      createdBy_uid: account.uid
-    })
+    patient.addToSession(patientSession)
+    patient.requestConsent(patientSession)
 
     request.flash(
       'success',

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -220,7 +220,7 @@ export const patientController = {
     }))
 
     // Clean up session data
-    delete data.invitedToClinic
+    delete data.clinicStatus
     delete data.option
     delete data.patientConsent
     delete data.patientDeferred
@@ -425,10 +425,11 @@ export const patientController = {
       clinicProgramme_ids = stringToArray(clinicProgramme_ids)
     }
 
-    // TODO: Record the invitation in audit events?
-
     // Update the record of programmes for which the patient's been invited to clinic
     const patient = Patient.update(patient_uuid, { clinicProgramme_ids }, data)
+
+    // Send comms to parents and record in audit trail
+    patient.inviteToClinic(clinicProgramme_ids)
 
     // Report the success
     const formatter = new Intl.ListFormat('en', {

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 
 import {
   ArchiveRecordReason,
+  PatientClinicStatus,
   PatientStatus,
   ProgrammeType,
   SessionPresetName,
@@ -18,7 +19,7 @@ import {
 } from '../models.js'
 import { today } from '../utils/date.js'
 import { getResults, getPagination } from '../utils/pagination.js'
-import { formatYearGroup } from '../utils/string.js'
+import { formatYearGroup, stringToArray } from '../utils/string.js'
 
 export const patientController = {
   read(request, response, next, patient_uuid) {
@@ -233,7 +234,35 @@ export const patientController = {
   },
 
   show(request, response) {
+    const { patient } = response.locals
     const view = request.params.view || 'show'
+
+    if (view === 'invite-to-clinic') {
+      // Order the clinic-ready programmes alphabetically
+      response.locals.clinicReadyProgrammes = Object.values(patient.programmes)
+        .filter(
+          ({ clinicStatus }) => clinicStatus === PatientClinicStatus.Ready
+        )
+        .sort((a, b) => a.programme_id.localeCompare(b.programme_id))
+
+      // Warn about inviting to any programmes that don't have clinics scheduled
+      const programmesWithoutClinics =
+        response.locals.clinicReadyProgrammes.filter(
+          (patientProgramme) => patientProgramme.scheduledClinicCount === 0
+        )
+      const formatter = new Intl.ListFormat('en', {
+        style: 'long',
+        type: 'disjunction'
+      })
+      response.locals.clinicReadyProgrammesWithoutClinics = {
+        count: programmesWithoutClinics.length,
+        names: formatter.format(
+          programmesWithoutClinics.map(({ programme }) =>
+            programme.name.replace('Flu', 'flu')
+          )
+        )
+      }
+    }
 
     response.render(`patient/${view}`)
   },
@@ -379,6 +408,45 @@ export const patientController = {
 
   showProgramme(request, response) {
     response.render(`patient/programme`)
+  },
+
+  inviteToClinic(request, response) {
+    const { patient_uuid } = request.params
+    const { data } = request.session
+    const { __ } = response.locals
+
+    // Strip any _unchecked value from the selected programme IDs
+    let { clinicProgramme_ids } = request.body
+    if (typeof clinicProgramme_ids === 'string') {
+      clinicProgramme_ids = [clinicProgramme_ids]
+    } else {
+      clinicProgramme_ids = stringToArray(clinicProgramme_ids)
+    }
+
+    // TODO: Record the invitation in audit events?
+
+    // Update the record of programmes for which the patient's been invited to clinic
+    const patient = Patient.update(patient_uuid, { clinicProgramme_ids }, data)
+
+    // Report the success
+    const formatter = new Intl.ListFormat('en', {
+      style: 'long',
+      type: 'conjunction'
+    })
+    const selectedProgrammeNames = formatter.format(
+      clinicProgramme_ids.map((programme_id) =>
+        Programme.findOne(programme_id, data)?.name?.replace('Flu', 'flu')
+      )
+    )
+    request.flash(
+      'success',
+      __('patient.inviteToClinic.success', {
+        patientName: patient.firstName,
+        selectedProgrammes: selectedProgrammeNames
+      })
+    )
+
+    response.redirect(patient.uri)
   },
 
   archive(request, response) {

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -458,6 +458,10 @@ export const patientController = {
       data
     )
 
+    patient.addToSession(createdPatientSession)
+
+    Patient.update(patient.uuid, { clinicProgramme_ids: [programme_id] }, data)
+
     const patientSession = PatientSession.findOne(
       createdPatientSession.uuid,
       data

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -65,8 +65,7 @@ export const patientController = {
   },
 
   readAll(request, response, next) {
-    const { invitedToClinic, option, programme_id, q, yearGroup } =
-      request.query
+    const { option, programme_id, q, yearGroup } = request.query
     const { data } = request.session
 
     const programmes = Programme.findAll(data)
@@ -103,6 +102,7 @@ export const patientController = {
     // Filter defaults
     const filters = {
       report: request.query.report || 'none',
+      clinicStatus: request.query.clinicStatus || 'none',
       patientConsent: request.query.patientConsent || 'none',
       patientDeferred: request.query.patientDeferred || 'none',
       patientRefused: request.query.patientRefused || 'none',
@@ -120,17 +120,25 @@ export const patientController = {
       )
     }
 
-    // Filter by programme clinic invitations
-    if (programme_id && invitedToClinic === 'true') {
-      results = results.filter(
-        (patient) => patient.programmes[programme_id]?.invitedToClinic
-      )
-    } else if (invitedToClinic === 'true') {
-      results = results.filter((patient) =>
-        Object.values(patient.programmes).some(
-          (programme) => programme.invitedToClinic
+    // Filter by programme clinic status
+    if (filters.clinicStatus && filters.clinicStatus !== 'none') {
+      if (programme_id) {
+        // Patient must have the selected clinic status for any of the selected programmes (if
+        // there's a selected programme), or for *any* programme if not
+        results = results.filter((patient) =>
+          programme_ids.some(
+            (programme_id) =>
+              patient.programmes[programme_id]?.clinicStatus ===
+              filters.clinicStatus
+          )
         )
-      )
+      } else {
+        results = results.filter((patient) =>
+          Object.values(patient.programmes).some(
+            (programme) => programme.clinicStatus === filters.clinicStatus
+          )
+        )
+      }
     }
 
     // Filter by status
@@ -238,7 +246,7 @@ export const patientController = {
     const params = new URLSearchParams()
 
     // Radios and text inputs
-    for (const key of ['q', 'report']) {
+    for (const key of ['q', 'report', 'clinicStatus']) {
       const value = request.body[key]
       if (value) {
         params.append(key, String(value))
@@ -247,7 +255,6 @@ export const patientController = {
 
     // Checkboxes
     for (const key of [
-      'invitedToClinic',
       'option',
       'patientConsent',
       'patientDeferred',

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -123,6 +123,8 @@ export const patientController = {
 
     // Filter by programme clinic status
     if (filters.clinicStatus && filters.clinicStatus !== 'none') {
+      response.locals.showingClinicReady =
+        filters.clinicStatus === PatientClinicStatus.Ready
       if (programme_id) {
         // Patient must have the selected clinic status for any of the selected programmes (if
         // there's a selected programme), or for *any* programme if not

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -6,6 +6,7 @@ import {
   PatientStatus,
   ProgrammeType,
   SessionPresetName,
+  SessionStatus,
   SessionType,
   VaccinationOutcome
 } from '../enums.js'
@@ -19,6 +20,11 @@ import {
 } from '../models.js'
 import { today } from '../utils/date.js'
 import { getResults, getPagination } from '../utils/pagination.js'
+import {
+  ConjunctionType,
+  programmeNamesListForSentence
+} from '../utils/programme.js'
+import { queryToQueryString } from '../utils/querystring.js'
 import { formatYearGroup, stringToArray } from '../utils/string.js'
 
 export const patientController = {
@@ -122,12 +128,12 @@ export const patientController = {
     }
 
     // Filter by programme clinic status
+    let showingClinicReady = false
     if (filters.clinicStatus && filters.clinicStatus !== 'none') {
-      response.locals.showingClinicReady =
-        filters.clinicStatus === PatientClinicStatus.Ready
+      showingClinicReady = filters.clinicStatus === PatientClinicStatus.Ready
+      // Patient must have the selected clinic status for any of the selected programmes (if
+      // there's a selected programme), or for *any* programme if not
       if (programme_id) {
-        // Patient must have the selected clinic status for any of the selected programmes (if
-        // there's a selected programme), or for *any* programme if not
         results = results.filter((patient) =>
           programme_ids.some(
             (programme_id) =>
@@ -202,8 +208,13 @@ export const patientController = {
 
     // Results
     response.locals.patients = patients
+    response.locals.showingClinicReady = showingClinicReady
+    if (showingClinicReady) {
+      data.clinicPatient_ids = results.map(({ uuid }) => uuid)
+    }
     response.locals.results = getResults(results, request.query)
     response.locals.pages = getPagination(results, request.query)
+    response.locals.query = request.query
 
     // Programme filter options
     response.locals.programmeItems = programmes.map((programme) => ({
@@ -412,7 +423,7 @@ export const patientController = {
     response.render(`patient/programme`)
   },
 
-  inviteToClinic(request, response) {
+  inviteOneToClinic(request, response) {
     const { patient_uuid } = request.params
     const { data } = request.session
     const { __ } = response.locals
@@ -425,21 +436,16 @@ export const patientController = {
       clinicProgramme_ids = stringToArray(clinicProgramme_ids)
     }
 
-    // Update the record of programmes for which the patient's been invited to clinic
-    const patient = Patient.update(patient_uuid, { clinicProgramme_ids }, data)
-
     // Send comms to parents and record in audit trail
+    const patient = Patient.findOne(patient_uuid, data)
     patient.inviteToClinic(clinicProgramme_ids)
+    Patient.update(patient.uuid, patient, data)
 
     // Report the success
-    const formatter = new Intl.ListFormat('en', {
-      style: 'long',
-      type: 'conjunction'
-    })
-    const selectedProgrammeNames = formatter.format(
-      clinicProgramme_ids.map((programme_id) =>
-        Programme.findOne(programme_id, data)?.name?.replace('Flu', 'flu')
-      )
+    const selectedProgrammeNames = programmeNamesListForSentence(
+      clinicProgramme_ids,
+      ConjunctionType.and,
+      data
     )
     request.flash(
       'success',
@@ -450,6 +456,148 @@ export const patientController = {
     )
 
     response.redirect(patient.uri)
+  },
+
+  showInviteManyToClinic(request, response) {
+    const { __, __mf } = response.locals
+    const { data } = request.session
+    const { clinicPatient_ids } = data
+    const { programme_id } = request.query
+
+    const programmes = Programme.findAll(data)
+      .filter((programme) => !programme.hidden)
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    let programme_ids
+    if (programme_id) {
+      programme_ids = Array.isArray(programme_id)
+        ? programme_id
+        : [programme_id]
+    } else {
+      programme_ids = programmes.map(({ id }) => id)
+    }
+
+    // e.g. 271 children can be invited to clinic for HPV, MenACWY, or Td/IPV programmes.
+    const childrenFragment = __mf(
+      'patient.bulkInviteToClinic.childrenFragment',
+      { count: clinicPatient_ids.length }
+    )
+    const programmesFragment = programme_id
+      ? __mf('patient.bulkInviteToClinic.programmesFragment', {
+          count: programme_ids.length,
+          programmeNames: programmeNamesListForSentence(
+            programme_ids,
+            ConjunctionType.or,
+            data
+          )
+        })
+      : __('patient.bulkInviteToClinic.anyProgrammesFragment')
+    response.locals.cohortSummary = __(
+      'patient.bulkInviteToClinic.cohortSummary',
+      { children: childrenFragment, programmes: programmesFragment }
+    )
+
+    // Create the programme checkboxes and their patient and clinic counts
+    const checkboxItems = []
+    const scheduledSessions = Session.findAll(data)
+      .filter(({ type }) => type === SessionType.Clinic)
+      .filter(({ status }) => status === SessionStatus.Planned)
+    const invitableProgrammes = programmes.filter((programme) =>
+      programme_ids.includes(programme.id)
+    )
+    for (const programme of invitableProgrammes) {
+      const clinicReadyChildrenCount = clinicPatient_ids
+        .map((id) => Patient.findOne(id, data))
+        .filter(
+          (patient) =>
+            patient.programmes[programme.id].clinicStatus ===
+            PatientClinicStatus.Ready
+        ).length
+      if (clinicReadyChildrenCount > 0) {
+        const scheduledClinicCount = scheduledSessions.filter((session) =>
+          session.programme_ids.includes(programme.id)
+        ).length
+
+        const childrenHint = __mf(
+          'patient.bulkInviteToClinic.programme.hint.children',
+          {
+            count: clinicReadyChildrenCount,
+            programmeName: programme.name
+          }
+        )
+        const clinicsHint = __mf(
+          'patient.bulkInviteToClinic.programme.hint.clinics',
+          {
+            count: scheduledClinicCount,
+            programmeName: programme.name
+          }
+        )
+        checkboxItems.push({
+          text: programme.name,
+          value: programme.id,
+          hint: {
+            html: __('patient.bulkInviteToClinic.programme.hint.combined', {
+              childrenHint,
+              clinicsHint
+            })
+          }
+        })
+      }
+    }
+
+    response.locals.checkboxItems = checkboxItems
+
+    response.render('patient/bulk-invite-to-clinic')
+  },
+
+  inviteManyToClinic(request, response) {
+    let { clinicProgramme_ids } = request.body
+    const { __mf } = response.locals
+    const { data } = request.session
+    const { clinicPatient_ids } = data
+
+    // Tidy up any _unchecked values
+    if (typeof clinicProgramme_ids === 'string') {
+      clinicProgramme_ids = [clinicProgramme_ids]
+    } else {
+      clinicProgramme_ids = stringToArray(clinicProgramme_ids)
+    }
+
+    // Invite each of the children to clinic for the subset of the selected programmes
+    // that make sense for that child
+    let invitedChildrenCount = 0
+    for (const patient of clinicPatient_ids.map((id) =>
+      Patient.findOne(id, data)
+    )) {
+      // Work out which of the selected programmes this patient was clinic-ready for
+      const { clinicReadyProgramme_ids } = patient
+      const invitedProgramme_ids = [
+        ...new Set(clinicReadyProgramme_ids).intersection(
+          new Set(clinicProgramme_ids)
+        )
+      ]
+
+      if (invitedProgramme_ids.length) {
+        // Send comms to parents and record in audit trail
+        patient.inviteToClinic(invitedProgramme_ids)
+        Patient.update(patient.uuid, patient, data)
+
+        invitedChildrenCount++
+      }
+    }
+
+    request.flash(
+      'success',
+      __mf('patient.bulkInviteToClinic.success', {
+        count: invitedChildrenCount
+      })
+    )
+
+    // Reset the cohort
+    delete data.clinicPatient_ids
+
+    // Get back to the filter page as we left it
+    response.redirect(`/patients${queryToQueryString(request.query)}`)
   },
 
   archive(request, response) {

--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -473,23 +473,20 @@ export const schoolController = {
     const school = School.findOne(school_id, data)
 
     // Find patients to invite to clinic
-    const patientSessionsForClinic = school.patients.map(
-      (patient) => patient.uuid
-    )
+    const patient_uuids = school.patients.map((patient) => patient.uuid)
 
     // Invite parents to book into a clinic
-    for (const patient of school.patients) {
-      const clinicProgramme_ids = request.body.clinicProgramme_ids.filter(
-        (item) => item !== '_unchecked'
-      )
-
-      Patient.update(patient.uuid, { clinicProgramme_ids }, data)
+    const clinicProgramme_ids = request.body.clinicProgramme_ids.filter(
+      (item) => item !== '_unchecked'
+    )
+    for (const patient_uuid of patient_uuids) {
+      Patient.update(patient_uuid, { clinicProgramme_ids }, data)
     }
 
     request.flash(
       'success',
       __mf(`school.inviteToClinic.success`, {
-        count: patientSessionsForClinic.length
+        count: patient_uuids.length
       })
     )
 

--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -93,8 +93,7 @@ export const schoolController = {
   },
 
   readPatients(request, response, next) {
-    const { invitedToClinic, option, programme_id, q, yearGroup } =
-      request.query
+    const { option, programme_id, q, yearGroup } = request.query
     const { data } = request.session
     const { school } = response.locals
 
@@ -126,6 +125,7 @@ export const schoolController = {
     // Filter defaults
     const filters = {
       report: request.query.report || 'none',
+      clinicStatus: request.query.clinicStatus || 'none',
       patientConsent: request.query.patientConsent || 'none',
       patientDeferred: request.query.patientDeferred || 'none',
       patientRefused: request.query.patientRefused || 'none',
@@ -143,17 +143,23 @@ export const schoolController = {
       )
     }
 
-    // Filter by programme clinic invitations
-    if (programme_id && invitedToClinic === 'true') {
-      results = results.filter(
-        (patient) => patient.programmes[programme_id]?.invitedToClinic
-      )
-    } else if (invitedToClinic === 'true') {
-      results = results.filter((patient) =>
-        Object.values(patient.programmes).some(
-          (programme) => programme.invitedToClinic
+    // Filter by programme clinic status
+    if (filters.clinicStatus && filters.clinicStatus !== 'none') {
+      if (programme_id) {
+        results = results.filter((patient) =>
+          programme_ids.some(
+            (programme_id) =>
+              patient.programmes[programme_id]?.clinicStatus ===
+              filters.clinicStatus
+          )
         )
-      )
+      } else {
+        results = results.filter((patient) =>
+          Object.values(patient.programmes).some(
+            (programme) => programme.clinicStatus === filters.clinicStatus
+          )
+        )
+      }
     }
 
     // Filter by status
@@ -234,7 +240,7 @@ export const schoolController = {
     }))
 
     // Clean up session data
-    delete data.invitedToClinic
+    delete data.clinicStatus
     delete data.option
     delete data.patientConsent
     delete data.patientDeferred
@@ -255,7 +261,7 @@ export const schoolController = {
     const params = new URLSearchParams()
 
     // Radios and text inputs
-    for (const key of ['q', 'report']) {
+    for (const key of ['q', 'report', 'clinicStatus']) {
       const value = request.body[key]
       if (value) {
         params.append(key, String(value))
@@ -264,7 +270,6 @@ export const schoolController = {
 
     // Checkboxes
     for (const key of [
-      'invitedToClinic',
       'option',
       'patientConsent',
       'patientDeferred',

--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -485,7 +485,9 @@ export const schoolController = {
       (item) => item !== '_unchecked'
     )
     for (const patient_uuid of patient_uuids) {
-      Patient.update(patient_uuid, { clinicProgramme_ids }, data)
+      const patient = Patient.findOne(patient_uuid, data)
+      patient.inviteToClinic(clinicProgramme_ids)
+      Patient.update(patient_uuid, patient, data)
     }
 
     request.flash(

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -294,6 +294,7 @@ export const sessionController = {
       instruct: request.query.instruct || 'none',
       register: request.query.register || 'none',
       report: request.query.report || 'none',
+      clinicStatus: request.query.clinicStatus || 'none',
       patientConsent: request.query.patientConsent || 'none',
       patientDeferred: request.query.patientDeferred || 'none',
       patientRefused: request.query.patientRefused || 'none',
@@ -453,7 +454,7 @@ export const sessionController = {
     const params = new URLSearchParams()
 
     // Radios
-    for (const key of ['q', 'instruct', 'register', 'report']) {
+    for (const key of ['q', 'clinicStatus', 'instruct', 'register', 'report']) {
       const value = request.body[key]
       if (value) {
         params.append(key, String(value))

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -819,22 +819,35 @@ export const sessionController = {
       )
 
     // Find patients to invite to clinic
-    const patientUuidsForClinic = session.patientSessionsForClinic.map(
-      (patient) => patient.uuid
+    const patientSessionUuidsForClinic = session.patientSessionsForClinic.map(
+      (patientSession) => patientSession.uuid
     )
 
     if (clinic) {
       // Move patients to clinic
-      for (const patientUuid of patientUuidsForClinic) {
-        const patientSession = PatientSession.findOne(patientUuid, data)
+      for (const patientSessionUuid of patientSessionUuidsForClinic) {
+        const patientSession = PatientSession.findOne(patientSessionUuid, data)
 
         if (patientSession) {
           patientSession.removeFromSession({
             createdBy_uid: account.uid
           })
-          patientSession.patient.addToSession(patientSession.session)
+          const clinicPatientSession = PatientSession.create(
+            {
+              createdBy_uid: account.uid,
+              patient_uuid: patientSession.patient_uuid,
+              programme_id: patientSession.programme_id,
+              session_id
+            },
+            data
+          )
+          patientSession.patient.addToSession(clinicPatientSession)
 
-          Patient.update(patientSession.patient_uuid, {}, data)
+          Patient.update(
+            patientSession.patient_uuid,
+            { clinicProgramme_ids: clinic.programme_ids },
+            data
+          )
         }
       }
     }
@@ -842,7 +855,7 @@ export const sessionController = {
     request.flash(
       'success',
       __mf(`session.inviteToClinic.success`, {
-        count: patientUuidsForClinic.length
+        count: patientSessionUuidsForClinic.length
       })
     )
 

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -833,7 +833,7 @@ export const sessionController = {
           patientSession.removeFromSession({
             createdBy_uid: account.uid
           })
-          const clinicPatientSession = PatientSession.create(
+          let clinicPatientSession = PatientSession.create(
             {
               createdBy_uid: account.uid,
               patient_uuid: patientSession.patient_uuid,
@@ -842,6 +842,7 @@ export const sessionController = {
             },
             data
           )
+          clinicPatientSession = new PatientSession(clinicPatientSession, data)
           patientSession.patient.addToSession(clinicPatientSession)
 
           Patient.update(

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -845,11 +845,9 @@ export const sessionController = {
           clinicPatientSession = new PatientSession(clinicPatientSession, data)
           patientSession.patient.addToSession(clinicPatientSession)
 
-          Patient.update(
-            patientSession.patient_uuid,
-            { clinicProgramme_ids: clinic.programme_ids },
-            data
-          )
+          const patient = Patient.findOne(patientSession.patient_uuid, data)
+          patient.inviteToClinic(clinic.programme_ids)
+          Patient.update(patient.uuid, patient, data)
         }
       }
     }

--- a/app/enums.js
+++ b/app/enums.js
@@ -339,6 +339,18 @@ export const PatientStatus = {
  * @readonly
  * @enum {string}
  */
+export const PatientClinicStatus = {
+  Ready: 'Can be invited',
+  Invited: 'Invited',
+  Booked: 'Booked in',
+  Registered: 'Attending',
+  Completed: 'Attended'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
 export const PatientConsentStatus = {
   NotScheduled: 'No request scheduled',
   Scheduled: 'Request scheduled',

--- a/app/filters.js
+++ b/app/filters.js
@@ -2,6 +2,7 @@ import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 import _ from 'lodash'
 
 import { ordinal } from './utils/number.js'
+import { queryToQueryString } from './utils/querystring.js'
 import {
   formatHighlight,
   formatList,
@@ -181,6 +182,16 @@ export default (env) => {
    */
   filters.removeEmpty = (array) => {
     return array.filter((item) => item !== '')
+  }
+
+  /**
+   * Rebuild the querystring from the request.query object
+   *
+   * @param {object} query - the request.query object
+   * @returns {string} - the rebuilt query string
+   */
+  filters.asQueryString = function (query) {
+    return queryToQueryString(query)
   }
 
   return filters

--- a/app/globals.js
+++ b/app/globals.js
@@ -259,22 +259,24 @@ export default () => {
    *
    * @param {object} Enum - Enumerable name
    * @param {string} selected - Selected value
+   * @param {boolean} sorted - true to sort the values alphabetically, false to preserve enum order
    * @returns {object} Radio items
    */
-  globals.radioFilterItems = function (Enum, selected) {
+  globals.radioFilterItems = function (Enum, selected, sorted = true) {
+    const values = sorted
+      ? Object.values(Enum).sort((a, b) => a.localeCompare(b))
+      : Object.values(Enum)
     return [
       {
         text: 'Any',
         value: 'none',
         checked: !selected || selected === 'none'
       },
-      ...Object.values(Enum)
-        .sort((a, b) => a.localeCompare(b))
-        .map((value) => ({
-          text: value,
-          value,
-          checked: value === selected
-        }))
+      ...values.map((value) => ({
+        text: value,
+        value,
+        checked: value === selected
+      }))
     ]
   }
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1334,27 +1334,27 @@ export const en = {
       title: {
         multiple:
           'Which programmes do you want to send a clinic booking invitation for?',
-        single:
-          'Send a clinic booking invitation for {{firstName}} {{lastName}}'
+        single: {
+          clinicsScheduled:
+            'Send a clinic booking invitation for {{firstName}} {{lastName}}',
+          noClinicsScheduled:
+            'Are you sure you want to send a clinic booking invitation for {{firstName}} {{lastName}}?'
+        }
       },
       clinicCount: {
         hint: '{count, plural, =0 {No clinics are scheduled for {programmeName}} one {1 clinic is scheduled for {programmeName}} other {# clinics are scheduled for {programmeName}}}',
-        paragraph:
-          '{count, plural, one {There is 1 clinic scheduled for the {programmeName} programme.} other {There are # clinics scheduled for the {programmeName} programme.}}'
+        someParagraph:
+          '{count, plural, one {There is 1 clinic scheduled for the {programmeName} programme.} other {There are # clinics scheduled for the {programmeName} programme.}}',
+        noneParagraph:
+          'No clinics are scheduled for the {{programmeName}} programme. Only send an invitation if you can offer {{programmeName}} alongside other vaccinations.'
       },
       scheduledClinicWarning: {
-        multiple: {
-          title: 'Programmes without clinics',
-          description:
-            '{count, plural, one {No clinics are scheduled for <b>{programmeNames}</b> vaccinations. Only select this option if you’re able to offer it as a catch-up alongside other vaccinations.} other {No clinics are scheduled for <b>{programmeNames}</b> vaccinations. Only select these options if you’re able to offer them as a catch-up alongside other vaccinations.}}'
-        },
-        single: {
-          title: 'Programmes without clinics',
-          description:
-            '{count, plural, one {No clinics are scheduled for <b>{programmeNames}</b> vaccinations. Only send an invitation if you’re able to offer it as a catch-up alongside other vaccinations.} other {No clinics are scheduled for <b>{programmeNames}</b> vaccinations. Only send an invitation if you’re able to offer them as a catch-up alongside other vaccinations.}}'
-        }
+        title: 'Programmes without clinics',
+        description:
+          '{count, plural, one {No clinics are scheduled for the <b>{programmeNames}</b> programme. Only select this option if you can offer it alongside other vaccinations.} other {No clinics are scheduled for the <b>{programmeNames}</b> programmes. Only select these options if you can offer them alongside other vaccinations.}}'
       },
       confirm: 'Send clinic invitation',
+      cancel: 'Go back to child record',
       success:
         '{{patientName}} has been invited to attend a clinic for {{selectedProgrammes}} vaccination'
     },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1330,6 +1330,34 @@ export const en = {
         hint: 'This will merge the duplicate records into a single record'
       }
     },
+    inviteToClinic: {
+      title: {
+        multiple:
+          'Which programmes do you want to send a clinic booking invitation for?',
+        single:
+          'Send a clinic booking invitation for {{firstName}} {{lastName}}'
+      },
+      clinicCount: {
+        hint: '{count, plural, =0 {No clinics are scheduled for {programmeName}} one {1 clinic is scheduled for {programmeName}} other {# clinics are scheduled for {programmeName}}}',
+        paragraph:
+          '{count, plural, one {There is 1 clinic scheduled for the {programmeName} programme.} other {There are # clinics scheduled for the {programmeName} programme.}}'
+      },
+      scheduledClinicWarning: {
+        multiple: {
+          title: 'Programmes without clinics',
+          description:
+            '{count, plural, one {No clinics are scheduled for <b>{programmeNames}</b> vaccinations. Only select this option if you’re able to offer it as a catch-up alongside other vaccinations.} other {No clinics are scheduled for <b>{programmeNames}</b> vaccinations. Only select these options if you’re able to offer them as a catch-up alongside other vaccinations.}}'
+        },
+        single: {
+          title: 'Programmes without clinics',
+          description:
+            '{count, plural, one {No clinics are scheduled for <b>{programmeNames}</b> vaccinations. Only send an invitation if you’re able to offer it as a catch-up alongside other vaccinations.} other {No clinics are scheduled for <b>{programmeNames}</b> vaccinations. Only send an invitation if you’re able to offer them as a catch-up alongside other vaccinations.}}'
+        }
+      },
+      confirm: 'Send clinic invitation',
+      success:
+        '{{patientName}} has been invited to attend a clinic for {{selectedProgrammes}} vaccination'
+    },
     auditEvents: {
       label: 'Activity log'
     },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2196,6 +2196,10 @@ export const en = {
   },
   search: {
     label: 'Search',
+    hint: {
+      patient: 'Search by name, NHS number, postcode, and more',
+      session: 'Search by location name or postcode'
+    },
     advanced: 'Advanced filters',
     initial:
       'Search for a child or use filters to see children matching your selection',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1372,8 +1372,12 @@ export const en = {
       label: 'Last reminder sent'
     },
     count: '{count, plural, =0 {No children} one {1 child} other {# children}}',
-    results:
-      '{count, plural, =0 {No children matching your search criteria were found} one {Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> record} other {Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> children}}',
+    results: {
+      summary:
+        '{count, plural, =0 {No children matching your search criteria were found} one {Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> record} other {Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> children}}',
+      inviteToClinic:
+        '{count, plural, one {Invite 1 child to clinic} other {Invite {count} children to clinic}}'
+    },
     search: {
       label: 'Find children',
       dob: 'Child’s date of birth',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1358,6 +1358,31 @@ export const en = {
       success:
         '{{patientName}} has been invited to attend a clinic for {{selectedProgrammes}} vaccination'
     },
+    bulkInviteToClinic: {
+      title: 'Invite parents to book a clinic appointment',
+      caption:
+        '{count, plural, one {1 child selected} other {{count} children selected}}',
+      childrenFragment:
+        '{count, plural, =0 {No children} one {1 child} other {{count} children}}',
+      programmesFragment:
+        '{count, plural, one {the {programmeNames} programme} other {the {programmeNames} programmes}}',
+      anyProgrammesFragment: 'at least one programme',
+      cohortSummary:
+        '{{children}} can be invited to clinic for {{programmes}}.',
+      programme: {
+        label: 'Which programmes do you want to send invitations for?',
+        hint: {
+          children:
+            '{count, plural, one {1 child can be invited for {programmeName}} other {{count} children can be invited for {programmeName}}}',
+          clinics:
+            '{count, plural, =0 {No clinics are scheduled for {programmeName}} one {1 clinic is scheduled for {programmeName}} other {{count} clinics are scheduled for {programmeName}}}',
+          combined: '{{childrenHint}}<br>{{clinicsHint}}'
+        }
+      },
+      confirm: 'Send clinic invitations',
+      success:
+        '{count, plural, one {1 child has been invited to clinic} other {{count} children have been invited to clinic}}'
+    },
     auditEvents: {
       label: 'Activity log'
     },

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -1,15 +1,23 @@
 import { addMonths, addWeeks } from 'date-fns'
 
 import {
+  ConsentOutcome,
+  PatientClinicStatus,
   PatientConsentStatus,
   PatientDueStatus,
   PatientStatus,
-  ProgrammeType
+  ProgrammeType,
+  RegistrationOutcome,
+  ScreenOutcome,
+  SessionStatus,
+  SessionType,
+  VaccinationOutcome
 } from '../enums.js'
 import { AuditEvent, Patient, Programme, Vaccination } from '../models.js'
 import {
   getCurrentAcademicYear,
-  getDateValueDifference
+  getDateValueDifference,
+  today
 } from '../utils/date.js'
 import { ordinal } from '../utils/number.js'
 import { getReportOutcome } from '../utils/patient-session.js'
@@ -137,6 +145,86 @@ export class PatientProgramme {
       this.status !== PatientStatus.Ineligible &&
       this.status !== PatientStatus.Vaccinated
     )
+  }
+
+  /**
+   * Get the patient's clinic status for this programme
+   *
+   * @returns {PatientClinicStatus|boolean} - the patient's clinic status for this programme, or false if clinic not applicable
+   */
+  get clinicStatus() {
+    // Work backwards from the most complete status
+
+    const { lastPatientSession } = this // should we look beyond the last session?
+    if (
+      lastPatientSession &&
+      lastPatientSession.session.type === SessionType.Clinic
+    ) {
+      // Clinic vaccination has already happened?
+      if (lastPatientSession.outcome === VaccinationOutcome.Vaccinated) {
+        return PatientClinicStatus.Completed
+      }
+
+      // Attending a clinic right now?
+      if (lastPatientSession.register === RegistrationOutcome.Present) {
+        return PatientClinicStatus.Registered
+      }
+
+      // For the PatientSession at a clinic to exist, the child must be booked in
+      return PatientClinicStatus.Booked
+    }
+
+    // Invited to a clinic?
+    if (this.invitedToClinic) {
+      return PatientClinicStatus.Invited
+    }
+
+    // Check various disqualifying conditions to see whether the child's ready to invite to clinic...
+    if (lastPatientSession) {
+      const { report, screen, consent, triageNotes } = lastPatientSession
+      // Already vaccinated?
+      if (report === PatientStatus.Vaccinated) {
+        return false
+      }
+      // Triaged as not safe to vaccinate?
+      if (screen === ScreenOutcome.DoNotVaccinate) {
+        return false
+      }
+      // Triaged as needing to delay vaccination and earliest vaccs date not yet passed?
+      if (
+        screen === ScreenOutcome.DelayVaccination &&
+        triageNotes?.at(-1)?.outcomeAt > today()
+      ) {
+        return false
+      }
+      // Refused consent?
+      if (
+        [ConsentOutcome.Refused, ConsentOutcome.FinalRefusal].includes(consent)
+      ) {
+        return false
+      }
+    }
+    // Not old enough for this programme?
+    if (!this.eligible) {
+      return false
+    }
+    // Child's school session for this academic year hasn't happened yet?
+    // (Remember that patient may have only recently moved to the school.)
+    const latestSchoolSession = this.patient?.school?.sessions
+      ?.filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
+      ?.at(-1)
+    if (
+      latestSchoolSession &&
+      ![SessionStatus.Completed, SessionStatus.Closed].includes(
+        latestSchoolSession.status
+      ) &&
+      latestSchoolSession.academicYear === getCurrentAcademicYear()
+    ) {
+      return false
+    }
+
+    // Must be ready to invite, as we've ruled out all disqualifying criteria
+    return PatientClinicStatus.Ready
   }
 
   /**

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -1,14 +1,13 @@
 import { addMonths, addWeeks } from 'date-fns'
 
 import {
-  ConsentOutcome,
   PatientClinicStatus,
   PatientConsentStatus,
+  PatientDeferredStatus,
   PatientDueStatus,
   PatientStatus,
   ProgrammeType,
   RegistrationOutcome,
-  ScreenOutcome,
   SessionStatus,
   SessionType,
   VaccinationOutcome
@@ -185,58 +184,65 @@ export class PatientProgramme {
       return PatientClinicStatus.Invited
     }
 
-    // Check various disqualifying conditions to see whether the child's ready to invite to clinic...
+    // Maybe we *can* vaccinate the child, but there are no school sessions left?
+    if (this.canVaccinateAtClinic && !this.schoolSessionPending) {
+      return PatientClinicStatus.Ready
+    }
 
-    // Not old enough for this programme?
-    if (!this.eligible) {
+    return false
+  }
+
+  /**
+   * Can the child be vaccinated (assuming we get the right consent and triage outcomes, if required)?
+   *
+   * @returns {boolean} - true if it's ok to invite to clinic for a vaccination based on patient status, or false otherwise
+   */
+  get canVaccinateAtClinic() {
+    const { status } = this
+
+    switch (status) {
+      case PatientStatus.Due:
+      case PatientStatus.Triage:
+        return true
+      case PatientStatus.Deferred: {
+        switch (this.lastPatientSession?.patientDeferred) {
+          case PatientDeferredStatus.DoNotVaccinate:
+            return false
+          case PatientDeferredStatus.DelayVaccination: {
+            const firstSafeDate =
+              this.lastPatientSession?.triageNotes?.at(-1)?.outcomeAt
+            return firstSafeDate === undefined || today() > firstSafeDate
+          }
+          default:
+            return true
+        }
+      }
+      case PatientStatus.Consent:
+        return !this.patient?.hasNoContactDetails
+      default:
+        return false
+    }
+  }
+
+  /**
+   * Does the patient still have a chance to get vaccinated at school this academic year?
+   *
+   * @returns {boolean} - true if there's still a chance for school vaccination, or false otherwise
+   */
+  get schoolSessionPending() {
+    const school = this.patient?.school
+    if (school?.homeOrUnknown) {
       return false
     }
-    if (lastPatientSession) {
-      const { report, screen, triageNotes } = lastPatientSession
-      // Already vaccinated?
-      if (report === PatientStatus.Vaccinated) {
-        return false
-      }
-      // Refused consent?
-      if (report === PatientStatus.Refused) {
-        return false
-      }
-      // Need consent, but no contact details?
-      if (
-        report === PatientStatus.Consent &&
-        lastPatientSession.patientConsent === PatientConsentStatus.NoDetails
-      ) {
-        return false
-      }
-      // Triaged as not safe to vaccinate?
-      if (screen === ScreenOutcome.DoNotVaccinate) {
-        return false
-      }
-      // Triaged as needing to delay vaccination and earliest vaccs date not yet passed?
-      if (
-        screen === ScreenOutcome.DelayVaccination &&
-        triageNotes?.at(-1)?.outcomeAt > today()
-      ) {
-        return false
-      }
-    }
-    // Child's school session for this academic year hasn't happened yet?
-    // (Remember that patient may have only recently moved to the school.)
-    const latestSchoolSession = this.patient?.school?.sessions
+
+    const latestSchoolSession = school?.sessions
       ?.filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
       ?.at(-1)
-    if (
-      latestSchoolSession &&
+    return (
       ![SessionStatus.Completed, SessionStatus.Closed].includes(
-        latestSchoolSession.status
-      ) &&
-      latestSchoolSession.academicYear === getCurrentAcademicYear()
-    ) {
-      return false
-    }
-
-    // Must be ready to invite, as we've ruled out all disqualifying criteria
-    return PatientClinicStatus.Ready
+        latestSchoolSession?.status
+      ) && latestSchoolSession?.academicYear === getCurrentAcademicYear()
+    )
   }
 
   /**

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -5,6 +5,7 @@ import {
   PatientConsentStatus,
   PatientDeferredStatus,
   PatientDueStatus,
+  PatientRefusedStatus,
   PatientStatus,
   ProgrammeType,
   RegistrationOutcome,
@@ -219,6 +220,11 @@ export class PatientProgramme {
       }
       case PatientStatus.Consent:
         return !this.patient?.hasNoContactDetails
+      case PatientStatus.Refused:
+        return (
+          this.lastPatientSession?.patientRefused ===
+          PatientRefusedStatus.FollowUp
+        )
       default:
         return false
     }

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -13,7 +13,13 @@ import {
   SessionType,
   VaccinationOutcome
 } from '../enums.js'
-import { AuditEvent, Patient, Programme, Vaccination } from '../models.js'
+import {
+  AuditEvent,
+  Patient,
+  Programme,
+  Session,
+  Vaccination
+} from '../models.js'
 import {
   getCurrentAcademicYear,
   getDateValueDifference,
@@ -225,6 +231,19 @@ export class PatientProgramme {
 
     // Must be ready to invite, as we've ruled out all disqualifying criteria
     return PatientClinicStatus.Ready
+  }
+
+  /**
+   * Get the number of clinics scheduled for this programme
+   *
+   * @returns {number} - the number of scheduled clinics targeting this programme
+   */
+  get scheduledClinicCount() {
+    const scheduledClinics = Session.findAll(this.context)
+      ?.filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
+      ?.filter(({ type }) => type === SessionType.Clinic)
+      ?.filter(({ status }) => status === SessionStatus.Planned)
+    return scheduledClinics?.length || 0
   }
 
   /**

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -186,6 +186,11 @@ export class PatientProgramme {
     }
 
     // Check various disqualifying conditions to see whether the child's ready to invite to clinic...
+
+    // Not old enough for this programme?
+    if (!this.eligible) {
+      return false
+    }
     if (lastPatientSession) {
       const { report, screen, consent, triageNotes } = lastPatientSession
       // Already vaccinated?
@@ -209,10 +214,6 @@ export class PatientProgramme {
       ) {
         return false
       }
-    }
-    // Not old enough for this programme?
-    if (!this.eligible) {
-      return false
     }
     // Child's school session for this academic year hasn't happened yet?
     // (Remember that patient may have only recently moved to the school.)

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -132,7 +132,7 @@ export class PatientProgramme {
    *
    * @returns {boolean} Eligible for vaccination
    */
-  get inviteToSession() {
+  get canInviteToSession() {
     return (
       this.status !== PatientStatus.Ineligible &&
       this.status !== PatientStatus.Vaccinated

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -192,9 +192,20 @@ export class PatientProgramme {
       return false
     }
     if (lastPatientSession) {
-      const { report, screen, consent, triageNotes } = lastPatientSession
+      const { report, screen, triageNotes } = lastPatientSession
       // Already vaccinated?
       if (report === PatientStatus.Vaccinated) {
+        return false
+      }
+      // Refused consent?
+      if (report === PatientStatus.Refused) {
+        return false
+      }
+      // Need consent, but no contact details?
+      if (
+        report === PatientStatus.Consent &&
+        lastPatientSession.patientConsent === PatientConsentStatus.NoDetails
+      ) {
         return false
       }
       // Triaged as not safe to vaccinate?
@@ -205,12 +216,6 @@ export class PatientProgramme {
       if (
         screen === ScreenOutcome.DelayVaccination &&
         triageNotes?.at(-1)?.outcomeAt > today()
-      ) {
-        return false
-      }
-      // Refused consent?
-      if (
-        [ConsentOutcome.Refused, ConsentOutcome.FinalRefusal].includes(consent)
       ) {
         return false
       }

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -17,7 +17,8 @@ import {
   RegistrationOutcome,
   ScreenOutcome,
   VaccinationOutcome,
-  ProgrammeType
+  ProgrammeType,
+  PatientClinicStatus
 } from '../enums.js'
 import {
   AuditEvent,
@@ -306,6 +307,15 @@ export class PatientSession {
     } catch (error) {
       console.error('PatientSession.session', error.message)
     }
+  }
+
+  /**
+   * Get clinic readiness status
+   *
+   * @returns {PatientClinicStatus|undefined} clinic status for our programme
+   */
+  get clinicStatus() {
+    return this.patientProgramme?.clinicStatus
   }
 
   /**

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -34,6 +34,7 @@ import {
   formatOther,
   formatParent,
   formatWithSecondaryText,
+  stringToArray,
   stringToBoolean
 } from '../utils/string.js'
 
@@ -562,6 +563,11 @@ export class Patient extends Child {
    * @static
    */
   static update(uuid, updates, context, log = false) {
+    // Sanitise any checkbox values in the updates
+    if (updates?.clinicProgramme_ids) {
+      updates.clinicProgramme_ids = stringToArray(updates.clinicProgramme_ids)
+    }
+
     const patient = Patient.findOne(uuid, context)
     const updatedPatient = _.merge(Patient.findOne(uuid, context), updates)
 

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -642,9 +642,12 @@ export class Patient extends Child {
   /**
    * Add patient to session
    *
-   * @param {import('./session.js').Session} session - Session
+   * @param {import('./patient-session.js').PatientSession} patientSession - PatientSession
    */
-  addToSession(session) {
+  addToSession(patientSession) {
+    this.patientSession_uuids.push(patientSession.uuid)
+
+    const session = patientSession.session
     this.addEvent({
       name: activity.session.added(session),
       createdAt: session.openAt,
@@ -678,8 +681,6 @@ export class Patient extends Child {
    * @param {import('./patient-session.js').PatientSession} patientSession - Patient session
    */
   requestConsent(patientSession) {
-    this.patientSession_uuids.push(patientSession.uuid)
-
     for (const parent of this.parents) {
       if (parent.email && parent.emailStatus === NotifyEmailStatus.Delivered) {
         this.addEvent({

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -665,18 +665,16 @@ export class Patient extends Child {
   /**
    * Invite parent to book a clinic appointment
    *
-   * @param {import('./session.js').Session} session - Clinic session
+   * @param {Array<string>} programme_ids - The programmes for which the child's invited
    */
-  inviteToClinic(session) {
+  inviteToClinic(programme_ids) {
     for (const parent of this.parents) {
       this.addEvent({
         name: activity.notify['invite-clinic'](parent),
         messageRecipient: parent,
         messageTemplate: 'invite-clinic',
-        createdAt: session.openAt,
         patient_uuid: this.uuid,
-        programme_ids: session.programme_ids,
-        session_id: session.id
+        programme_ids: programme_ids
       })
     }
   }

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -339,7 +339,7 @@ export class Patient extends Child {
 
       // Patient invited to clinic if invitation needed and invitation sent
       patientProgramme.invitedToClinic =
-        patientProgramme.inviteToSession &&
+        patientProgramme.canInviteToSession &&
         this.clinicProgramme_ids.includes(programme.id)
 
       programmes[programme.id] = patientProgramme

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -10,6 +10,7 @@ import {
   Impairment,
   NoticeType,
   NotifyEmailStatus,
+  PatientClinicStatus,
   VaccinationOutcome
 } from '../enums.js'
 import {
@@ -350,6 +351,17 @@ export class Patient extends Child {
   }
 
   /**
+   * Get the IDs of programmes for which this patient can be invited to clinic
+   *
+   * @returns {Array<string>} the IDs of programmes for which this patient is clinic-ready
+   */
+  get clinicReadyProgramme_ids() {
+    return Object.values(this.programmes)
+      .filter(({ clinicStatus }) => clinicStatus === PatientClinicStatus.Ready)
+      .map(({ programme_id }) => programme_id)
+  }
+
+  /**
    * Get replies
    *
    * @returns {Array<Reply>} Replies
@@ -668,6 +680,10 @@ export class Patient extends Child {
    * @param {Array<string>} programme_ids - The programmes for which the child's invited
    */
   inviteToClinic(programme_ids) {
+    this.clinicProgramme_ids = [
+      ...new Set(this.clinicProgramme_ids.concat(programme_ids))
+    ]
+
     for (const parent of this.parents) {
       this.addEvent({
         name: activity.notify['invite-clinic'](parent),

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -88,7 +88,7 @@ export class School extends Location {
    */
   patientsToInviteToSession(programmeId) {
     return this.patients.filter(
-      (patient) => patient.programmes[programmeId].inviteToSession
+      (patient) => patient.programmes[programmeId].canInviteToSession
     )
   }
 

--- a/app/routes/patient.js
+++ b/app/routes/patient.js
@@ -19,6 +19,7 @@ router.post('/:patient_uuid/edit/:view', patient.updateForm)
 router.post('/:patient_uuid/new/note', patient.note)
 
 router.post('/:patient_uuid/archive', patient.archive)
+router.post('/:patient_uuid/invite-to-clinic', patient.inviteToClinic)
 
 router.all('/:patient_uuid/programmes{/:programme_id}', patient.readProgramme)
 router.get('/:patient_uuid/programmes{/:programme_id}', patient.showProgramme)

--- a/app/routes/patient.js
+++ b/app/routes/patient.js
@@ -7,6 +7,9 @@ const router = express.Router({ strict: true, mergeParams: true })
 router.get('/', patient.readAll, patient.list)
 router.post('/', patient.filterList)
 
+router.get('/invite-to-clinic', patient.readAll, patient.showInviteManyToClinic)
+router.post('/invite-to-clinic', patient.inviteManyToClinic)
+
 router.param('patient_uuid', patient.read)
 
 router.get('/:patient_uuid/edit', patient.edit)
@@ -19,7 +22,7 @@ router.post('/:patient_uuid/edit/:view', patient.updateForm)
 router.post('/:patient_uuid/new/note', patient.note)
 
 router.post('/:patient_uuid/archive', patient.archive)
-router.post('/:patient_uuid/invite-to-clinic', patient.inviteToClinic)
+router.post('/:patient_uuid/invite-to-clinic', patient.inviteOneToClinic)
 
 router.all('/:patient_uuid/programmes{/:programme_id}', patient.readProgramme)
 router.get('/:patient_uuid/programmes{/:programme_id}', patient.showProgramme)

--- a/app/utils/programme.js
+++ b/app/utils/programme.js
@@ -1,0 +1,36 @@
+import { Programme } from '../models.js'
+
+/**
+ * @readonly
+ * @enum {string}
+ */
+export const ConjunctionType = {
+  and: 'conjunction',
+  or: 'disjunction'
+}
+
+/**
+ * Get a comma-delimited list of programme names to use in a sentence
+ *
+ * @param {Array<string>} programme_ids - the IDs of programmes whose name will form the list
+ * @param {ConjunctionType} conjunctionType - Choice between 'and' and 'or'
+ * @param {object} context - the data context where programmes are held
+ * @returns {string} the list ready to use in a sentence
+ */
+export const programmeNamesListForSentence = (
+  programme_ids,
+  conjunctionType,
+  context
+) => {
+  const formatter = new Intl.ListFormat('en', {
+    style: 'long',
+    type: conjunctionType
+  })
+  const programmeNames = formatter.format(
+    programme_ids.map((programme_id) =>
+      Programme.findOne(programme_id, context)?.name?.replace('Flu', 'flu')
+    )
+  )
+
+  return programmeNames
+}

--- a/app/utils/querystring.js
+++ b/app/utils/querystring.js
@@ -1,0 +1,25 @@
+/**
+ * Rebuild the querystring from a request.query object
+ *
+ * @param {object} query - the request.query object
+ * @returns {string} - the rebuilt query string
+ */
+export function queryToQueryString(query) {
+  if (!query) {
+    return ''
+  }
+
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    if (Array.isArray(value)) {
+      // Make sure we replicate repeated parameters the way they were originally
+      value.forEach((item) => params.append(key, item))
+    } else {
+      // Otherwise, just set it normally
+      params.append(key, value)
+    }
+  }
+
+  const queryString = params.toString()
+  return queryString ? `?${queryString}` : ''
+}

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -64,19 +64,16 @@
       decorate: "programme_id"
     }) if programmeItems }}
 
-    {{ checkboxes({
+    {{ radios({
       fieldset: {
         legend: {
           classes: "nhsuk-fieldset__legend--s",
-          text: __("patient.clinicProgramme_ids.label")
+          text: "Clinic status"
         }
       },
       small: true,
-      items: [{
-        text: 'Invited to clinic',
-        value: 'true'
-      }],
-      decorate: "invitedToClinic"
+      items: radioFilterItems(PatientClinicStatus, data["clinicStatus"]),
+      decorate: "clinicStatus"
     }) }}
 
     {% for name, enums in params.checkboxFilters %}

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -73,7 +73,7 @@
         }
       },
       small: true,
-      items: radioFilterItems(PatientClinicStatus, data["clinicStatus"]),
+      items: radioFilterItems(PatientClinicStatus, data["clinicStatus"], false),
       decorate: "clinicStatus"
     }) }}
 

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -45,6 +45,7 @@
   }) %}
     {{ appSearchInput({
       label: { text: __("search.label") },
+      hint: { text: __("search.hint.patient") },
       attributes: {
         formaction: params.formaction,
         formmethod: "post"

--- a/app/views/_macros/search-input.njk
+++ b/app/views/_macros/search-input.njk
@@ -6,9 +6,10 @@
 {{ input({
   classes: "app-search-input__input" + (" " + params.classes if params.classes),
   label: {
-    classes: "nhsuk-u-visually-hidden",
+    classes: "nhsuk-u-font-weight-bold",
     text: params.label.text
   },
+  hint: { text: params.hint.text },
   type: "search",
   autocomplete: "off",
   spellcheck: false,

--- a/app/views/_macros/session-search.njk
+++ b/app/views/_macros/session-search.njk
@@ -17,6 +17,7 @@
   }) %}
     {{ appSearchInput({
       label: { text: __("search.label") },
+      hint: { text: __("search.hint.session") },
       attributes: {
         formaction: params.formaction,
         formmethod: "post"

--- a/app/views/consent/match.njk
+++ b/app/views/consent/match.njk
@@ -65,7 +65,7 @@
           level: 3,
           size: "m",
           title: __("search.results"),
-          summary: __mf("patient.results", {
+          summary: __mf("patient.results.summary", {
             from: results.from,
             to: results.to,
             count: results.count

--- a/app/views/patient/bulk-invite-to-clinic.njk
+++ b/app/views/patient/bulk-invite-to-clinic.njk
@@ -1,0 +1,26 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("patient.bulkInviteToClinic.title") %}
+{% set confirmButtonText = __("patient.bulkInviteToClinic.confirm") %}
+{% set formAction = "invite-to-clinic" + query | asQueryString %}
+
+{% block form %}
+  {{ appHeading({
+    caption: __mf("patient.bulkInviteToClinic.caption", { count: data.clinicPatient_ids.length }),
+    title: title
+  }) }}
+
+  {# e.g. 271 children can be invited to clinic for HPV, MenACWY, or Td/IPV programmes. #}
+  {{ cohortSummary | nhsukMarkdown }}
+
+  {{ checkboxes({
+    fieldset: {
+      legend: {
+        text: __("patient.bulkInviteToClinic.programme.label"),
+        size: "m"
+      }
+    },
+    items: checkboxItems,
+    decorate: "clinicProgramme_ids"
+  }) }}
+{% endblock %}

--- a/app/views/patient/invite-to-clinic.njk
+++ b/app/views/patient/invite-to-clinic.njk
@@ -1,12 +1,17 @@
 {% extends "_layouts/form.njk" %}
 
 {% set paths = { back: patient.uri } %}
+{% set confirmButtonText = __("patient.inviteToClinic.confirm") %}
+
 {% if clinicReadyProgrammes.length > 1 %}
   {% set title = __("patient.inviteToClinic.title.multiple") %}
 {% else %}
-  {% set title = __("patient.inviteToClinic.title.single", { firstName: patient.firstName, lastName: patient.lastName }) %}
+  {% if clinicReadyProgrammesWithoutClinics.count === 0 %}
+    {% set title = __("patient.inviteToClinic.title.single.clinicsScheduled", { firstName: patient.firstName, lastName: patient.lastName }) %}
+  {% else %}
+    {% set title = __("patient.inviteToClinic.title.single.noClinicsScheduled", { firstName: patient.firstName, lastName: patient.lastName }) %}
+  {% endif %}
 {% endif %}
-{% set confirmButtonText = __("patient.inviteToClinic.confirm") %}
 
 {% set checkboxItems = [] %}
 {% for patientProgramme in clinicReadyProgrammes %}
@@ -32,7 +37,10 @@
   }) }}
 
   {% if clinicReadyProgrammes.length > 1 %}
-    {# Let the user choose which programmes to invite for, based on availability of clinics #}
+    {#
+      The child is clinic-ready for multiple programmes, so we'll offer checkboxes to invite to all of them,
+      regardless of clinic availability — but warn if any don't have clinics available
+    #}
     {{ checkboxes({
       fieldset: {
         attributes: {
@@ -44,8 +52,8 @@
     }) }}
   
     {{ warningCallout({
-      heading: __("patient.inviteToClinic.scheduledClinicWarning.multiple.title"),
-      text: __mf("patient.inviteToClinic.scheduledClinicWarning.multiple.description",
+      heading: __("patient.inviteToClinic.scheduledClinicWarning.title"),
+      text: __mf("patient.inviteToClinic.scheduledClinicWarning.description",
         {
           programmeNames: clinicReadyProgrammesWithoutClinics.names,
           count: clinicReadyProgrammesWithoutClinics.count
@@ -53,27 +61,45 @@
     }) if clinicReadyProgrammesWithoutClinics.count > 0 }}
   {% else %}
     {#
-      There must be only 1 clinic ready programme, so only show the paragraph about number of clinics
+      There must be exactly 1 clinic-ready programme, so only show the paragraph about number of clinics
       for this one programme if there actually are some. Otherwise, lean on the warning callout.
     #}
-    {% if clinicReadyProgrammesWithoutClinics.length === 0 %}
-      {{ __mf("patient.inviteToClinic.clinicCount.paragraph",
+    {% if clinicReadyProgrammesWithoutClinics.count === 0 %}
+      {# Tell the user how many clinics are available for this child's one clinic-ready programme #}
+      {{ __mf("patient.inviteToClinic.clinicCount.someParagraph",
       {
         programmeName: clinicReadyProgrammes[0].programme.name | replace("Flu", "flu"),
         count: clinicReadyProgrammes[0].scheduledClinicCount
-      }) }}
+      }) | nhsukMarkdown }}
     {% else %}
-      {{ warningCallout({
-        heading: __("patient.inviteToClinic.scheduledClinicWarning.single.title"),
-        text: __mf("patient.inviteToClinic.scheduledClinicWarning.single.description",
+      {# Tell the user there are NO clinics available for this child's one clinic-ready programme #}
+      {{ __("patient.inviteToClinic.clinicCount.noneParagraph",
           {
-            programmeNames: clinicReadyProgrammesWithoutClinics.names,
-            count: clinicReadyProgrammesWithoutClinics.count
-          }) | safe
-      }) if clinicReadyProgrammesWithoutClinics.count > 0 }}
+            programmeName: clinicReadyProgrammesWithoutClinics.names
+          }) | nhsukMarkdown
+      }}
     {% endif %}
 
     {# Fake the user's selection of a checkbox for this programme #}
     <input type="hidden" id="clinicProgramme_ids" name="clinicProgramme_ids" value="{{clinicReadyProgrammes[0].programme_id}}" />
   {% endif %}
 {% endblock %}
+
+{% block afterForm %}
+  {# Include a link to back out if there are no clinics available for the clinic-ready programmes #}
+  {% if clinicReadyProgrammes.length === clinicReadyProgrammesWithoutClinics.count %}
+    {{ appButtonGroup({
+      buttons: [{
+        text: confirmButtonText,
+        variant: confirmButtonVariant
+      }],
+      links: [{
+        text: __("patient.inviteToClinic.cancel"),
+        href: paths.back
+      }]
+    }) }}
+  {% else %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+

--- a/app/views/patient/invite-to-clinic.njk
+++ b/app/views/patient/invite-to-clinic.njk
@@ -1,0 +1,79 @@
+{% extends "_layouts/form.njk" %}
+
+{% set paths = { back: patient.uri } %}
+{% if clinicReadyProgrammes.length > 1 %}
+  {% set title = __("patient.inviteToClinic.title.multiple") %}
+{% else %}
+  {% set title = __("patient.inviteToClinic.title.single", { firstName: patient.firstName, lastName: patient.lastName }) %}
+{% endif %}
+{% set confirmButtonText = __("patient.inviteToClinic.confirm") %}
+
+{% set checkboxItems = [] %}
+{% for patientProgramme in clinicReadyProgrammes %}
+  {% set checkboxItems = checkboxItems | push({
+    text: patientProgramme.programme.type,
+    value: patientProgramme.programme_id,
+    hint: { text: __mf("patient.inviteToClinic.clinicCount.hint",
+      {
+        programmeName: patientProgramme.programme.name | replace("Flu", "flu"),
+        count: patientProgramme.scheduledClinicCount
+      })
+    }
+  }) %}
+{% endfor %}
+
+{% block form %}
+  {{ appHeading({
+    attributes: {
+      "id": "checkboxes-heading"
+    },
+    caption: patient.fullName,
+    title: title
+  }) }}
+
+  {% if clinicReadyProgrammes.length > 1 %}
+    {# Let the user choose which programmes to invite for, based on availability of clinics #}
+    {{ checkboxes({
+      fieldset: {
+        attributes: {
+          "aria-labelledby": "checkboxes-heading"
+        }
+      },
+      items: checkboxItems,
+      decorate: "clinicProgramme_ids"
+    }) }}
+  
+    {{ warningCallout({
+      heading: __("patient.inviteToClinic.scheduledClinicWarning.multiple.title"),
+      text: __mf("patient.inviteToClinic.scheduledClinicWarning.multiple.description",
+        {
+          programmeNames: clinicReadyProgrammesWithoutClinics.names,
+          count: clinicReadyProgrammesWithoutClinics.count
+        }) | safe
+    }) if clinicReadyProgrammesWithoutClinics.count > 0 }}
+  {% else %}
+    {#
+      There must be only 1 clinic ready programme, so only show the paragraph about number of clinics
+      for this one programme if there actually are some. Otherwise, lean on the warning callout.
+    #}
+    {% if clinicReadyProgrammesWithoutClinics.length === 0 %}
+      {{ __mf("patient.inviteToClinic.clinicCount.paragraph",
+      {
+        programmeName: clinicReadyProgrammes[0].programme.name | replace("Flu", "flu"),
+        count: clinicReadyProgrammes[0].scheduledClinicCount
+      }) }}
+    {% else %}
+      {{ warningCallout({
+        heading: __("patient.inviteToClinic.scheduledClinicWarning.single.title"),
+        text: __mf("patient.inviteToClinic.scheduledClinicWarning.single.description",
+          {
+            programmeNames: clinicReadyProgrammesWithoutClinics.names,
+            count: clinicReadyProgrammesWithoutClinics.count
+          }) | safe
+      }) if clinicReadyProgrammesWithoutClinics.count > 0 }}
+    {% endif %}
+
+    {# Fake the user's selection of a checkbox for this programme #}
+    <input type="hidden" id="clinicProgramme_ids" name="clinicProgramme_ids" value="{{clinicReadyProgrammes[0].programme_id}}" />
+  {% endif %}
+{% endblock %}

--- a/app/views/patient/list.njk
+++ b/app/views/patient/list.njk
@@ -38,12 +38,19 @@
           level: 2,
           size: "m",
           title: __("search.results"),
-          summary: __mf("patient.results", {
+          summary: __mf("patient.results.summary", {
             from: results.from,
             to: results.to,
             count: results.count
           }) | safe
         }) }}
+
+        {% if showingClinicReady and results.count > 0 %}
+          {{ actionLink({
+            text: __mf("patient.results.inviteToClinic", { count: results.count }),
+            href: "/patients/invite-to-clinic"
+          }) }}
+        {% endif %}
 
         {% for patient in results.page %}
           {% set reportStatusHtml -%}

--- a/app/views/patient/list.njk
+++ b/app/views/patient/list.njk
@@ -45,12 +45,10 @@
           }) | safe
         }) }}
 
-        {% if showingClinicReady and results.count > 0 %}
-          {{ actionLink({
-            text: __mf("patient.results.inviteToClinic", { count: results.count }),
-            href: "/patients/invite-to-clinic"
-          }) }}
-        {% endif %}
+        {{ actionLink({
+          text: __mf("patient.results.inviteToClinic", { count: results.count }),
+          href: "/patients/invite-to-clinic" + query | asQueryString
+        }) if showingClinicReady and results.count > 0 }}
 
         {% for patient in results.page %}
           {% set reportStatusHtml -%}

--- a/app/views/patient/show.njk
+++ b/app/views/patient/show.njk
@@ -83,7 +83,9 @@
     }) }}
   {% endcall %}
 
+  {# Vaccination programmes card #}
   {% set patientProgrammeRows = [] %}
+  {% set canInviteToSession = false %}
   {% for id, patientProgramme in patient.programmes %}
     {% set patientProgrammeRows = patientProgrammeRows | push([
       {
@@ -99,23 +101,34 @@
         html: patientProgramme.statusNotes
       }
     ]) %}
+    {% set canInviteToSession = canInviteToSession or patientProgramme.clinicStatus === PatientClinicStatus.Ready %}
   {% endfor %}
 
-  {{ table({
-    id: "programmes",
-    responsive: true,
-    card: {
-      heading: __("patient.programmes.label"),
-      headingLevel: 3
-    },
-    head: [
-      { text: __("patientProgramme.name.label") },
-      { text: __("patientProgramme.status.label") },
-      { text: __("patientProgramme.statusNotes.label") }
-    ],
-    rows: patientProgrammeRows
-  }) }}
+  {% call card({
+    heading: __("patient.programmes.label"),
+    headingLevel: 3,
+    actions: {
+      items: [
+        {
+          text: "Invite to clinic",
+          href: patient.uri + "/invite-to-clinic"
+        } if not patient.archived and canInviteToSession
+      ]
+    }
+  }) %}
+    {{ table({
+      id: "programmes",
+      responsive: true,
+      head: [
+        { text: __("patientProgramme.name.label") },
+        { text: __("patientProgramme.status.label") },
+        { text: __("patientProgramme.statusNotes.label") }
+      ],
+      rows: patientProgrammeRows
+    }) }}
+  {% endcall %}
 
+  {# Activity log card #}
   {{ card({
     heading: __("patient.auditEvents.label"),
     headingLevel: 3,

--- a/app/views/school/show.njk
+++ b/app/views/school/show.njk
@@ -55,7 +55,7 @@
         level: 2,
         size: "m",
         title: __("search.results"),
-        summary: __mf("patient.results", {
+        summary: __mf("patient.results.summary", {
           from: results.from,
           to: results.to,
           count: results.count

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -53,7 +53,7 @@
           level: 3,
           size: "m",
           title: title | replace(",", " or "),
-          summary: __mf("patient.results", {
+          summary: __mf("patient.results.summary", {
             from: results.from,
             to: results.to,
             count: results.count

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -292,7 +292,7 @@ for (let session of Object.values(context.sessions)) {
           )
 
           // Add patient to session
-          patient.addToSession(patientSession.session)
+          patient.addToSession(patientSession)
 
           // 2️⃣🅰️ REQUEST CONSENT
           patient.requestConsent(patientSession)
@@ -323,7 +323,7 @@ for (let session of Object.values(context.sessions)) {
           )
 
           // Add patient to session
-          patient.addToSession(patientSession.session)
+          patient.addToSession(patientSession)
 
           // 2️⃣🅱️ INVITE home-educated/school unknown patient to clinic
           patient.requestConsent(patientSession)
@@ -545,17 +545,29 @@ for (const programme of Object.values(context.programmes)) {
   for (const session of programmeSchoolSessions) {
     if (session.isCompleted) {
       // TODO: Patients have no context, so won’t have outcomes to filter on
-      const sessionPatients = session.patients
+      const patientSessions = session.patients
         .filter(({ report }) => report !== PatientStatus.Vaccinated)
         .filter(({ screen }) => screen !== ScreenOutcome.DoNotVaccinate)
         .filter(({ consent }) => consent !== ConsentOutcome.Refused)
         .filter(({ consent }) => consent !== ConsentOutcome.FinalRefusal)
 
-      for (let patient of sessionPatients) {
-        patient = new Patient(patient, context)
+      for (let patientSession of patientSessions) {
+        const patient = new Patient(patientSession.patient, context)
+
+        const clinicPatientSession = new PatientSession(
+          {
+            createdBy_uid: nurse.uid,
+            patient_uuid: patient.uuid,
+            programme_id: programme.id,
+            session_id: programmeClinicSession.id
+          },
+          context
+        )
+        context.patientSessions[clinicPatientSession.uuid] =
+          clinicPatientSession
 
         // Add patient to community clinic
-        patient.addToSession(programmeClinicSession)
+        patient.addToSession(clinicPatientSession)
 
         // 2️⃣ INVITE TO BOOK CLINIC APPOINTMENT
         patient.inviteToClinic(programmeClinicSession)

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -570,7 +570,7 @@ for (const programme of Object.values(context.programmes)) {
         patient.addToSession(clinicPatientSession)
 
         // 2️⃣ INVITE TO BOOK CLINIC APPOINTMENT
-        patient.inviteToClinic(programmeClinicSession)
+        patient.inviteToClinic(programmeClinicSession.programme_ids)
       }
     }
   }

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -278,9 +278,9 @@ for (let session of Object.values(context.sessions)) {
       patient = new Patient(patient, context)
 
       for (const programme_id of session.programme_ids) {
-        const { inviteToSession } = patient.programmes[programme_id]
+        const { canInviteToSession } = patient.programmes[programme_id]
 
-        if (inviteToSession) {
+        if (canInviteToSession) {
           const patientSession = new PatientSession(
             {
               createdAt: session.openAt,
@@ -310,9 +310,9 @@ for (let session of Object.values(context.sessions)) {
 
     for (const patient of patientsOutsideSchool) {
       for (const programme_id of session.programme_ids) {
-        const { inviteToSession } = patient.programmes[programme_id]
+        const { canInviteToSession } = patient.programmes[programme_id]
 
-        if (inviteToSession) {
+        if (canInviteToSession) {
           const patientSession = new PatientSession(
             {
               patient_uuid: patient.uuid,


### PR DESCRIPTION
This PR adds:

- a new clinic-readiness status per patient and programme
- a filter on children listings to filter to a given clinic status
- a way to invite a given child to all clinics they're 'ready' for, from the child record
- a way to bulk-invite children matching a given filter on child listings (only available when filtering to clinic-ready children)

The clinic status filter, seen in the main Children page, with the link to invite to clinic present because the filter is showing children who can be invited to clinic:
<img width="1581" height="1349" alt="image" src="https://github.com/user-attachments/assets/22faf155-d4c2-42dc-8cee-a972a60cd353" />

The page allowing you to specify which programmes you want to invite the selected children to at clinic:
<img width="2880" height="2310" alt="image" src="https://github.com/user-attachments/assets/0595a49d-3244-4ac1-997f-97833bdd3736" />

In the child record, a new link from the Child record tab allowing you to invite to all relevant programmes in one go:
<img width="2880" height="1453" alt="image" src="https://github.com/user-attachments/assets/58e4a839-d97a-4b90-9721-4ab62d20e676" />

And the page allowing you to select the programmes to invite to clinic for, for that child:
<img width="2880" height="2550" alt="image" src="https://github.com/user-attachments/assets/22f5d3c2-bea9-4a0d-b604-bd98ca2c9539" />

Arguably, the invite page in the Children list also needs that warning callout for programmes that have no scheduled clinics.