### PR TITLE
Add warnings about missing clinics to the bulk invite page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Run lint
-        run: npm run lint
-
       - name: Run create-data
         run: npm run create-data
+
+      - name: Run lint
+        run: npm run lint

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -460,7 +460,6 @@ export const patientController = {
   },
 
   showInviteManyToClinic(request, response) {
-    const { __, __mf } = response.locals
     const { data } = request.session
     const { clinicPatient_ids } = data
     const { programme_id } = request.query
@@ -477,35 +476,27 @@ export const patientController = {
     } else {
       programme_ids = programmes.map(({ id }) => id)
     }
-
-    // e.g. 271 children can be invited to clinic for HPV, MenACWY, or Td/IPV programmes.
-    const childrenFragment = __mf(
-      'patient.bulkInviteToClinic.childrenFragment',
-      { count: clinicPatient_ids.length }
-    )
-    const programmesFragment = programme_id
-      ? __mf('patient.bulkInviteToClinic.programmesFragment', {
-          count: programme_ids.length,
-          programmeNames: programmeNamesListForSentence(
-            programme_ids,
-            ConjunctionType.or,
-            data
-          )
-        })
-      : __('patient.bulkInviteToClinic.anyProgrammesFragment')
-    response.locals.cohortSummary = __(
-      'patient.bulkInviteToClinic.cohortSummary',
-      { children: childrenFragment, programmes: programmesFragment }
-    )
-
-    // Create the programme checkboxes and their patient and clinic counts
-    const checkboxItems = []
-    const scheduledSessions = Session.findAll(data)
-      .filter(({ type }) => type === SessionType.Clinic)
-      .filter(({ status }) => status === SessionStatus.Planned)
     const invitableProgrammes = programmes.filter((programme) =>
       programme_ids.includes(programme.id)
     )
+
+    // Details required for the intro paragraph
+    response.locals.cohortDetails = {
+      childrenCount: clinicPatient_ids.length,
+      specificProgrammes: !!programme_id,
+      programmeCount: programme_ids.length,
+      programmeNames: programmeNamesListForSentence(
+        programme_ids,
+        ConjunctionType.or,
+        data
+      )
+    }
+
+    // Details required for the programme checkboxes
+    const clinicReadyProgrammes = []
+    const scheduledSessions = Session.findAll(data)
+      .filter(({ type }) => type === SessionType.Clinic)
+      .filter(({ status }) => status === SessionStatus.Planned)
     for (const programme of invitableProgrammes) {
       const clinicReadyChildrenCount = clinicPatient_ids
         .map((id) => Patient.findOne(id, data))
@@ -519,34 +510,28 @@ export const patientController = {
           session.programme_ids.includes(programme.id)
         ).length
 
-        const childrenHint = __mf(
-          'patient.bulkInviteToClinic.programme.hint.children',
-          {
-            count: clinicReadyChildrenCount,
-            programmeName: programme.name
-          }
-        )
-        const clinicsHint = __mf(
-          'patient.bulkInviteToClinic.programme.hint.clinics',
-          {
-            count: scheduledClinicCount,
-            programmeName: programme.name
-          }
-        )
-        checkboxItems.push({
-          text: programme.name,
-          value: programme.id,
-          hint: {
-            html: __('patient.bulkInviteToClinic.programme.hint.combined', {
-              childrenHint,
-              clinicsHint
-            })
-          }
+        clinicReadyProgrammes.push({
+          name: programme.name,
+          id: programme.id,
+          childrenCount: clinicReadyChildrenCount,
+          clinicCount: scheduledClinicCount
         })
       }
     }
+    response.locals.clinicReadyProgrammes = clinicReadyProgrammes
 
-    response.locals.checkboxItems = checkboxItems
+    // Summary information for a warning about programmes without clinics
+    const programmesWithoutClinics = clinicReadyProgrammes.filter(
+      ({ clinicCount }) => clinicCount === 0
+    )
+    response.locals.clinicReadyProgrammesWithoutClinics = {
+      count: programmesWithoutClinics.length,
+      names: programmeNamesListForSentence(
+        programmesWithoutClinics.map(({ id }) => id),
+        ConjunctionType.or,
+        data
+      )
+    }
 
     response.render('patient/bulk-invite-to-clinic')
   },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1382,7 +1382,20 @@ export const en = {
           combined: '{{childrenHint}}<br>{{clinicsHint}}'
         }
       },
