### PR TITLE
Add ability to retry upload

### DIFF
--- a/app/controllers/upload.js
+++ b/app/controllers/upload.js
@@ -127,86 +127,97 @@ export const uploadController = {
     response.redirect(`${upload.uri}/new/${data.startPath}`)
   },
 
-  update(request, response) {
-    const { upload_id } = request.params
-    const { data, referrer } = request.session
-    const { __ } = response.locals
+  update(type) {
+    return (request, response) => {
+      const { upload_id } = request.params
+      const { data, referrer } = request.session
+      const { __ } = response.locals
 
-    // Update session data
-    let upload = Upload.update(
-      upload_id,
-      data.wizard.uploads[upload_id],
-      data.wizard
-    )
+      // Update session data
+      let upload = Upload.update(
+        upload_id,
+        data.wizard.uploads[upload_id],
+        data.wizard
+      )
 
-    upload = Upload.create(upload, data)
+      // Editing an upload means retrying an upload with a new file
+      // This means the existing failed or invalid status should be replaced
+      if (type === 'edit') {
+        upload.status = UploadStatus.Processing
+        upload.progress = 10
+      }
 
-    // Clean up session data
-    delete data.upload
-    delete data.wizard
+      upload = Upload.create(upload, data)
 
-    request.flash('success', __('upload.new.success'))
+      // Clean up session data
+      delete data.upload
+      delete data.wizard
 
-    response.redirect(referrer || upload.uri)
+      request.flash('success', __(`upload.${type}.success`))
+
+      response.redirect(referrer || upload.uri)
+    }
   },
 
-  readForm(request, response, next) {
-    const { upload_id } = request.params
-    const { data } = request.session
-    const { __ } = response.locals
+  readForm(type) {
+    return (request, response, next) => {
+      const { upload_id } = request.params
+      const { data } = request.session
+      const { __ } = response.locals
 
-    // Setup wizard if not already setup
-    let upload = Upload.findOne(upload_id, data.wizard)
-    if (!upload) {
-      upload = Upload.create(response.locals.upload, data.wizard)
-    }
+      // Setup wizard if not already setup
+      let upload = Upload.findOne(upload_id, data.wizard)
+      if (!upload) {
+        upload = Upload.create(response.locals.upload, data.wizard)
+      }
 
-    const journey = {
-      [`/`]: {},
-      ...(data.startPath === 'type'
-        ? {
-            [`/${upload_id}/new/type`]: {
-              [`/${upload_id}/new/file`]: {
-                data: 'upload.type',
-                excludedValue: UploadType.School
-              }
-            },
-            [`/${upload_id}/new/school`]: {},
-            [`/${upload_id}/new/year-groups`]: {},
-            [`/${upload_id}/new/file`]: {}
-          }
-        : {
-            [`/${upload_id}/new/school`]: {},
-            [`/${upload_id}/new/year-groups`]: {},
-            [`/${upload_id}/new/file`]: {}
-          }),
-      [`/${upload_id}`]: {}
-    }
+      const journey = {
+        [`/`]: {},
+        ...(data.startPath === 'type'
+          ? {
+              [`/${upload_id}/${type}/type`]: {
+                [`/${upload_id}/${type}/file`]: {
+                  data: 'upload.type',
+                  excludedValue: UploadType.School
+                }
+              },
+              [`/${upload_id}/${type}/school`]: {},
+              [`/${upload_id}/${type}/year-groups`]: {},
+              [`/${upload_id}/${type}/file`]: {}
+            }
+          : {
+              [`/${upload_id}/${type}/school`]: {},
+              [`/${upload_id}/${type}/year-groups`]: {},
+              [`/${upload_id}/${type}/file`]: {}
+            }),
+        [`/${upload_id}`]: {}
+      }
 
-    // TODO: Use presenter
-    upload = new Upload(upload, data)
-    response.locals.upload = upload
+      // TODO: Use presenter
+      upload = new Upload(upload, data)
+      response.locals.upload = upload
 
-    response.locals.paths = wizard(journey, request)
+      response.locals.paths = wizard(journey, request)
 
-    response.locals.typeItems = Object.entries(UploadType).map(
-      ([key, value]) => ({
-        text: UploadType[key],
-        hint: { text: __(`upload.type.hint.${key}`) },
-        value
-      })
-    )
-
-    if (upload.school) {
-      response.locals.yearGroupItems = upload.school.yearGroups.map(
-        (yearGroup) => ({
-          text: formatYearGroup(yearGroup),
-          value: yearGroup
+      response.locals.typeItems = Object.entries(UploadType).map(
+        ([key, value]) => ({
+          text: UploadType[key],
+          hint: { text: __(`upload.type.hint.${key}`) },
+          value
         })
       )
-    }
 
-    next()
+      if (upload.school) {
+        response.locals.yearGroupItems = upload.school.yearGroups.map(
+          (yearGroup) => ({
+            text: formatYearGroup(yearGroup),
+            value: yearGroup
+          })
+        )
+      }
+
+      next()
+    }
   },
 
   showForm(request, response) {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2940,6 +2940,10 @@ export const en = {
       label: 'Upload records',
       success: 'Records uploaded for processing'
     },
+    edit: {
+      label: 'Upload corrected %s',
+      success: 'Corrected records uploaded for processing'
+    },
     file: {
       title: 'Upload {{type}}',
       label: 'Upload file',

--- a/app/routes/upload.js
+++ b/app/routes/upload.js
@@ -11,11 +11,15 @@ router.get('/new', upload.new)
 
 router.param('upload_id', upload.read)
 
-router.post('/:upload_id/new/file', upload.update)
-
-router.all('/:upload_id/new/:view', upload.readForm)
+router.all('/:upload_id/new/:view', upload.readForm('new'))
 router.get('/:upload_id/new/:view', upload.showForm)
+router.post('/:upload_id/new/file', upload.update('new'))
 router.post('/:upload_id/new/:view', upload.updateForm)
+
+router.all('/:upload_id/edit/:view', upload.readForm('edit'))
+router.get('/:upload_id/edit/:view', upload.showForm)
+router.post('/:upload_id/edit/file', upload.update('edit'))
+router.post('/:upload_id/edit/:view', upload.updateForm)
 
 router.get(
   '/:upload_id/remove-relationships',

--- a/app/views/upload/show.njk
+++ b/app/views/upload/show.njk
@@ -11,16 +11,6 @@
   {% set title = __("upload.show.title", { upload: upload }) %}
 {% endif %}
 
-{% set templateFormat %}
-  {% if upload.type == UploadType.Cohort %}
-    {% include "upload/_template-format-cohort.njk" %}
-  {% elif upload.type == UploadType.School %}
-    {% include "upload/_template-format-school.njk" %}
-  {% elif upload.type == UploadType.Report %}
-    {% include "upload/_template-format-report.njk" %}
-  {% endif %}
-{% endset %}
-
 {% block beforeContent %}
   {{ breadcrumb({
     items: [{
@@ -124,9 +114,9 @@
         {{ __("upload.invalid.description") | nhsukMarkdown }}
       </div>
 
-      {{ details({
-        summaryText: __("upload.file.format", { type: upload.type | lower }),
-        html: templateFormat
+      {{ actionLink({
+        text: __("upload.edit.label", upload.type | lower),
+        href: upload.uri + "/edit/file"
       }) }}
 
       {% for row, validations in upload.validations %}
@@ -155,9 +145,9 @@
         {{ __("upload.failed.description") | nhsukMarkdown }}
       </div>
 
-      {{ details({
-        summaryText: __("upload.file.format", { type: upload.type | lower }),
-        html: templateFormat
+      {{ actionLink({
+        text: __("upload.edit.label", upload.type | lower),
+        href: upload.uri + "/edit/file"
       }) }}
     {% endcall %}
 


### PR DESCRIPTION
[MAV-8499](https://nhsd-jira.digital.nhs.uk/browse/MAV-8499)

Users have reported finding it difficult to keep track of cases where previously failed upload(s) have been superseded by a later successful upload.

Users have also reported being frustrated having to navigate the Imports section when there are many previous failed uploads.

This PR adds an option to retry an upload that appears on failed upload pages. This would allow users to upload a new file to replace their previous failed attempt. The upload journey wouldn’t need to ask the user for the type of file they are uploading, as this remains the same as the failed upload.

Uploading a replacement file resets the status of the upload; it’d move from ‘Invalid’ back to ‘Processing’.

<img width="2398" height="3572" alt="Failed upload" src="https://github.com/user-attachments/assets/0339232d-1532-4b19-94d0-7fb1fefa5102" />

<img width="2398" height="2690" alt="Upload processing" src="https://github.com/user-attachments/assets/acec3c31-2f1a-4a30-85cc-99545648fe46" />