### PR TITLE
Allow users to choose where notes appear (session, programme or child record)

### DIFF
--- a/app/assets/stylesheets/components/_timeline.scss
+++ b/app/assets/stylesheets/components/_timeline.scss
@@ -94,7 +94,7 @@ $_timeline-border-width: 2px;
       border-color: nhsuk-colour("blue");
     }
 
-    &--pinned blockquote {
+    &--highlighted blockquote {
       padding-right: nhsuk-spacing(3);
       border-color: nhsuk-tint(nhsuk-colour("warm-yellow"), 10%);
       background-color: nhsuk-tint(nhsuk-colour("warm-yellow"), 70%);

--- a/app/assets/stylesheets/components/_timeline.scss
+++ b/app/assets/stylesheets/components/_timeline.scss
@@ -93,6 +93,12 @@ $_timeline-border-width: 2px;
     &--past::before {
       border-color: nhsuk-colour("blue");
     }
+
+    &--pinned blockquote {
+      padding-right: nhsuk-spacing(3);
+      border-color: nhsuk-tint(nhsuk-colour("warm-yellow"), 10%);
+      background-color: nhsuk-tint(nhsuk-colour("warm-yellow"), 70%);
+    }
   }
 
   &__badge {

--- a/app/controllers/activity.js
+++ b/app/controllers/activity.js
@@ -155,7 +155,7 @@ export const activityController = {
             name: activity.note.created(AuditEventType.SessionNote),
             note: 'Mum phoned to say child will be arriving at school at 11am',
             createdBy_uid,
-            programme_ids: ['flu']
+            session_id: session.id
           }),
           auditEvent({
             name: activity.note.created(AuditEventType.RecordNote),

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -140,6 +140,13 @@ export const patientSessionController = {
       ]
     ]
 
+    response.locals.programmeItems = [
+      ...patientSession.siblingPatientSessions.map((patientSession) => ({
+        text: patientSession.programme.name,
+        value: patientSession.programme_id
+      }))
+    ]
+
     response.locals.referrer = patientSession.uri
     response.locals.patientProgramme = patientProgramme
     response.locals.patientSession = patientSession
@@ -382,15 +389,24 @@ export const patientSessionController = {
    */
   note(request, response) {
     const { account } = request.app.locals
-    const { note, pinned } = request.body
+    let { note, pinned, type, programme_ids } = request.body
     const { data } = request.session
     const { __, back, patientSession } = response.locals
+
+    programme_ids = Array.isArray(programme_ids)
+      ? programme_ids
+      : [programme_ids]
 
     patientSession.saveNote({
       note,
       pinned,
-      type: AuditEventType.SessionNote,
-      createdBy_uid: account.uid
+      type,
+      createdBy_uid: account.uid,
+      session_id:
+        type === AuditEventType.SessionNote && patientSession.session_id,
+      programme_ids:
+        type === AuditEventType.ProgrammeNote &&
+        programme_ids?.filter((programme_id) => programme_id !== '_unchecked')
     })
 
     // Clean up session data

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -389,7 +389,7 @@ export const patientSessionController = {
    */
   note(request, response) {
     const { account } = request.app.locals
-    let { note, pinned, type, programme_ids } = request.body
+    let { note, type, programme_ids } = request.body
     const { data } = request.session
     const { __, back, patientSession } = response.locals
 
@@ -399,7 +399,6 @@ export const patientSessionController = {
 
     patientSession.saveNote({
       note,
-      pinned,
       type,
       createdBy_uid: account.uid,
       session_id:

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -1,4 +1,5 @@
 import {
+  AuditEventType,
   ConsentOutcome,
   ConsentWindow,
   InstructionOutcome,
@@ -388,6 +389,7 @@ export const patientSessionController = {
     patientSession.saveNote({
       note,
       pinned,
+      type: AuditEventType.SessionNote,
       createdBy_uid: account.uid
     })
 

--- a/app/enums.js
+++ b/app/enums.js
@@ -54,6 +54,7 @@ export const AuditEventType = {
   Notice: 'Notice',
   Reminder: 'Reminder',
   Record: 'Change to child record',
+  ProgrammeNote: 'Programme note',
   RecordNote: 'Child record note',
   SessionNote: 'Session note'
 }

--- a/app/globals.js
+++ b/app/globals.js
@@ -3,6 +3,7 @@ import { decorate } from 'nhsuk-decorated-components'
 
 import { healthQuestions } from './datasets/health-questions.js'
 import {
+  AuditEventType,
   InstructionOutcome,
   PatientConsentStatus,
   PatientRefusedStatus,
@@ -157,7 +158,7 @@ export default () => {
 
       timelineItems.push({
         headingText: formatMarkdown(auditEvent.name),
-        isPinnedItem: auditEvent.pinned,
+        isHighlightedItem: auditEvent.type === AuditEventType.SessionNote,
         isPastItem: auditEvent.isPastEvent,
         html:
           auditEvent.note &&

--- a/app/globals.js
+++ b/app/globals.js
@@ -157,6 +157,7 @@ export default () => {
 
       timelineItems.push({
         headingText: formatMarkdown(auditEvent.name),
+        isPinnedItem: auditEvent.pinned,
         isPastItem: auditEvent.isPastEvent,
         html:
           auditEvent.note &&

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1343,8 +1343,8 @@ export const en = {
     },
     pinned: {
       label: 'Pinned',
-      title: 'Do you want to pin this note?',
-      hint: 'Pinned notes show at the top of session pages and on search results within a session'
+      title: 'Pin note',
+      hint: 'Pin note to the top of session pages and search results'
     },
     outcome: {
       label: 'Outcome'
@@ -1751,16 +1751,16 @@ export const en = {
     notes: {
       label: 'Notes',
       new: {
-        title: 'Add a session note',
-        confirm: 'Save session note',
-        success: 'Session note added'
+        title: 'Add a note',
+        confirm: 'Save note',
+        success: 'Note added'
       }
     },
     pinnedNotes: {
-      label: 'Session notes'
+      label: 'Pinned session notes'
     },
     pinnedNote: {
-      label: 'Session note'
+      label: 'Pinned session note'
     },
     patientProgramme: {
       label: 'View child’s %s record'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1341,11 +1341,6 @@ export const en = {
       label: 'Note',
       hint: 'Notes are visible to all users, and cannot be edited or deleted'
     },
-    pinned: {
-      label: 'Pinned',
-      title: 'Pin note',
-      hint: 'Pin note to the top of session pages and search results'
-    },
     outcome: {
       label: 'Outcome'
     }
@@ -1746,7 +1741,7 @@ export const en = {
       title: 'Child record'
     },
     events: {
-      title: 'Session notes and activity'
+      title: 'Activity and notes'
     },
     notes: {
       label: 'Notes',
@@ -1756,11 +1751,12 @@ export const en = {
         success: 'Note added'
       }
     },
-    pinnedNotes: {
-      label: 'Pinned session notes'
+    sessionNotes: {
+      label: 'Session notes'
     },
-    pinnedNote: {
-      label: 'Pinned session note'
+    sessionNote: {
+      label: 'Session note',
+      hint: 'The most recent session note is shown at the top of session pages and in search results'
     },
     patientProgramme: {
       label: 'View child’s %s record'

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -19,8 +19,7 @@ import { getScreenOutcomeStatus } from '../utils/status.js'
 import {
   formatTag,
   formatMarkdown,
-  formatWithSecondaryText,
-  stringToBoolean
+  formatWithSecondaryText
 } from '../utils/string.js'
 
 /**
@@ -33,7 +32,6 @@ import {
  * @property {string} name - Name
  * @property {string} [note] - Note
  * @property {import('../enums.js').AuditEventType} [type] - Audit event type
- * @property {boolean} [pinned] - Pinned
  * @property {object} [messageRecipient] - Message recipient
  * @property {string} [messageTemplate] - Message template
  * @property {Array} [updatedFields] - Updated fields
@@ -53,7 +51,6 @@ export class AuditEvent {
     this.name = options.name
     this.note = options.note
     this.type = options?.type
-    this.pinned = stringToBoolean(options?.pinned) || false
     this.messageRecipient = options?.messageRecipient
     this.messageTemplate = options?.messageTemplate
     this.updatedFields = options?.updatedFields

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -53,7 +53,7 @@ export class AuditEvent {
     this.name = options.name
     this.note = options.note
     this.type = options?.type
-    this.pinned = stringToBoolean(options?.pinned)
+    this.pinned = stringToBoolean(options?.pinned) || false
     this.messageRecipient = options?.messageRecipient
     this.messageTemplate = options?.messageTemplate
     this.updatedFields = options?.updatedFields

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -1,6 +1,7 @@
 import { addMonths, addWeeks } from 'date-fns'
 
 import {
+  AuditEventType,
   PatientClinicStatus,
   PatientConsentStatus,
   PatientDeferredStatus,
@@ -111,10 +112,11 @@ export class PatientProgramme {
   get auditEvents() {
     return this.patient.events
       .map((auditEvent) => new AuditEvent(auditEvent, this.context))
+      .filter(({ type }) => type === AuditEventType.ProgrammeNote)
       .filter(({ programme_ids }) =>
         programme_ids?.some((id) => this.programme_id === id)
       )
-      .sort((a, b) => getDateValueDifference(a.createdAt, b.createdAt))
+      .sort((a, b) => getDateValueDifference(b.createdAt, a.createdAt))
   }
 
   /**

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -161,9 +161,9 @@ export class PatientSession {
    * @returns {object} Events grouped by date
    */
   get auditEventLog() {
-    return this.auditEvents
-      .sort((a, b) => getDateValueDifference(b.createdAt, a.createdAt))
-      .reverse()
+    return this.auditEvents.sort((a, b) =>
+      getDateValueDifference(b.createdAt, a.createdAt)
+    )
   }
 
   /**

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -150,8 +150,13 @@ export class PatientSession {
   get auditEvents() {
     return this.patient?.events
       .map((auditEvent) => new AuditEvent(auditEvent, this.context))
-      .filter(({ programme_ids }) =>
-        programme_ids?.some((id) => this.session?.programme_ids.includes(id))
+      .filter(
+        ({ programme_ids, session_id }) =>
+          (programme_ids &&
+            programme_ids.some((id) =>
+              this.session?.programme_ids.includes(id)
+            )) ||
+          session_id === this.session_id
       )
   }
 
@@ -161,9 +166,13 @@ export class PatientSession {
    * @returns {object} Events grouped by date
    */
   get auditEventLog() {
-    return this.auditEvents.sort((a, b) =>
-      getDateValueDifference(b.createdAt, a.createdAt)
-    )
+    return [...this.auditEvents].sort((a, b) => {
+      if (a.pinned !== b.pinned) {
+        // Show pinned items first
+        return a.pinned ? -1 : 1
+      }
+      return getDateValueDifference(b.createdAt, a.createdAt)
+    })
   }
 
   /**
@@ -173,6 +182,7 @@ export class PatientSession {
    */
   get triageNotes() {
     return this.auditEvents
+      .filter(({ type }) => type === AuditEventType.ProgrammeNote)
       .filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
       .filter(({ outcome }) => outcome)
   }
@@ -184,7 +194,7 @@ export class PatientSession {
    */
   get pinnedNotes() {
     return this.auditEvents
-      .filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
+      .filter(({ session_id }) => session_id === this.session_id)
       .filter(({ pinned }) => pinned)
       .sort((a, b) => getDateValueDifference(b.createdAt, a.createdAt))
   }
@@ -1148,8 +1158,10 @@ export class PatientSession {
       name: activity.note.created(event.type),
       note: event.note,
       pinned: event.pinned,
+      type: event.type || AuditEventType.SessionNote,
       createdBy_uid: event.createdBy_uid,
-      programme_ids: this.session?.programme_ids
+      programme_ids: event.programme_ids,
+      session_id: event.session_id
     })
   }
 

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -166,11 +166,7 @@ export class PatientSession {
    * @returns {object} Events grouped by date
    */
   get auditEventLog() {
-    return [...this.auditEvents].sort((a, b) => {
-      if (a.pinned !== b.pinned) {
-        // Show pinned items first
-        return a.pinned ? -1 : 1
-      }
+    return this.auditEvents.sort((a, b) => {
       return getDateValueDifference(b.createdAt, a.createdAt)
     })
   }
@@ -188,14 +184,14 @@ export class PatientSession {
   }
 
   /**
-   * Get pinned session notes
+   * Get session notes
    *
    * @returns {Array<import('./audit-event.js').AuditEvent>} Audit event
    */
-  get pinnedNotes() {
+  get sessionNotes() {
     return this.auditEvents
+      .filter(({ type }) => type === AuditEventType.SessionNote)
       .filter(({ session_id }) => session_id === this.session_id)
-      .filter(({ pinned }) => pinned)
       .sort((a, b) => getDateValueDifference(b.createdAt, a.createdAt))
   }
 
@@ -1157,7 +1153,6 @@ export class PatientSession {
     this.patient?.addEvent({
       name: activity.note.created(event.type),
       note: event.note,
-      pinned: event.pinned,
       type: event.type || AuditEventType.SessionNote,
       createdBy_uid: event.createdBy_uid,
       programme_ids: event.programme_ids,

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -187,6 +187,11 @@ export class Patient extends Child {
     return [...contacts.values()]
   }
 
+  /**
+   * Get child record events
+   *
+   * @returns {Array<AuditEvent>} Child record events
+   */
   get recordEvents() {
     const recordEvents = []
 
@@ -242,7 +247,7 @@ export class Patient extends Child {
       .filter(({ type }) =>
         [AuditEventType.Record, AuditEventType.RecordNote].includes(type)
       )
-      .sort((a, b) => getDateValueDifference(a.createdAt, b.createdAt))
+      .sort((a, b) => getDateValueDifference(b.createdAt, a.createdAt))
   }
 
   /**
@@ -671,6 +676,7 @@ export class Patient extends Child {
     if (patientSession?.session) {
       this.addEvent({
         name: activity.session.added(patientSession.session),
+        type: AuditEventType.ProgrammeNote,
         createdAt: patientSession.session.openAt,
         createdBy_uid: patientSession.session.createdBy_uid,
         programme_ids: patientSession.session.programme_ids
@@ -691,6 +697,7 @@ export class Patient extends Child {
     for (const contact of this.contacts) {
       this.addEvent({
         name: activity.notify['invite-clinic'](contact),
+        type: AuditEventType.ProgrammeNote,
         messageRecipient: contact,
         messageTemplate: 'invite-clinic',
         patient_uuid: this.uuid,
@@ -712,6 +719,7 @@ export class Patient extends Child {
       ) {
         this.addEvent({
           name: activity.notify.invite(contact),
+          type: AuditEventType.ProgrammeNote,
           messageRecipient: contact,
           messageTemplate: 'invite',
           createdAt: patientSession.session.openAt,
@@ -747,6 +755,7 @@ export class Patient extends Child {
     this.reply_uuids.push(reply.uuid)
     this.addEvent({
       name,
+      type: AuditEventType.ProgrammeNote,
       createdAt: isNew ? reply.createdAt : today(),
       createdBy_uid: reply.createdBy_uid,
       programme_ids: [reply.programme_id]
@@ -764,6 +773,7 @@ export class Patient extends Child {
     this.addEvent({
       name: activity.vaccination.recorded(vaccination),
       note: vaccination.note,
+      type: AuditEventType.ProgrammeNote,
       createdAt: vaccination.updatedAt || vaccination.createdAt,
       createdBy_uid: vaccination.createdBy_uid,
       programme_ids: [vaccination.programme_id]

--- a/app/views/_macros/timeline.njk
+++ b/app/views/_macros/timeline.njk
@@ -6,8 +6,9 @@
   {% set headingLevel = params.headingLevel if params.headingLevel else 3 %}
   {% set headingBold = "nhsuk-u-font-weight-bold" if item.active else "" %}
   {% set isPastItem = "app-timeline__item--past" if item.isPastItem else "" %}
+  {% set isPinnedItem = "app-timeline__item--pinned" if item.isPinnedItem else "" %}
 
-  <li class="app-timeline__item {{ isPastItem | trim }}">
+  <li class="app-timeline__item {{ isPastItem | trim }} {{ isPinnedItem | trim }}">
     {% if item.active or item.isPastItem %}
       <svg class="app-timeline__badge" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
         <circle cx="14" cy="14" r="13" fill="#005EB8"/>

--- a/app/views/_macros/timeline.njk
+++ b/app/views/_macros/timeline.njk
@@ -6,9 +6,9 @@
   {% set headingLevel = params.headingLevel if params.headingLevel else 3 %}
   {% set headingBold = "nhsuk-u-font-weight-bold" if item.active else "" %}
   {% set isPastItem = "app-timeline__item--past" if item.isPastItem else "" %}
-  {% set isPinnedItem = "app-timeline__item--pinned" if item.isPinnedItem else "" %}
+  {% set isHighlightedItem = "app-timeline__item--highlighted" if item.isHighlightedItem else "" %}
 
-  <li class="app-timeline__item {{ isPastItem | trim }} {{ isPinnedItem | trim }}">
+  <li class="app-timeline__item {{ isPastItem | trim }} {{ isHighlightedItem | trim }}">
     {% if item.active or item.isPastItem %}
       <svg class="app-timeline__badge" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
         <circle cx="14" cy="14" r="13" fill="#005EB8"/>

--- a/app/views/patient-session/_note.njk
+++ b/app/views/patient-session/_note.njk
@@ -4,7 +4,8 @@
 }) %}
   {{ textarea({
     label: {
-      text: __("event.note.label")
+      text: __("event.note.label"),
+      size: "s"
     },
     hint: {
       text: __("event.note.hint")
@@ -15,13 +16,48 @@
 
   {{ radios({
     fieldset: {
-      legend: { text: __("event.pinned.title") }
+      legend: {
+        text: "What do you want to add this note to?",
+        size: "s"
+      }
     },
-    hint: { text: __("event.pinned.hint") },
-    inline: true,
-    items: getBooleanItems(),
-    decorate: "pinned"
+    items: [{
+      text: "Programme",
+      value: AuditEventType.ProgrammeNote,
+      conditional: {
+        html: checkboxes({
+          items: programmeItems,
+          decorate: "programme_ids"
+        })
+      }
+    } if session.programmes.length > 1 else {
+      text: session.programmeNames.titleCase + " programme",
+      value: AuditEventType.ProgrammeNote
+    }, {
+      text: "Session",
+      value: AuditEventType.SessionNote,
+      conditional: {
+        html: checkboxes({
+          items: [{
+            text: __("event.pinned.title"),
+            hint: { text: __("event.pinned.hint") },
+            value: true
+          }],
+          decorate: "pinned"
+        })
+      }
+    }, {
+      text: "Child record",
+      value: AuditEventType.RecordNote
+    }],
+    decorate: "type"
   }) }}
+
+  {{ input({
+    type: "hidden",
+    value: session.programme_ids[0],
+    decorate: "programme_ids"
+  }) if session.programmes.length == 1 }}
 
   {{ button({
     text: __("patientSession.notes.new.confirm"),

--- a/app/views/patient-session/_note.njk
+++ b/app/views/patient-session/_note.njk
@@ -22,6 +22,10 @@
       }
     },
     items: [{
+      text: "Session",
+      value: AuditEventType.SessionNote,
+      hint: { text: __("patientSession.sessionNote.hint") }
+    }, {
       text: "Programme",
       value: AuditEventType.ProgrammeNote,
       conditional: {
@@ -33,19 +37,6 @@
     } if session.programmes.length > 1 else {
       text: session.programmeNames.titleCase + " programme",
       value: AuditEventType.ProgrammeNote
-    }, {
-      text: "Session",
-      value: AuditEventType.SessionNote,
-      conditional: {
-        html: checkboxes({
-          items: [{
-            text: __("event.pinned.title"),
-            hint: { text: __("event.pinned.hint") },
-            value: true
-          }],
-          decorate: "pinned"
-        })
-      }
     }, {
       text: "Child record",
       value: AuditEventType.RecordNote

--- a/app/views/patient-session/events.njk
+++ b/app/views/patient-session/events.njk
@@ -26,17 +26,6 @@
 
   {% include "patient-session/_note.njk" %}
 
-  {% if patientSession.pinnedNotes.length %}
-    {% for auditEvent in patientSession.pinnedNotes %}
-      {{ card({
-        classes: "app-card--orange",
-        heading: auditEvent.name,
-        headingLevel: 3,
-        descriptionHtml: appEvent({ auditEvent: auditEvent, showProgrammes: true })
-      }) }}
-    {% endfor %}
-  {% endif %}
-
   {{ appTimeline({
     items: timelineItems(patientSession.auditEventLog)
   }) }}

--- a/app/views/patient-session/events.njk
+++ b/app/views/patient-session/events.njk
@@ -14,9 +14,6 @@
     }, {
       text: __("session.report.title"),
       href: session.uri + "/report"
-    }, {
-      text: __("session." + activity + ".label"),
-      href: session.uri + "/" + activity
     }]
   }) }}
 {% endblock %}

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -13,10 +13,7 @@
     }, {
       text: __("session.report.title"),
       href: session.uri + "/report"
-    }, {
-      text: __("session." + activity + ".label"),
-      href: session.uri + "/" + activity
-    } if activity]
+    }]
   }) }}
 {% endblock %}
 
@@ -54,10 +51,10 @@
 
       {% include "patient-session/_report.njk" %}
 
-      {% for auditEvent in patientSession.pinnedNotes %}
+      {% for auditEvent in patientSession.sessionNotes %}
         {{ card({
           classes: "nhsuk-u-margin-top-2 app-card--orange",
-          heading: __("patientSession.pinnedNote.label"),
+          heading: __("patientSession.sessionNote.label"),
           headingLevel: 3,
           descriptionHtml: appEvent({ auditEvent: auditEvent, showProgrammes: true })
         }) }}

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -57,7 +57,7 @@
       {% for auditEvent in patientSession.pinnedNotes %}
         {{ card({
           classes: "nhsuk-u-margin-top-2 app-card--orange",
-          heading: auditEvent.name,
+          heading: __("patientSession.pinnedNote.label"),
           headingLevel: 3,
           descriptionHtml: appEvent({ auditEvent: auditEvent, showProgrammes: true })
         }) }}

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -117,14 +117,14 @@
                   value: reportStatusHtml
                 },
                 notes: {
-                  label: __("patientSession.pinnedNote.label"),
+                  label: __("patientSession.sessionNotes.label"),
                   value: appEvent({
-                    auditEvent: patientSession.pinnedNotes[0],
+                    auditEvent: patientSession.sessionNotes[0],
                     showProgrammes: false,
                     truncate: 300,
                     patientSession: patientSession
                   })
-                } if patientSession.pinnedNotes[0]
+                } if patientSession.sessionNotes[0]
               })
             }) }}
 


### PR DESCRIPTION
Session notes can be optionally pinned:

<p><img width="2400" height="4480" alt="Session notes and activity" src="https://github.com/user-attachments/assets/389367a5-63d7-4f28-b806-faaaade71d9b" /></p>

If a session has multiple programmes associated with it, a user can select which programmes the note should be associated with:

<p><img width="2400" height="3848" alt="Session notes and activity" src="https://github.com/user-attachments/assets/1279e71f-833e-421b-8908-59822095314f" /></p>

## Todo

- [ ] Review functionality
- [ ] Review content