### PR TITLE
Fix patient session lookup leaking another programme

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -24,9 +24,12 @@ export const patientSessionController = {
     const { programme_id, session_id } = request.params
     const { __ } = response.locals
 
-    const patientSession = PatientSession.findAll(request.session.data)
-      .filter(({ session }) => session.id === session_id)
-      .find(({ patient }) => patient.nhsn === nhsn)
+    const patientSession = PatientSession.findAll(request.session.data).find(
+      (patientSession) =>
+        patientSession.session.id === session_id &&
+        patientSession.programme_id === programme_id &&
+        patientSession.patient.nhsn === nhsn
+    )
 
     const {
       consent,


### PR DESCRIPTION
The patient-session read controller matched on session_id and nhsn but not programme_id, so when a patient had sessions for multiple programmes (eg MMR and Td/IPV), the first match was returned regardless of which programme tab was clicked. This caused the report card to show the wrong programme name and status, eg MMR: due under the Td/IPV tab.

(I don't believe this is intended behaviour)