### PR TITLE
Create less data before linting project in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
 permissions:
   contents: read
 
+env:
+  BATCHES: 1
+  RECORDS: 1
+  TEAMS: 1
+  USERS: 1
+
 jobs:
   lint-and-create-data:
     runs-on: ubuntu-latest


### PR DESCRIPTION
An alternative approach to #285 which means we can still catch any errors generating data.

| Approach | Time     |
| -------- | -------- |
| Original | 6m 37s + |
| PR 285   | 34s      |
| This PR  | 33s      |