### PR TITLE
Clinic booking: add another child

### DIFF
--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -60,9 +60,11 @@ export const bookIntoClinicController = {
 
     // Create a new clinic booking in the wizard context
     const booking = ClinicBooking.create({}, data.wizard)
+    booking.addAppointment()
+    const firstAppointment = booking.appointments[0]
 
     // Redirect to the first page in the booking journey (after the start page, that is)
-    const redirectUrl = `${request.baseUrl}/${booking.bookingUri}/new/child-count`
+    const redirectUrl = `${firstAppointment.uri.new}/child`
 
     return response.redirect(redirectUrl)
   },
@@ -112,6 +114,10 @@ export const bookIntoClinicController = {
         const currentAppointment = booking.findAppointment(appointment_uuid)
         response.locals.appointment = currentAppointment
 
+        // Check answers needs a version of the appointment that can find its booking on the context
+        response.locals.wizardAppointment =
+          wizardBooking.findAppointment(appointment_uuid)
+
         response.locals.childNumber =
           booking.appointments.indexOf(currentAppointment) + 1
         response.locals.childCount = booking.appointments.length
@@ -129,7 +135,6 @@ export const bookIntoClinicController = {
 
     const journey = {
       [`/`]: {},
-      [`/${booking_uuid}/new/child-count`]: {},
 
       // Appointment journey; once per child
       ...getAllAppointmentPaths(
@@ -137,6 +142,7 @@ export const bookIntoClinicController = {
         request.session.data,
         booking.appointments
       ),
+      [`/${booking_uuid}/new/add-another`]: {},
 
       // Parent journey
       [`/${booking_uuid}/new/parent`]: {
@@ -185,7 +191,10 @@ export const bookIntoClinicController = {
     let { booking_uuid } = request.params
     let view = String(request.params.view)
 
-    if (view === 'address-selection') {
+    if (view === 'child') {
+      console.log(request.originalUrl)
+      console.log(JSON.stringify(appointment, null, 2))
+    } else if (view === 'address-selection') {
       // Build the options for the selection of a home address address from those already entered
       const booking = ClinicBooking.findOne(booking_uuid, data.wizard)
       response.locals.previousAddressItems = getPreviousAddressItems(
@@ -450,7 +459,7 @@ export const bookIntoClinicController = {
 
       // Start the appointment journey for the first child
       const firstAppointment = booking.appointments[0]
-      const firstAppointmentUrl = `${request.baseUrl}/${booking.bookingUri}/new/${firstAppointment.uuid}/child`
+      const firstAppointmentUrl = `${firstAppointment.uri.new}/child`
       paths.next = firstAppointmentUrl
     } else if (
       view === 'address-selection' &&
@@ -482,6 +491,31 @@ export const bookIntoClinicController = {
         currentAppointment.session_id = request.body.transaction.sessionChoice
         ClinicBooking.update(booking.uuid, booking, data.wizard)
       }
+    } else if (view === 'add-another') {
+      // If the user elected to add another, create the new appointment and override the default redirect
+      const addAnother = request.body.transaction.addAnother === 'true'
+      if (addAnother) {
+        const booking = ClinicBooking.findOne(booking_uuid, data.wizard)
+        const appointment = booking.addAppointment()
+        ClinicBooking.update(booking.uuid, booking, data.wizard)
+
+        // Clear out values we don't want pre-selected for the next child
+        delete data.appointment
+        delete data.transaction.addAnother
+        delete data.transaction.addressChoice
+        delete data.transaction.sessionChoice
+        delete data.transaction.timeRange
+        delete data.transaction.time
+
+        paths.next = `${appointment.uri.new}/child`
+      }
+    } else if (view === 'remove-appointment') {
+      // The user's chosen to remove an appointment
+      const booking = ClinicBooking.findOne(booking_uuid, data.wizard)
+      booking.removeAppointment(String(appointment_uuid))
+      ClinicBooking.update(booking.uuid, booking, data.wizard)
+
+      paths.next = `${booking.uri.new}/add-another`
     }
 
     // NB: request.session.save was needed to avoid race condition issues on heroku

--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -1,5 +1,6 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import wizard from '@x-govuk/govuk-prototype-wizard'
+import { addMinutes } from 'date-fns'
 import _ from 'lodash'
 
 import { ParentalRelationship, SessionStatus, SessionType } from '../enums.js'
@@ -381,7 +382,7 @@ export const bookIntoClinicController = {
         ([formattedTime, availability]) => {
           appointmentTimeItems.push({
             text: formattedTime,
-            value: formatTime(availability.date, false),
+            value: availability.date.toISOString(),
             hint: {
               text: __mf('clinicBooking.time.nurses', {
                 count: availability.count
@@ -491,6 +492,17 @@ export const bookIntoClinicController = {
         currentAppointment.session_id = request.body.transaction.sessionChoice
         ClinicBooking.update(booking.uuid, booking, data.wizard)
       }
+    } else if (view === 'appointment-time') {
+      const booking = ClinicBooking.findOne(booking_uuid, data.wizard)
+      const appointment = booking?.findAppointment(appointment_uuid)
+      const appointmentLengthInMinutes =
+        Session.findOne(appointment.session_id, data)?.appointmentLength ?? 10
+
+      const startAt = new Date(request.body.transaction.time)
+      const endAt = addMinutes(startAt, appointmentLengthInMinutes)
+      _.merge(appointment, { startAt, endAt })
+
+      ClinicBooking.update(booking_uuid, booking, data.wizard)
     } else if (view === 'add-another') {
       // If the user elected to add another, create the new appointment and override the default redirect
       const addAnother = request.body.transaction.addAnother === 'true'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -291,6 +291,24 @@ export const en = {
     },
     vaccinations: {
       label: 'Vaccinations'
+    },
+    extraTime: {
+      label: 'Is extra time needed?'
+    },
+    fluVaccineType: {
+      label: 'Flu vaccine'
+    },
+    fluAlternative: {
+      label: 'Flu alternative accepted?'
+    },
+    mmrAlternative: {
+      label: 'MMR vaccine'
+    },
+    homeAddress: {
+      label: 'Home address'
+    },
+    parentalRelationship: {
+      label: 'Your relationship'
     }
   },
   clinicBooking: {
@@ -485,6 +503,30 @@ export const en = {
       },
       nurses:
         '{count, plural, =0 {No nurses available} one {1 nurse available} other {{count} nurses available}}'
+    },
+    'check-appointment': {
+      title: 'Check %s’s appointment details',
+      summary: {
+        child: 'Child details',
+        vaccination: 'Vaccination details',
+        appointment: 'Appointment details'
+      },
+      confirm: 'Confirm'
+    },
+    addAnother: {
+      title: 'Add, change, or remove appointments',
+      summary: {
+        title: 'Appointments',
+        child: {
+          label: 'Child'
+        }
+      },
+      question: 'Do you want to add another child?'
+    },
+    removeAppointment: {
+      title: 'Are you sure you want to remove %s’s appointment?',
+      confirm: 'Yes, remove this appointment',
+      cancel: 'No, return to the previous page'
     },
     parent: {
       title: 'About you',

--- a/app/middleware/navigation.js
+++ b/app/middleware/navigation.js
@@ -29,10 +29,19 @@ export const navigation = (request, response, next) => {
       'MMR(V)': getSessionConsentUrl(sessions, SessionPresetName.MMR)
     },
     clinicInviteUrl: {
-      Flu: getClinicInviteUrl(SessionPresetName.Flu),
-      HPV: getClinicInviteUrl(SessionPresetName.HPV),
-      Doubles: getClinicInviteUrl(SessionPresetName.Doubles),
-      'MMR(V)': getClinicInviteUrl(SessionPresetName.MMR)
+      Flu: getClinicInviteUrl([SessionPresetName.Flu]),
+      HPV: getClinicInviteUrl([SessionPresetName.HPV]),
+      Doubles: getClinicInviteUrl([SessionPresetName.Doubles]),
+      'MMR(V)': getClinicInviteUrl([SessionPresetName.MMR]),
+      'adolescent programmes': getClinicInviteUrl([
+        SessionPresetName.HPV,
+        SessionPresetName.Doubles
+      ]),
+      'all but flu': getClinicInviteUrl([
+        SessionPresetName.HPV,
+        SessionPresetName.Doubles,
+        SessionPresetName.MMR
+      ])
     }
   }
 

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -12,6 +12,7 @@ import {
 import { formatDate } from '../utils/date.js'
 import {
   formatLinkWithSecondaryText,
+  formatWithSecondaryText,
   stringToArray,
   stringToBoolean
 } from '../utils/string.js'
@@ -243,6 +244,26 @@ export class ClinicAppointment {
       ]
         .filter(Boolean)
         .join('<br>'),
+      homeAddress: this.child.formatted.address,
+      parentalRelationship: this.parent?.formatted.relationship,
+      ...(this.fluDecision && this.fluDecision !== ReplyDecision.NoResponse
+        ? { fluVaccineType: this.fluDecision }
+        : {}),
+      ...(this.fluAlternative !== undefined
+        ? { fluAlternative: this.fluAlternative ? 'Yes' : 'No' }
+        : {}),
+      ...(this.mmrAlternative !== undefined
+        ? {
+            mmrAlternative: this.mmrAlternative
+              ? 'Must not contain gelatine'
+              : 'No preference'
+          }
+        : {}),
+      extraTime: formatWithSecondaryText(
+        this.needsExtraTime ? 'Yes' : 'No',
+        this.extraTimeReason,
+        true
+      ),
       location: Object.values(session?.clinic?.location ?? {})
         .filter(Boolean)
         .join(', '),
@@ -257,19 +278,32 @@ export class ClinicAppointment {
   }
 
   /**
+   * Get the parent for this appointment's child
+   *
+   * @returns {Parent} parent with the correct relationship to this appointment's child
+   */
+  get parent() {
+    // Take most details from the parent in the booking
+    const parent = new Parent(this.booking?.parent ?? {})
+    if (parent) {
+      parent.relationship = this.parentalRelationship
+      parent.relationshipOther = this.parentalRelationshipOther
+      parent.hasParentalResponsibility = this.parentHasParentalResponsibility
+    }
+
+    return parent
+  }
+
+  /**
    * Get formatted links
    *
    * @returns {object} Formatted links
    */
   get link() {
-    const parent = new Parent({
-      fullName: this.booking?.parent?.fullName,
-      relationship: this.parentalRelationship
-    })
     return {
-      summary: formatLinkWithSecondaryText(
-        this.uri,
-        parent.fullNameAndRelationship,
+      unmatched: formatLinkWithSecondaryText(
+        this.uri.unmatched,
+        this.parent.fullNameAndRelationship,
         `for ${this.child.fullName}`
       )
     }
@@ -287,10 +321,13 @@ export class ClinicAppointment {
   /**
    * Get URI, without the context of the session
    *
-   * @returns {string} URI
+   * @returns {object} an object with various URIs for this appointment
    */
   get uri() {
-    return `/appointments/${this.uuid}`
+    return {
+      unmatched: `/appointments/${this.uuid}`,
+      new: `/book-into-a-clinic/${this.booking_uuid}/new/${this.uuid}`
+    }
   }
 
   /**

--- a/app/models/clinic-booking.js
+++ b/app/models/clinic-booking.js
@@ -42,23 +42,17 @@ export class ClinicBooking {
   }
 
   /**
-   * Get URI of the booking journey
-   *
-   * @returns {string} Booking journey URI
-   */
-  get bookingUri() {
-    return `${this.uuid}`
-  }
-
-  /**
    * Add a new appointment to this clinic booking
    *
    * @param {object} options - any specific values to give the new period
    * @returns {ClinicAppointment} - the new clinic appointment
    */
   addAppointment(options) {
+    const appointment = new ClinicAppointment(options, this.context)
+    appointment.booking_uuid = this.uuid
+
     this.appointments = this.appointments || []
-    this.appointments.push(new ClinicAppointment(options, this.context))
+    this.appointments.push(appointment)
 
     return this.appointments.at(-1)
   }
@@ -125,10 +119,13 @@ export class ClinicBooking {
   /**
    * Get URI
    *
-   * @returns {string} URI
+   * @returns {object} An object containing different URLs for this booking
    */
   get uri() {
-    return `/clinic-bookings/${this.uuid}`
+    return {
+      new: `/book-into-a-clinic/${this.uuid}/new`,
+      debug: `/clinic-bookings/${this.uuid}`
+    }
   }
 
   /**
@@ -194,7 +191,17 @@ export class ClinicBooking {
 
     // Copy updates into the relevant booking
     const existingBooking = ClinicBooking.findOne(uuid, context)
-    const updatedBooking = _.merge(existingBooking, updates)
+    const updatedBooking = _.mergeWith(
+      existingBooking,
+      updates,
+      (oldValue, newValue) => {
+        // The appointments array shouldn’t be merged but replaced entirely, or updates following
+        // the removal of a non-last appointment will result in appointment duplication
+        if (Array.isArray(oldValue)) {
+          return newValue
+        }
+      }
+    )
 
     // Remove booking context
     delete updatedBooking.context

--- a/app/utils/clinic-appointment.js
+++ b/app/utils/clinic-appointment.js
@@ -77,7 +77,7 @@ export const getAllAppointmentPaths = (
         : {}),
       [`/${booking_uuid}/new/${appointment_uuid}/preferred-location`]: {
         [`/${booking_uuid}/new/${appointment_uuid}/clinic-location`]: () => {
-          const searchTerm = sessionData.transaction.preferredLocation
+          const searchTerm = sessionData.transaction?.preferredLocation
           const searchType = getLocationSearchType(searchTerm)
           switch (searchType) {
             case LocationSearchType.Postcode:
@@ -99,7 +99,8 @@ export const getAllAppointmentPaths = (
       [`/${booking_uuid}/new/${appointment_uuid}/clinic-location`]: {},
       [`/${booking_uuid}/new/${appointment_uuid}/clinic-date`]: {},
       [`/${booking_uuid}/new/${appointment_uuid}/appointment-time-range`]: {},
-      [`/${booking_uuid}/new/${appointment_uuid}/appointment-time`]: {}
+      [`/${booking_uuid}/new/${appointment_uuid}/appointment-time`]: {},
+      [`/${booking_uuid}/new/${appointment_uuid}/check-appointment`]: {}
     }
   })
 

--- a/app/utils/clinic-booking.js
+++ b/app/utils/clinic-booking.js
@@ -4,15 +4,15 @@ import { SessionPresets } from '../enums.js'
 /**
  * Generate a URL for booking into a clinic whose primary programme is given by the session preset
  *
- * @param {string} sessionPresetName - the primary programme for the clinic
+ * @param {Array<string>} sessionPresetNames - the programmes for which the child has been invited to clinic
  * @returns {string} - path to the start of the clinic booking journey for the given programme
  */
-export const getClinicInviteUrl = (sessionPresetName) => {
-  const sessionPreset = SessionPresets.find(
-    (preset) => preset.name === sessionPresetName
+export const getClinicInviteUrl = (sessionPresetNames) => {
+  const sessionPresets = SessionPresets.filter((preset) =>
+    sessionPresetNames.includes(preset.name)
   )
-  const programme_ids = sessionPreset.programmeTypes.map(
-    (type) => programmesData[type].id
+  const programme_ids = sessionPresets.flatMap((preset) =>
+    preset.programmeTypes.map((type) => programmesData[type].id)
   )
 
   const searchParams = new URLSearchParams()

--- a/app/views/appointments/list.njk
+++ b/app/views/appointments/list.njk
@@ -31,7 +31,7 @@
     {% set appointmentRows = appointmentRows | push([
       {
         header: __("appointments.summary.label"),
-        html: appointment.link.summary | replace("/appointments", appointmentsPath)
+        html: appointment.link.unmatched | replace("/appointments", appointmentsPath)
       },
       {
         header: __("appointments.location.label"),

--- a/app/views/book-into-a-clinic/form/add-another.njk
+++ b/app/views/book-into-a-clinic/form/add-another.njk
@@ -1,0 +1,58 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("clinicBooking.addAnother.title") %}
+
+{% block form %}
+  {{ appHeading({
+    title: title
+  }) }}
+
+  {% set appointmentRows = [] %}
+  {% for appointment in booking.appointments %}
+    {% set appointmentRows = appointmentRows | push([
+      {
+        header: __("clinicBooking.addAnother.summary.child.label"),
+        html: appointment.fullName
+      },
+      {
+        header: __("actions.label"),
+        html: appActionList({
+          items: [{
+            text: __("actions.change"),
+            href: appointment.uri.new + "/check-appointment"
+          }, {
+            text: __("actions.remove"),
+            href: appointment.uri.new + "/remove-appointment"
+          } if booking.appointments.length > 1]
+        })
+      }
+    ]) %}
+  {% endfor %}
+
+  {{ table({
+    id: "appointments",
+    responsive: true,
+    card: {
+      heading: __("clinicBooking.addAnother.summary.title"),
+      headingSize: "m"
+    },
+    head: [
+      { text: __("clinicBooking.addAnother.summary.child.label") },
+      { text: __("actions.label") }
+    ],
+    rows: appointmentRows
+  }) if appointmentRows.length }}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        html: appHeading({
+          size: "m",
+          title: __("clinicBooking.addAnother.question")
+        })
+      }
+    },
+    items: getBooleanItems(),
+    decorate: "transaction.addAnother"
+  }) }}
+{% endblock %}

--- a/app/views/book-into-a-clinic/form/check-answers.njk
+++ b/app/views/book-into-a-clinic/form/check-answers.njk
@@ -4,7 +4,7 @@
 {% set title = __("clinicBooking.check-answers.title") %}
 {% set gridColumns = "three-quarters" %}
 {% macro editPath(view) -%}
-  {{- view }}?referrer={{ clinicBooking.bookingUri }}/new/check-answers
+  {{- view }}?referrer={{ clinicBooking.uri.new }}/check-answers
 {%- endmacro %}
 
 {% block form %}

--- a/app/views/book-into-a-clinic/form/check-appointment.njk
+++ b/app/views/book-into-a-clinic/form/check-appointment.njk
@@ -1,0 +1,74 @@
+{% extends "_layouts/form.njk" %}
+
+{% set confirmButtonText = __("clinicBooking.check-appointment.confirm") %}
+{% set title = __("clinicBooking.check-appointment.title", firstName) %}
+
+{% block form %}
+  {{ appHeading({
+    title: title
+  }) }}
+
+  {{ summaryList({
+    card: {
+      heading: __("clinicBooking.check-appointment.summary.child"),
+      headingSize: "m"
+    },
+    lastRowBorder: false,
+    rows: summaryRows(appointment, {
+      nameAndAge: {
+        href: appointment.uri.new + "/child"
+      },
+      homeAddress: {
+        href: appointment.uri.new + "/address"
+      },
+      parentalRelationship: {
+        href: appointment.uri.new + "/parental-relationship",
+        value: wizardAppointment.formatted.parentalRelationship
+      }
+    })
+  }) }}
+
+  {{ summaryList({
+    card: {
+      heading: __("clinicBooking.check-appointment.summary.vaccination"),
+      headingSize: "m"
+    },
+    lastRowBorder: false,
+    rows: summaryRows(appointment, {
+      vaccinations: {
+        href: appointment.uri.new + "/programmes"
+      },
+      fluVaccineType: {
+        href: appointment.uri.new + "/flu-choice"
+      },
+      fluAlternative: {
+        href: appointment.uri.new + "/flu-alternative"
+      },
+      mmrAlternative: {
+        href: appointment.uri.new + "/mmr-alternative"
+      }
+    })
+  }) }}
+
+  {{ summaryList({
+    card: {
+      heading: __("clinicBooking.check-appointment.summary.appointment"),
+      headingSize: "m"
+    },
+    lastRowBorder: false,
+    rows: summaryRows(appointment, {
+      location: {
+        href: appointment.uri.new + "/clinic-location"
+      },
+      date: {
+        href: appointment.uri.new + "/clinic-date"
+      },
+      timeSlot: {
+        href: appointment.uri.new + "/appointment-time-range"
+      },
+      extraTime: {
+        href: appointment.uri.new + "/extra-time"
+      }
+    })
+  }) }}
+{% endblock %}

--- a/app/views/book-into-a-clinic/form/confirmation.njk
+++ b/app/views/book-into-a-clinic/form/confirmation.njk
@@ -32,16 +32,6 @@
         appointment. You will also be able to answer any unanswered health questions via this link.
         Doing this ahead of the clinic will save time on the day.
       </p>
-
-      <h2 class="nhsuk-heading-l">
-        Help us to improve this service
-      </h2>
-
-      <p>
-        Are you willing to answer some questions about your visit today? This typically takes around 2 minutes.
-      </p>
-
-      <p><a href="#">Take our survey</a></p>
     </div>
   </div>
 {% endblock %}

--- a/app/views/book-into-a-clinic/form/remove-appointment.njk
+++ b/app/views/book-into-a-clinic/form/remove-appointment.njk
@@ -1,0 +1,37 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("clinicBooking.removeAppointment.title", firstName) %}
+
+{% block form %}
+  {{ appHeading({
+    title: title
+  }) }}
+
+  {{ summaryList({
+    card: {
+      heading: appointment.fullName,
+      headingSize: "s",
+      headingLevel: 4
+    },
+    lastRowBorder: false,
+    rows: summaryRows(appointment, {
+      location: {},
+      date: {},
+      vaccinations: {}
+    })
+  }) }}
+{% endblock %}
+
+{% block afterForm %}
+  {{ appButtonGroup({
+    buttons: [{
+      text: __("clinicBooking.removeAppointment.confirm"),
+      variant: "warning"
+    }],
+    links: [{
+      text: __("clinicBooking.removeAppointment.cancel"),
+      href: booking.uri.new + "/add-another"
+    }]
+  }) }}
+{% endblock %}
+

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -87,6 +87,16 @@
           }) }}
         {% endif %}
       {% endfor %}
+      {{ actionLink({
+        classes: "nhsuk-u-margin-bottom-2",
+        text: "Start page for parents to book into a clinic for the adolescent programmes",
+        href: navigation.clinicInviteUrl["adolescent programmes"]
+      }) }}
+      {{ actionLink({
+        classes: "nhsuk-u-margin-bottom-2",
+        text: "Start page for parents to book into a clinic for all but flu",
+        href: navigation.clinicInviteUrl["all but flu"]
+      }) }}
 
     </main>
   </div>


### PR DESCRIPTION
Rather than locking the parent into booking multiple appointments at the _start_ of the booking journey, leave the decision to add more children until they've been through the process of adding the first.

For this change, the initial 'How many children' question has been dropped and the following pages have been added:

- Check Answers page for an individual child's appointment
- Add Another page to allow the parent to check which children they've booked in and add another
- Confirm Remove page to allow the parent to remove an appointment from their booking