### PR TITLE
Display communication needs to SAIS teams

### DIFF
--- a/app/controllers/give-or-refuse-consent.js
+++ b/app/controllers/give-or-refuse-consent.js
@@ -158,9 +158,7 @@ export const giveOrRefuseConsentController = {
         [`/${session_id}/parental-responsibility`]: {
           data: 'consent.parent.hasParentalResponsibility',
           value: 'false'
-        },
-        [`/${session_id}/${consent_uuid}/new/decision`]: () =>
-          !request.session.data.consent?.parent?.tel
+        }
       },
       [`/${session_id}/${consent_uuid}/new/contact-preference`]: {},
       [`/${session_id}/${consent_uuid}/new/decision`]: {

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -54,6 +54,11 @@ export const patientController = {
         href: patient.uri,
         current: currentPath === patient.uri
       },
+      {
+        text: __('patient.parents.label'),
+        href: `${patient.uri}/contacts`,
+        current: currentPath === `${patient.uri}/contacts`
+      },
       ...Object.values(patient.programmes).map((patientProgramme) => {
         return {
           text: patientProgramme.programme.name,

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -54,6 +54,13 @@ export function generateConsent(
     return
   }
 
+  // If telephone number provided, sometimes add a communication need
+  if (parent.tel && faker.datatype.boolean(0.2)) {
+    parent.contactPreference = true
+    parent.contactPreferenceDetails =
+      'I sometimes have difficulty hearing phone calls, so it’s best to send me a text message.'
+  }
+
   // Decision
   const decision = faker.helpers.weightedArrayElement([
     { value: ReplyDecision.Given, weight: 10 },

--- a/app/generators/parent.js
+++ b/app/generators/parent.js
@@ -46,7 +46,7 @@ export function generateParent(childLastName, isMum) {
   const phoneNumber = '077## 9#####'.replace(/#+/g, (m) =>
     faker.string.numeric(m.length)
   )
-  const tel = faker.helpers.maybe(() => phoneNumber, { probability: 0.4 })
+  const tel = faker.helpers.maybe(() => phoneNumber, { probability: 0.6 })
 
   const sms = faker.datatype.boolean(0.5)
   const smsStatus = faker.helpers.weightedArrayElement([

--- a/app/generators/parent.js
+++ b/app/generators/parent.js
@@ -67,8 +67,6 @@ export function generateParent(childLastName, isMum) {
     { value: NotifyEmailStatus.Technical, weight: 1 }
   ])
 
-  const contactPreference = faker.datatype.boolean(0.2)
-
   return new Parent({
     fullName: `${firstName} ${lastName}`,
     relationship,
@@ -82,12 +80,7 @@ export function generateParent(childLastName, isMum) {
     ...(tel && {
       tel,
       sms,
-      ...(smsStatus && { smsStatus }),
-      contactPreference,
-      ...(contactPreference && {
-        contactPreferenceDetails:
-          'I sometimes have difficulty hearing phone calls, so it’s best to send me a text message.'
-      })
+      ...(smsStatus && { smsStatus })
     })
   })
 }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1323,7 +1323,12 @@ export const en = {
       label: 'Phone number'
     },
     contactPreference: {
-      label: 'Communication needs'
+      label: 'Communication needs',
+      yes: 'Yes',
+      no: 'No'
+    },
+    contactPreferenceDetails: {
+      label: 'Give details'
     },
     relationshipOther: {
       label: 'Give details'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1298,6 +1298,9 @@ export const en = {
   },
   parent: {
     label: 'Parent or guardian',
+    new: {
+      label: 'Add a new contact'
+    },
     fullName: {
       label: 'Name'
     },
@@ -1545,7 +1548,7 @@ export const en = {
       label: 'Year group'
     },
     parents: {
-      label: 'Parents or guardians'
+      label: 'Contacts'
     },
     vaccinations: {
       label: 'Vaccinations'
@@ -1554,9 +1557,6 @@ export const en = {
       label: 'Parent or guardian',
       fullName: {
         label: 'Name'
-      },
-      relationship: {
-        label: 'Relationship to child'
       },
       notify: {
         label: 'Send notifications'
@@ -1567,16 +1567,25 @@ export const en = {
       tel: {
         label: 'Phone number'
       },
+      relationship: {
+        label: 'Relationship to child'
+      },
       relationshipOther: {
         label: 'Relationship to the child'
+      },
+      contactPreference: {
+        label: 'Communication needs',
+        yes: 'Yes',
+        no: 'No'
+      },
+      contactPreferenceDetails: {
+        label: 'Give details'
       }
     },
     parent1: {
-      label: 'First parent or guardian',
       title: 'Details for first parent or guardian'
     },
     parent2: {
-      label: 'Second parent or guardian',
       title: 'Details for second parent or guardian'
     },
     programmes: {

--- a/app/models/parent.js
+++ b/app/models/parent.js
@@ -39,8 +39,7 @@ export class Parent {
     this.emailStatus = this?.email && options?.emailStatus
     this.sms = stringToBoolean(options.sms) || false
     this.smsStatus = this?.tel && options?.smsStatus
-    this.contactPreference =
-      stringToBoolean(options?.contactPreference) || false
+    this.contactPreference = stringToBoolean(options?.contactPreference)
 
     if (this.contactPreference) {
       this.contactPreferenceDetails = options?.contactPreferenceDetails

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -29,10 +29,8 @@ import { getPreferredNames } from '../utils/reply.js'
 import {
   formatLink,
   formatLinkWithSecondaryText,
-  formatList,
   formatNhsNumber,
   formatOther,
-  formatParent,
   formatWithSecondaryText,
   stringToArray,
   stringToBoolean
@@ -478,7 +476,6 @@ export class Patient extends Child {
    */
   get formatted() {
     const formattedNhsn = formatNhsNumber(this.nhsn, this.invalid)
-    const formattedParents = this.parents.map((parent) => formatParent(parent))
 
     return {
       ...super.formatted,
@@ -487,9 +484,6 @@ export class Patient extends Child {
       newUrn:
         this.pendingChanges?.school_id &&
         schools[this.pendingChanges.school_id].name,
-      parent1: this.parent1 && formatParent(this.parent1),
-      parent2: this.parent2 && formatParent(this.parent2),
-      parents: formatList(formattedParents),
       archiveReason: formatOther(this.archiveReasonOther, this.archiveReason),
       lastReminderDate: this.lastReminderDate
         ? `Last reminder sent on ${this.lastReminderDate}`

--- a/app/views/give-or-refuse-consent/form/contact-preference.njk
+++ b/app/views/give-or-refuse-consent/form/contact-preference.njk
@@ -17,6 +17,7 @@
     },
     items: [{
       text: __("consent.parent.contactPreference.yes"),
+      value: true,
       conditional: {
         html: textarea({
           label: { text: __("consent.parent.contactPreferenceDetails.label") },
@@ -24,7 +25,8 @@
         })
       }
     }, {
-      text: __("consent.parent.contactPreference.no")
+      text: __("consent.parent.contactPreference.no"),
+      value: false
     }],
     decorate: "consent.parent.contactPreference"
   }) }}

--- a/app/views/patient-session/_consent.njk
+++ b/app/views/patient-session/_consent.njk
@@ -73,12 +73,16 @@
         },
         lastRowBorder: false,
         rows: summaryRows(reply, {
-          tel: {
-            value: appParentSms(reply.parent, reply.given)
-          } if reply.parent.tel,
           email: {
             value: appParentEmail(reply.parent, reply.given)
           } if reply.parent.email,
+          tel: {
+            value: appParentSms(reply.parent, reply.given)
+          } if reply.parent.tel,
+          contactPreference: {
+            label: __("parent.contactPreference.label"),
+            value: reply.parent.contactPreferenceDetails
+          } if reply.parent.contactPreferenceDetails,
           createdAt: {},
           decisionStatus: {},
           vaccineCriteria: {}
@@ -104,8 +108,9 @@
         },
         lastRowBorder: false,
         rows: summaryRows(parent, {
-          tel: {},
           email: {},
+          tel: {},
+          contactPreference: {},
           createdAt: {},
           decisionStatus: {
             label: __("reply.decisionStatus.label"),

--- a/app/views/patient/contacts.njk
+++ b/app/views/patient/contacts.njk
@@ -1,0 +1,56 @@
+{% from "patient/_navigation.njk" import patientNavigation with context %}
+
+{% extends "_layouts/form.njk" %}
+
+{% set gridColumns = "full" %}
+{% set hideConfirmButton = true %}
+{% set title = patient.initials %}
+
+{% block beforeContent %}
+  {{ breadcrumb({
+    items: [{
+      text: __("home.show.title"),
+      href: "/"
+    }, {
+      text: __("patient.list.title"),
+      href: "/patients"
+    }]
+  }) }}
+{% endblock %}
+
+{% block form %}
+  {{ super() }}
+
+  {{ patientNavigation({
+    patient: patient,
+    view: "show"
+  }) }}
+
+  {{ actionLink({
+    text: __("parent.new.label"),
+    href: "#"
+  }) }}
+
+  {% for parent in patient.parents %}
+    {{ summaryList({
+      card: {
+        heading: parent.fullNameAndRelationship,
+        headingLevel: 4,
+        actions: {
+          items: [{
+            text: "Edit",
+            href: patient.uri + "/edit/parent-" + loop.index
+          }, {
+            text: "Remove",
+            href: "#"
+          }]
+        }
+      },
+      rows: summaryRows(parent, {
+        email: {},
+        tel: {},
+        contactPreference: {}
+      })
+    }) }}
+  {% endfor %}
+{% endblock %}

--- a/app/views/patient/edit.njk
+++ b/app/views/patient/edit.njk
@@ -17,6 +17,7 @@
       heading: __("patient.edit.summary"),
       headingSize: "m"
     },
+    lastRowBorder: false,
     rows: [{
       key: {
         text: __("patient.nhsn.label")
@@ -109,38 +110,6 @@
           text: __("actions.change"),
           href: "edit/gp-surgery"
         }] if patient.gpSurgery
-      }
-    }, {
-      key: {
-        text: __("patient.parent1.label")
-      },
-      value: {
-        html: patient.formatted.parent1
-      },
-      actions: {
-        items: [{
-          text: __("actions.change"),
-          href: "edit/parent-1"
-        }, {
-          text: __("actions.remove"),
-          href: "#"
-        }]
-      }
-    }, {
-      key: {
-        text: __("patient.parent2.label")
-      },
-      value: {
-        html: patient.formatted.parent2
-      },
-      actions: {
-        items: [{
-          text: __("actions.change"),
-          href: "edit/parent-2"
-        }, {
-          text: __("actions.remove"),
-          href: "#"
-        }]
       }
     }]
   }) }}

--- a/app/views/patient/form/parent.njk
+++ b/app/views/patient/form/parent.njk
@@ -45,4 +45,26 @@
     label: { text: __("patient.parent.tel.label") },
     decorate: "patient." + parent + ".tel"
   }) }}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        text: __("patient.parent.contactPreference.label")
+      }
+    },
+    items: [{
+      text: __("patient.parent.contactPreference.yes"),
+      value: true,
+      conditional: {
+        html: textarea({
+          label: { text: __("patient.parent.contactPreferenceDetails.label") },
+          decorate: "patient." + parent + ".contactPreferenceDetails"
+        })
+      }
+    }, {
+      text: __("patient.parent.contactPreference.no"),
+      value: false
+    }],
+    decorate: "patient." + parent + ".contactPreference"
+  }) }}
 {% endblock %}

--- a/app/views/patient/show.njk
+++ b/app/views/patient/show.njk
@@ -78,8 +78,7 @@
         address: {},
         schoolName: {},
         yearGroupWithRegistration: {},
-        gpSurgery: {},
-        parents: {}
+        gpSurgery: {}
       })
     }) }}
   {% endcall %}

