### PR TITLE
Support vaccinating children in post-16 education

### DIFF
--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -36,9 +36,10 @@ export const patientController = {
 
     const patient = Patient.findOne(patient_uuid, data)
 
-    const recordTitle = patient.post16
-      ? __('patient.label').replace('Child', 'Patient')
-      : __('patient.label')
+    const recordTitle =
+      patient?.age >= 18
+        ? __('patient.label').replace('Child', 'Patient')
+        : __('patient.label')
 
     response.locals.patient = patient
 
@@ -190,11 +191,11 @@ export const patientController = {
 
     // Filter by display option
     for (const key of [
+      'agedOutOfProgrammes',
       'archived',
       'hasImpairment',
       'hasAdjustment',
-      'hasMissingNhsNumber',
-      'post16'
+      'hasMissingNhsNumber'
     ]) {
       if (option?.includes(key)) {
         results = results.filter((patient) => patient[key])
@@ -224,7 +225,7 @@ export const patientController = {
     }))
 
     // Year group filter options
-    response.locals.yearGroupItems = [...Array(12).keys()].map((yearGroup) => ({
+    response.locals.yearGroupItems = [...Array(14).keys()].map((yearGroup) => ({
       text: formatYearGroup(yearGroup),
       value: yearGroup,
       checked: yearGroups?.includes(yearGroup) ?? false

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -63,7 +63,8 @@ export const replyController = {
         patient_uuid: patientSession.patient.uuid,
         programme_id: patientSession.programme.id,
         session_id: patientSession.session.id,
-        createdBy_uid: account.uid
+        createdBy_uid: account.uid,
+        selfConsent: patientSession?.patient?.post16
       },
       data
     )
@@ -71,7 +72,14 @@ export const replyController = {
     // TODO: Use presenter
     const reply = new Reply(createdReply, data)
 
-    response.redirect(`${reply.uri}/new/respondent`)
+    let next
+    if (patientSession?.patient?.post16) {
+      next = `${reply.uri}/new/decision`
+    } else {
+      next = `${reply.uri}/new/respondent`
+    }
+
+    response.redirect(next)
   },
 
   update(type) {
@@ -180,10 +188,6 @@ export const replyController = {
       response.locals.reply = new Reply(reply, data)
       response.locals.patient = patientSession.patient
 
-      // Child can self consent if assessed as Gillick competent
-      const canSelfConsent =
-        patientSession.gillick?.competent === GillickCompetent.True
-
       // Only ask for programme if more than 1 administered in a session
       const isMultiProgrammeSession =
         patientSession.session.programmes.length > 1
@@ -215,7 +219,7 @@ export const replyController = {
           [`/${reply_uuid}/${type}/programme`]: {}
         }),
         [`/${reply_uuid}/${type}/decision`]: {
-          [`/${reply_uuid}/${type}/${reply?.selfConsent ? 'notify-parent' : 'health-answers'}`]:
+          [`/${reply_uuid}/${type}/${reply?.selfConsent && !patientSession.patient.post16 ? 'notify-parent' : 'health-answers'}`]:
             {
               data: 'reply.decision',
               value: ReplyDecision.Given
@@ -291,9 +295,10 @@ export const replyController = {
         )
       }
 
-      if (canSelfConsent) {
+      // Child can self consent if assessed as Gillick competent
+      if (patientSession.gillick?.competent === GillickCompetent.True) {
         response.locals.respondentItems.unshift({
-          text: 'Child (Gillick competent)',
+          text: `${reply?.patient?.fullName} (child)`,
           value: 'self'
         })
       }

--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -204,11 +204,11 @@ export const schoolController = {
 
     // Filter by display option
     for (const key of [
+      'agedOutOfProgrammes',
       'archived',
       'hasImpairment',
       'hasAdjustment',
-      'hasMissingNhsNumber',
-      'post16'
+      'hasMissingNhsNumber'
     ]) {
       if (option?.includes(key)) {
         results = results.filter((patient) => patient[key])

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -337,11 +337,11 @@ export const sessionController = {
 
     // Filter patient by display option
     for (const key of [
+      'agedOutOfProgrammes',
       'archived',
       'hasImpairment',
       'hasAdjustment',
-      'hasMissingNhsNumber',
-      'post16'
+      'hasMissingNhsNumber'
     ]) {
       if (option?.includes(key)) {
         results = results.filter(({ patient }) => patient[key])

--- a/app/datasets/activity.js
+++ b/app/datasets/activity.js
@@ -7,9 +7,9 @@ export default {
     absent: (session) => `Absent from session at ${session.location.name}`
   },
   consent: {
-    created: ({ decision, parent, selfConsent }) =>
+    created: ({ child, decision, parent, selfConsent }) =>
       selfConsent
-        ? `${decision} by child (Gillick competent)`
+        ? `${decision} by ${child?.fullName} (child)`
         : `${decision} by ${parent.fullNameAndRelationship}`,
     updated: ({ decision, parent }) =>
       `${decision} in updated response from ${parent.fullNameAndRelationship}`,

--- a/app/enums.js
+++ b/app/enums.js
@@ -352,6 +352,7 @@ export const PatientClinicStatus = {
  * @enum {string}
  */
 export const PatientConsentStatus = {
+  SelfConsent: 'Can self-consent (16+)',
   NotScheduled: 'No request scheduled',
   Scheduled: 'Request scheduled',
   NoDetails: 'No contact details',

--- a/app/generators/child.js
+++ b/app/generators/child.js
@@ -111,7 +111,9 @@ export function generateChild() {
       { value: 12, weight: 8 },
       { value: 13, weight: 4 },
       { value: 14, weight: 2 },
-      { value: 15, weight: 1 }
+      { value: 15, weight: 1 },
+      { value: 16, weight: 1 },
+      { value: 17, weight: 1 }
     ])
 
     // Calculate birth year
@@ -131,10 +133,15 @@ export function generateChild() {
     school_id = faker.helpers.arrayElement(['888888', '999999'])
   }
 
-  // Add examples of children who have aged out (over 16)
+  // Add examples of children in post-16 education
   if (faker.datatype.boolean(0.05)) {
     dob = faker.date.birthdate({ min: 17, max: 18, mode: 'age' })
-    school_id = ''
+    school_id = '888888'
+  }
+
+  // Add examples of children who have aged out (over 18)
+  if (faker.datatype.boolean(0.1)) {
+    dob = faker.date.birthdate({ min: 19, max: 21, mode: 'age' })
   }
 
   // GP surgery

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1414,7 +1414,7 @@ export const en = {
       hasAdjustment: 'Children needing reasonable adjustments',
       hasImpairment: 'Children with impairments',
       hasMissingNhsNumber: 'Children missing an NHS&nbsp;number',
-      post16: 'Children aged out of programmes'
+      agedOutOfProgrammes: 'Children aged out of programmes'
     },
     archiveReason: {
       label: 'Reason archived'
@@ -1440,8 +1440,8 @@ export const en = {
     hasMissingNhsNumber: {
       label: 'Missing NHS number'
     },
-    post16: {
-      label: 'Over 16 years old?',
+    agedOutOfProgrammes: {
+      label: 'Aged out of programmes?',
       status:
         '{{patient.fullName}} is no longer eligible for school age immunisations'
     },

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -66,7 +66,10 @@ export class Child {
     this.address = options?.address
     this.gpSurgery = options?.gpSurgery
     this.registrationGroup = options?.registrationGroup
-    this.school_id = options?.school_id
+
+    if (!this.agedOutOfProgrammes) {
+      this.school_id = options?.school_id
+    }
 
     if (this.ethnicGroup === EthnicGroup.Other) {
       this.ethnicGroupOther = options?.ethnicGroupOther
@@ -179,12 +182,22 @@ export class Child {
   }
 
   /**
-   * Is the child over the age of 16?
+   * Is the child aged 16 or over?
+   * Children over the age of 16 can self-consent
    *
-   * @returns {boolean} Child is over the age of 16
+   * @returns {boolean} Child is aged 16 or over
    */
   get post16() {
-    return this.age >= 17
+    return this.age >= 16
+  }
+
+  /**
+   * Is the child still eligible for SAIS vaccinations?
+   *
+   * @returns {boolean} Child still eligible for SAIS vaccinations
+   */
+  get agedOutOfProgrammes() {
+    return this.age >= 18
   }
 
   /**
@@ -193,7 +206,7 @@ export class Child {
    * @returns {number|undefined} Year group, for example 8
    */
   get yearGroup() {
-    if (!this.post16) {
+    if (!this.agedOutOfProgrammes) {
       return getYearGroup(this.dob)
     }
   }
@@ -283,7 +296,7 @@ export class Child {
         Object.values(this.address)
           .filter((string) => string)
           .join('<br>'),
-      ...(!this.post16 && {
+      ...(!this.agedOutOfProgrammes && {
         yearGroup,
         yearGroupWithRegistration:
           this.registrationGroup && yearGroup

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -219,7 +219,7 @@ export class PatientProgramme {
         }
       }
       case PatientStatus.Consent:
-        return !this.patient?.hasNoContactDetails
+        return !this.patient?.hasNoContactDetails || this.patient.post16
       case PatientStatus.Refused:
         return (
           this.lastPatientSession?.patientRefused ===
@@ -270,7 +270,10 @@ export class PatientProgramme {
    * @returns {boolean} Eligible for programme
    */
   get eligible() {
-    return getCurrentAcademicYear() >= this.year
+    return (
+      !this.patient?.agedOutOfProgrammes &&
+      getCurrentAcademicYear() >= this.year
+    )
   }
 
   /**
@@ -507,7 +510,7 @@ export class PatientProgramme {
   get statusNotes() {
     switch (this.status) {
       case PatientStatus.Ineligible:
-        return this.patient.post16
+        return this.patient?.agedOutOfProgrammes
           ? 'Not eligible for school age immunisation'
           : `Eligible from 1 September ${this.year}`
       case PatientStatus.Vaccinated:

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -506,6 +506,10 @@ export class PatientSession {
    * @returns {PatientConsentStatus|undefined} Patient consent status
    */
   get patientConsent() {
+    if (this.patient?.post16) {
+      return PatientConsentStatus.SelfConsent
+    }
+
     if (this.patient?.hasNoContactDetails) {
       return PatientConsentStatus.NoDetails
     }
@@ -625,6 +629,10 @@ export class PatientSession {
   get consentDescription() {
     const relationships = filters.formatList(this.parentalRelationships)
     const parentNames = filters.formatList(this.parentsRequestingFollowUp)
+
+    if (this.patient?.post16) {
+      return `${this.patient.firstName} is old enough to self-consent.`
+    }
 
     if (this.patient?.hasNoContactDetails) {
       return 'There are no contact details for this child.'

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -177,7 +177,7 @@ export class Reply {
     if (this.parent) {
       return this.parent.relationship
     } else if (this.child) {
-      return 'Child (Gillick competent)'
+      return `${this.child.fullName} (child)`
     }
   }
 

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -248,8 +248,8 @@
             html: __("patient.search.hasMissingNhsNumber")
           },
           {
-            value: "post16",
-            text: __("patient.search.post16")
+            value: "agedOutOfProgrammes",
+            text: __("patient.search.agedOutOfProgrammes")
           }
         ],
         decorate: "option"

--- a/app/views/patient-session/_consent.njk
+++ b/app/views/patient-session/_consent.njk
@@ -37,7 +37,7 @@
         formmethod: "post"
       }
     }]
-  }) if not isVaccinated }}
+  }) if not isVaccinated and not patientSession.patient.post16 }}
 
   {% if patientSession.replies | length %}
     {# Requests with responses or requests that couldn’t be delivered #}
@@ -84,7 +84,7 @@
         })
       }) }}
     {% endfor %}
-  {% elif not patientSession.patient.hasNoContactDetails %}
+  {% elif not patientSession.patient.hasNoContactDetails and not patientSession.patient.post16 %}
     {# Requests that have been sent but with no response yet #}
     {# We don’t create replies so use parent details instead #}
 

--- a/app/views/patient/show.njk
+++ b/app/views/patient/show.njk
@@ -49,10 +49,10 @@
     }) if patient.notice }}
 
     {{ appStatus({
-      text: __("patient.post16.status", { patient: patient }),
+      text: __("patient.agedOutOfProgrammes.status", { patient: patient }),
       icon: "warning",
       colour: "blue"
-    }) if patient.post16 }}
+    }) if patient.agedOutOfProgrammes }}
 
     {{ summaryList({
       rows: summaryRows(patient, {

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -359,6 +359,11 @@ for (const patientSession of Object.values(context.patientSessions)) {
       getConsentForPatient = faker.datatype.boolean(0.75)
   }
 
+  // Children over 16 years old don’t need parental consent
+  if (patient.post16) {
+    getConsentForPatient = false
+  }
+
   if (getConsentForPatient && !patient.hasNoContactDetails) {
     const maxReplies = faker.helpers.weightedArrayElement([
       { value: 0, weight: 0.7 },


### PR DESCRIPTION
- Add ability to filter children in Years 12 and 13
- Add ability to filter children who can self consent
- Update verbal consent flow to support getting consent from the child only
- Show children due a vaccination and 16+ as being eligible for a clinic invitation

In order to support the 2 different ways a child can now give self consent (Gillick or by being 16 or older) this PR updates the label we show for a child who has given self-consent to just show the child’s name followed by ‘child’ in brackets.

<p><img width="2400" height="3200" alt="Children." src="https://github.com/user-attachments/assets/a3e2842b-4e94-4c9b-82f4-54953e2bea8d" /></p>

<p><img width="2400" height="2384" alt="Patient session with consent needed." src="https://github.com/user-attachments/assets/59fb092b-a255-44ff-9f2b-0a23a58b84ef" /></p>

<img width="2400" height="2000" alt="Does the child agree to having the children’s flu vaccine?" src="https://github.com/user-attachments/assets/4f4e0d4b-d96e-4c4c-abc2-dd4bdf4e9bce" />

<img width="2400" height="3200" alt="Patient session with consent given." src="https://github.com/user-attachments/assets/f3dccb38-6135-453e-8ad1-f8e05ebed3af" />