+      clinicCount: {
+        hint: '{count, plural, =0 {No clinics are scheduled for {programmeName}} one {1 clinic is scheduled for {programmeName}} other {# clinics are scheduled for {programmeName}}}',
+        someParagraph:
+          '{count, plural, one {There is 1 clinic scheduled for the {programmeName} programme.} other {There are # clinics scheduled for the {programmeName} programme.}}',
+        noneParagraph:
+          'No clinics are scheduled for the {{programmeName}} programme. Only send an invitation if you can offer {{programmeName}} alongside other vaccinations.'
+      },
+      scheduledClinicWarning: {
+        title: 'Programmes without clinics',
+        description:
+          '{count, plural, one {No clinics are scheduled for the <b>{programmeNames}</b> programme. Only select this option if you can offer it alongside other vaccinations.} other {No clinics are scheduled for the <b>{programmeNames}</b> programmes. Only select these options if you can offer them alongside other vaccinations.}}'
+      },
       confirm: 'Send clinic invitations',
+      cancel: 'Go back to children list',
       success:
         '{count, plural, one {1 child has been invited to clinic} other {{count} children have been invited to clinic}}'
     },

--- a/app/views/patient/bulk-invite-to-clinic.njk
+++ b/app/views/patient/bulk-invite-to-clinic.njk
@@ -4,23 +4,108 @@
 {% set confirmButtonText = __("patient.bulkInviteToClinic.confirm") %}
 {% set formAction = "invite-to-clinic" + query | asQueryString %}
 