--- a/app/views/reply/form/parent.njk
+++ b/app/views/reply/form/parent.njk
@@ -54,4 +54,26 @@
     label: { text: __("parent.tel.label") + " (optional)" },
     decorate: "reply.parent.tel"
   }) }}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        text: __("parent.contactPreference.label")
+      }
+    },
+    items: [{
+      text: __("parent.contactPreference.yes"),
+      value: true,
+      conditional: {
+        html: textarea({
+          label: { text: __("parent.contactPreferenceDetails.label") },
+          decorate: "reply.parent.contactPreferenceDetails"
+        })
+      }
+    }, {
+      text: __("parent.contactPreference.no"),
+      value: false
+    }],
+    decorate: "reply.parent.contactPreference"
+  }) }}
 {% endblock %}


### PR DESCRIPTION
A very long time ago, we changed how we ask for a parent’s communication needs in the parental consent journey. As a reminder, here is that question (and how it is shown when reviewing answers):

<p><img width="2398" height="2136" alt="If we need to contact you form." src="https://github.com/user-attachments/assets/d6940564-ffce-4e5e-8c77-c4add1dcdbfb" /></p>

<p><img width="2398" height="5042" alt="Check answer before submitting consent." src="https://github.com/user-attachments/assets/fead2fde-44ba-4016-915d-4d5df36baab7" /></p>

