### PR TITLE
Add heading to vaccination reports, remove card from monthly vaccinations table

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2021,6 +2021,7 @@ export const en = {
     vaccinations: {
       label: 'Vaccinations',
       title: 'Vaccinations',
+      total: 'Total vaccinations for this cohort',
       team: 'Monthly vaccinations by %s'
     },
     consent: {

--- a/app/views/report/vaccinations.njk
+++ b/app/views/report/vaccinations.njk
@@ -22,6 +22,12 @@
     </app-auto-submit>
 
     <div class="nhsuk-grid-column-three-quarters">
+      {{ appHeading({
+        title: __("report.vaccinations.total"),
+        level: 2,
+        size: "m"
+      }) }}
+
       <div class="nhsuk-grid-row nhsuk-card-group">
         <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
           {{ appDataCard({
@@ -60,11 +66,8 @@
 
       {{ table({
         responsive: true,
-        card: {
-          feature: true,
-          heading: __("report.vaccinations.team", data.team.ods),
-          headingLevel: 2
-        },
+        caption: __("report.vaccinations.team", data.team.ods),
+        captionSize: "m",
         head: [
           {
             text: "Month"


### PR DESCRIPTION
Ensure top cards have a heading to group them, and remove cards from tables to give them more horizontal space.

<img width="2400" height="2000" alt="Manage vaccinations in schools – NHS" src="https://github.com/user-attachments/assets/8639b57f-8e26-4097-87b1-726f1adc5d8a" />