+{% set checkboxItems = [] %}
+{% for programme in clinicReadyProgrammes %}
+  {% set checkboxItems = checkboxItems | push({
+    text: programme.name,
+    value: programme.id,
+    hint: { html: __("patient.bulkInviteToClinic.programme.hint.combined",
+      {
+        childrenHint: __mf(
+          'patient.bulkInviteToClinic.programme.hint.children',
+          {
+            count: programme.childrenCount,
+            programmeName: programme.name | replace("Flu", "flu")
+          }),
+        clinicsHint: __mf(
+          'patient.bulkInviteToClinic.programme.hint.clinics',
+          {
+            count: programme.clinicCount,
+            programmeName: programme.name | replace("Flu", "flu")
+          })
+      })
+    }
+  }) %}
+{% endfor %}
+
 {% block form %}
   {{ appHeading({
-    caption: __mf("patient.bulkInviteToClinic.caption", { count: data.clinicPatient_ids.length }),
+    caption: __mf("patient.bulkInviteToClinic.caption", { count: cohortDetails.childrenCount }),
     title: title
   }) }}
 
   {# e.g. 271 children can be invited to clinic for HPV, MenACWY, or Td/IPV programmes. #}
-  {{ cohortSummary | nhsukMarkdown }}
+  {{ __('patient.bulkInviteToClinic.cohortSummary',
+    {
+      children: __mf('patient.bulkInviteToClinic.childrenFragment', { count: cohortDetails.childrenCount }),
+      programmes: __mf('patient.bulkInviteToClinic.programmesFragment', { count: cohortDetails.programmeCount, programmeNames: cohortDetails.programmeNames }) if cohortDetails.specificProgrammes else __('patient.bulkInviteToClinic.anyProgrammesFragment')
+    }) | nhsukMarkdown
+  }}
 
-  {{ checkboxes({
-    fieldset: {
-      legend: {
-        text: __("patient.bulkInviteToClinic.programme.label"),
-        size: "m"
-      }
-    },
-    items: checkboxItems,
-    decorate: "clinicProgramme_ids"
-  }) }}
+  {% if clinicReadyProgrammes.length > 1 %}
+
+    {# Show checkboxes: can invite to clinic for multiple programmes #}
+    {{ checkboxes({
+      fieldset: {
+        legend: {
+          text: __("patient.bulkInviteToClinic.programme.label"),
+          size: "m"
+        }
+      },
+      items: checkboxItems,
+      decorate: "clinicProgramme_ids"
+    }) }}
+
+    {# Warn about inviting to any programmes that have no scheduled clinics #}
+    {{ warningCallout({
+      heading: __("patient.bulkInviteToClinic.scheduledClinicWarning.title"),
+      text: __mf("patient.bulkInviteToClinic.scheduledClinicWarning.description",
+        {
+          programmeNames: clinicReadyProgrammesWithoutClinics.names,
+          count: clinicReadyProgrammesWithoutClinics.count
+        }) | safe
+    }) if clinicReadyProgrammesWithoutClinics.count > 0 }}
+
+  {% else %}
+
+    {# Hide checkboxes: can invite to clinic for only a single programme #}
+    {% if clinicReadyProgrammesWithoutClinics.count === 0 %}
+      {# Clinics ARE scheduled: tell the user how many #}
+      {{ __mf("patient.bulkInviteToClinic.clinicCount.someParagraph",
+      {
+        programmeName: clinicReadyProgrammes[0].name | replace("Flu", "flu"),
+        count: clinicReadyProgrammes[0].clinicCount
+      }) | nhsukMarkdown }}
+    {% else %}
+      {# Clinics are NOT scheduled: warn about inviting to clinic #}
+      {{ warningCallout({
+        heading: __("patient.bulkInviteToClinic.scheduledClinicWarning.title"),
+        text: __("patient.bulkInviteToClinic.clinicCount.noneParagraph",
+          {
+            programmeName: clinicReadyProgrammes[0].name | replace("Flu", "flu")
+          })
+      }) }}
+    {% endif %}
+
+    {# Fake the user's selection of a checkbox for this one programme #}
+    <input type="hidden" id="clinicProgramme_ids" name="clinicProgramme_ids" value="{{clinicReadyProgrammes[0].programme_id}}" />
+  {% endif %}
+{% endblock %}
+
+{% block afterForm %}
+  {# Include a link to back out if there are no clinics available for the clinic-ready programmes #}
+  {% if clinicReadyProgrammes.length === clinicReadyProgrammesWithoutClinics.count %}
+    {{ appButtonGroup({
+      buttons: [{
+        text: confirmButtonText,
+        variant: confirmButtonVariant
+      }],
+      links: [{
+        text: __("patient.bulkInviteToClinic.cancel"),
+        href: "/patients" + query | asQueryString
+      }]
+    }) }}
+  {% else %}
+    {{ super() }}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
The invite to clinic page from the individual child record already had warnings about inviting to clinic when no clinics are set up to target specific programmes, but that hadn't been added to the bulk invite page yet. This PR rectifies that.

Example: lack-of-clinics warning when no programmes were selected in the child filters (ignore the pink box):
<img width="1558" height="2143" alt="image" src="https://github.com/user-attachments/assets/f738ad61-1f12-4559-983f-ced84a05636d" />

Example: lack-of-clinics warning when multiple programmes were selected:
<img width="1522" height="1803" alt="image" src="https://github.com/user-attachments/assets/055df67b-5985-419d-8bde-383f8cdf685d" />

Example: lack-of-clinics warning when a single programme was selected:
<img width="1496" height="978" alt="image" src="https://github.com/user-attachments/assets/c8964ae5-55cd-4647-8145-7a45cc752cea" />

Note that you also get a link to back out when there are literally no options to invite children to a programme that _does_ have clinics scheduled.