### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A point of care (POC) prototype, built using the [NHS.UK Prototype Rig](https://
 
 Point of Care Systems record data when someone is vaccinated, including product and batch details, and the recording of adverse reactions.
 
-<https://digital.nhs.uk/coronavirus/vaccinations/training-and-onboarding/point-of-care>
+<https://digital.nhs.uk/services/vaccinations-point-of-care>
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A point of care (POC) prototype, built using the [NHS.UK Prototype Rig](https://
 
 Point of Care Systems record data when someone is vaccinated, including product and batch details, and the recording of adverse reactions.
 
-<https://digital.nhs.uk/services/vaccinations-point-of-care>
-
 ## Requirements
 
 Node.js v22.21


### PR DESCRIPTION
The README link to https://digital.nhs.uk/coronavirus/vaccinations/training-and-onboarding/point-of-care now hits a 404.

This could work as an alternative https://digital.nhs.uk/services/vaccinations-point-of-care