> [!NOTE]
>
> One change from the previous design is that we now want to ask this question to all parents, not just those that provide a telephone number.

## Verbal consent journey

We also need to reflect this change in the SAIS-facing verbal consent journey:

<img width="2398" height="3394" alt="get-verbal-consent-parent" src="https://github.com/user-attachments/assets/8076f641-f9d0-4f9a-b25f-a1bc2a294167" />
 
## Display this answer to SAIS teams (in session context)

We need to show the answer to SAIS teams when reviewing/managing a session.

If (and only if) a parent has a communication need, show that on the consent card on the patient session page:

<img width="1634" height="1576" alt="consent-card" src="https://github.com/user-attachments/assets/89d3efda-42ef-499d-94fb-c5385ddbdf28" />

All replies should show the answer to this question:

<img width="2398" height="2800" alt="Reply" src="https://github.com/user-attachments/assets/7518e1c8-b8dd-44fd-b38d-12674b7221c2" />

## Display this answer to SAIS teams (in global context)

When viewing a child, you can see all their related contacts, each of which shows that contacts communication needs:

<p><img width="2398" height="2764" alt="Patient contacts" src="https://github.com/user-attachments/assets/585de71f-9cf0-4610-bca5-53cc2971311f" /></p>

When editing a contact, you can edit their communication needs:

<p><img width="2398" height="3294" alt="Contacts - edit contact." src="https://github.com/user-attachments/assets/ef96b0b1-409d-472d-b7c0-8ce9bfe93c41" /></p>

> [!NOTE]
>
> A separate PR will improve the management of contacts, making them a separate entity in the prototype and showing (updated) screens for editing, deleting, etc.
