### PR TITLE
Descope and re-order the parent clinic booking

### DIFF
--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -13,7 +13,6 @@ import {
 import { ClinicBooking, Programme, Session } from '../models.js'
 import {
   getAllAppointmentPaths,
-  getHealthQuestionPaths,
   getPreviousAddressItems,
   getPreviousSessionItems
 } from '../utils/clinic-appointment.js'
@@ -71,7 +70,7 @@ export const bookIntoClinicController = {
     const firstAppointment = booking.appointments[0]
 
     // Redirect to the first page in the booking journey (after the start page, that is)
-    const redirectUrl = `${firstAppointment.uri.new}/child`
+    const redirectUrl = `${firstAppointment.uri.new}/programmes`
 
     return request.session.save((error) => {
       if (!error) response.redirect(redirectUrl)
@@ -84,32 +83,6 @@ export const bookIntoClinicController = {
   readForm(request, response, next) {
     const { appointment_uuid, booking_uuid } = request.params
     const { data, referrer } = request.session
-
-    /**
-     * NOTE:
-     *
-     * The nature of the journey here is complex, as there are two separate sections in which we need to
-     * iterate over children. Or over appointments, if you want to think of it that way (each child has
-     * their own appointment). And the second iteration - the health questions - has pages that are
-     * dependent on the answers given during the appointment booking (specifically, the choice of vaccines
-     * per child).
-     *
-     * So, it goes:
-     * - Start page
-     * - How many children?
-     *   - Child name         <-- first page of the per-child appointment journey
-     *   - Child DOB
-     *   - ...
-     *   - Appointment time   <-- final page of the per-child appointment journey; iterate to next child if required
-     * - Contact info
-     * - Check answers
-     * - Health questions?
-     *   - Health question 1  <-- first page of the per-child health question journey
-     *   - ...
-     *   - Health question n  <-- final page of the per-child health question journey; iterate to next child if required
-     * - Confirmation
-     *
-     */
 
     // Create objects on the global context to allow us to check branching conditions, etc.
     // And make them available to the view.
@@ -151,31 +124,6 @@ export const bookIntoClinicController = {
         request.session.data,
         booking.appointments
       ),
-      [`/${booking_uuid}/new/add-another`]: {},
-
-      // Contact journey
-      [`/${booking_uuid}/new/contact`]: {
-        [`/${booking_uuid}/new/offer-health-questions`]: () =>
-          !request.session.data.booking?.contact?.tel
-      },
-      [`/${booking_uuid}/new/contact-preference`]: {},
-
-      // Health questions (optional)
-      [`/${booking_uuid}/new/offer-health-questions`]: {
-        [`/${booking_uuid}/new/confirmation`]: {
-          data: 'transaction.optedIntoHealthQuestions',
-          value: 'false'
-        }
-      },
-
-      // For each child being booked in, and their selected vaccinations, ask the
-      // relevant health questions and impairments/adjustments questions
-      ...getHealthQuestionPaths(
-        `/${booking_uuid}/new/`,
-        String(booking_uuid),
-        data.wizard,
-        data
-      ),
 
       // Confirmation! \o/
       [`/${booking_uuid}/new/confirmation`]: {}
@@ -213,8 +161,8 @@ export const bookIntoClinicController = {
         booking.appointments,
         data
       )
-    } else if (view === 'parental-relationship') {
-      // Prepare the radio options for the parental relationship page
+    } else if (view === 'parental-relationship' || view === 'contact') {
+      // Prepare the radio options for the parental relationship
       response.locals.parentalRelationshipItems = Object.values(
         ParentalRelationship
       )
@@ -224,47 +172,28 @@ export const bookIntoClinicController = {
           value: relationship
         }))
     } else if (view === 'programmes') {
-      response.locals.programmeItems = [
-        {
-          text: 'Flu',
-          value: 'flu',
+      // Create radio options for the programmes invited to (or flu if we've got none)
+      let programmes = data.clinicInvite.programme_ids
+        .map((programme_id) => Programme.findOne(programme_id, data))
+        .filter(Boolean)
+      programmes = programmes.length
+        ? programmes
+        : Programme.findOne('flu', data)
+
+      response.locals.programmeItems = programmes.map((programme) => {
+        const hint =
+          programme.type === ProgrammeType.MMR &&
+          appointment.child.canBeOfferedMmrv
+            ? programme.information.hintMmrv
+            : programme.information.hint
+        return {
+          text: programme.name,
+          value: programme.id,
           hint: {
-            text: 'Protects against flu, which can sometimes cause serious problems, such as pneumonia'
+            text: hint
           }
-        },
-        {
-          text: 'HPV',
-          value: 'hpv',
-          hint: {
-            text: 'Protects against human papillomavirus, some types of which are linked to an increased risk of certain types of cancer'
-          }
-        },
-        {
-          text: 'MenACWY',
-          value: 'menacwy',
-          hint: {
-            text: 'Protects against life-threatening illnesses like meningitis and sepsis'
-          }
-        },
-        {
-          text: 'Td/IPV',
-          value: 'td-ipv',
-          hint: { text: 'Protects against tetanus, diphtheria and polio' }
-        },
-        appointment.child.canBeOfferedMmrv
-          ? {
-              text: 'MMRV',
-              value: 'mmr',
-              hint: {
-                text: 'Protects against measles, mumps, rubella and varicella (chickenpox)'
-              }
-            }
-          : {
-              text: 'MMR',
-              value: 'mmr',
-              hint: { text: 'Protects against measles, mumps and rubella' }
-            }
-      ].filter(({ value }) => ['flu', 'mmr'].includes(value)) // test with these for now
+        }
+      })
     } else if (view === 'clinic-location') {
       const scheduledClinics = Session.findAll(data).filter(
         (session) =>

--- a/app/datasets/programmes.js
+++ b/app/datasets/programmes.js
@@ -51,6 +51,7 @@ export default {
         'Use this service to give or refuse consent for your child to have a flu vaccination.\n\nThis vaccination is recommended for school age children every year.\n\n## About the children’s flu vaccine\n\nThe children’s flu vaccine helps protect children against flu. Vaccinating children also protects others who are vulnerable to flu, such as babies and older people.\n\nThe vaccine is given as a nasal spray. This gives the most effective protection.\n\nSome children can have an injection instead, for example if they:\n\n- have had a serious allergic reaction to a previous dose of the nasal spray vaccine\n- have a severe egg allergy\n- have asthma that’s being treated with long-term steroid tablets\n- do not use gelatine or other animal products',
       description:
         'The vaccine protects against flu, which can cause serious health problems such as bronchitis and pneumonia. It is recommended for children from Reception to Year 11 every year.',
+      hint: 'Protects against flu, which can sometimes cause serious problems, such as pneumonia',
       url: 'https://www.nhs.uk/vaccinations/child-flu-vaccine/'
     },
     guidance: {
@@ -74,6 +75,7 @@ export default {
         'The HPV vaccine helps to prevent HPV related cancers from developing in boys and girls.\n\nThe number of doses you need depends on your age and how well your immune system works. Young people usually only need 1 dose.',
       description:
         'The HPV vaccine helps protect boys and girls against cancers caused by HPV, including:\n- cervical cancer\n- some mouth and throat (head and neck) cancers\n- some cancers of the anal and genital areas\n\nThe HPV vaccine has been given to girls since 2008. Following its success at helping prevent cervical cancers, it was introduced to boys in 2019 to help prevent HPV-related cancers that affect them.\n\nYoung people usually only need 1 dose.',
+      hint: 'Protects against human papillomavirus, some types of which are linked to an increased risk of certain types of cancer',
       url: 'https://www.nhs.uk/conditions/vaccinations/hpv-human-papillomavirus-vaccine/'
     },
     guidance: {
@@ -98,6 +100,7 @@ export default {
         'The MenACWY vaccine helps protect against meningitis and sepsis. It is recommended for all teenagers. Most people only need one dose of the vaccine.',
       description:
         'The MenACWY vaccine helps protect against life-threatening illnesses including meningitis, sepsis and septicaemia (blood poisoning).\n\nIt is recommended for all teenagers. Most people only need 1 dose of the vaccine.',
+      hint: 'Protects against life-threatening illnesses like meningitis and sepsis',
       url: 'https://www.nhs.uk/vaccinations/menacwy-vaccine/'
     },
     guidance: {
@@ -125,6 +128,9 @@ export default {
         'The MMR vaccine protects against measles, mumps and rubella. Having 2 doses gives lasting protection against all 3 illnesses. If you’re not sure how many doses your child has had, having further doses will not cause any harm. If your child has had 2 doses, please confirm this using the consent request form.\n\nResearch has shown there is no link between the MMR vaccine and autism.',
       description:
         'The MMR vaccine protects against measles, mumps and rubella. Having 2 doses gives lasting protection against all 3 illnesses. If you’re not sure how many doses your child has had, having further doses will not cause any harm.\n\nResearch has shown there is no link between the MMR vaccine and autism.',
+      hint: 'Protects against measles, mumps and rubella',
+      hintMmrv:
+        'Protects against measles, mumps, rubella and varicella (chickenpox)',
       url: 'https://www.nhs.uk/vaccinations/mmr-vaccine/'
     },
     guidance: {
@@ -148,6 +154,7 @@ export default {
         'The Td/IPV vaccine (also called the 3-in-1 teenage booster) helps protect against tetanus, diphtheria and polio.\n\nIt boosts the protection provided by the [6-in-1 vaccine](https://www.nhs.uk/vaccinations/6-in-1-vaccine/) and [4-in-1 pre-school booster vaccine](https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/).',
       description:
         'The Td/IPV vaccine (also called the 3-in-1 teenage booster) helps protect against tetanus, diphtheria and polio.\n\nIt’s offered at around 13 or 14 years old (school year 9 or 10). It boosts the protection provided by the [6-in-1 vaccine](https://www.nhs.uk/vaccinations/6-in-1-vaccine/) and [4-in-1 pre-school booster vaccine](https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/).',
+      hint: 'Protects against tetanus, diphtheria and polio',
       url: 'https://www.nhs.uk/vaccinations/td-ipv-vaccine-3-in-1-teenage-booster/'
     },
     guidance: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -278,6 +278,12 @@ export const en = {
     nameAndAge: {
       label: 'Child'
     },
+    fullName: {
+      label: 'Full name'
+    },
+    dob: {
+      label: 'Date of birth'
+    },
     location: {
       label: 'Clinic location'
     },
@@ -387,12 +393,12 @@ export const en = {
         'To give or refuse consent for a child’s vaccination, you need to have parental responsibility.\n\nIf you have any questions, please contact the local health organisation by calling {{team.tel}}, or email {{team.email}}.'
     },
     programmes: {
-      title: 'Do you consent to %s having the following vaccinations?',
+      title:
+        '{count, plural, one {Do you consent to {firstName} having the following vaccination?} other {Do you consent to {firstName} having the following vaccinations?}}',
       description: {
         matched:
           'While invited for {{ programmeNames }} vaccination, our records show that {{ firstName }} is also eligible for other vaccinations.'
       },
-      label: 'Select the vaccinations that you consent to %s having',
       hint: 'Each vaccine is given separately'
     },
     fluChoice: {
@@ -499,7 +505,8 @@ export const en = {
       summary: {
         child: 'Child details',
         vaccination: 'Vaccination details',
-        appointment: 'Appointment details'
+        appointment: 'Appointment details',
+        contact: 'Contact details'
       },
       confirm: 'Confirm'
     },

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -1,6 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
 import {
+  ParentalRelationship,
   ProgrammeType,
   ReplyDecision,
   VaccineCriteria,
@@ -15,7 +16,11 @@ import {
   Session
 } from '../models.js'
 import { formatDate } from '../utils/date.js'
-import { formatLinkWithSecondaryText, stringToArray } from '../utils/string.js'
+import {
+  formatLinkWithSecondaryText,
+  formatOther,
+  stringToArray
+} from '../utils/string.js'
 
 /**
  * @class ClinicAppointment
@@ -261,6 +266,13 @@ export class ClinicAppointment {
         fluVaccineType = 'Injected vaccine only'
         break
     }
+    const parentalRelationship =
+      this.parentalRelationship === ParentalRelationship.Other
+        ? formatOther(
+            ParentalRelationship.Other,
+            this.parentalRelationshipOther
+          )
+        : this.parentalRelationship
 
     return {
       nameAndAge: [
@@ -269,8 +281,9 @@ export class ClinicAppointment {
       ]
         .filter(Boolean)
         .join('<br>'),
+      dob: this.child.formatted.dob,
       homeAddress: this.child.formatted.address,
-      parentalRelationship: this.contact?.formatted.relationship,
+      parentalRelationship,
       ...(fluVaccineType ? { fluVaccineType } : {}),
       ...(this.mmrAlternative !== undefined
         ? {

--- a/app/models/clinic-booking.js
+++ b/app/models/clinic-booking.js
@@ -236,12 +236,16 @@ export class ClinicBooking {
         }
 
         // Willing to accept flu injection as alternative?
-        appointment.fluAlternative =
-          stringToBoolean(appointment.fluAlternative) || false
+        if (appointment?.fluAlternative) {
+          appointment.fluAlternative =
+            stringToBoolean(appointment.fluAlternative) || false
+        }
 
         // Gelatine free, or either type of MMR vaccine?
-        appointment.mmrAlternative =
-          stringToBoolean(appointment.mmrAlternative) || false
+        if (appointment?.mmrAlternative) {
+          appointment.mmrAlternative =
+            stringToBoolean(appointment.mmrAlternative) || false
+        }
 
         // Impairments
         if (appointment?.child?.impairments) {
@@ -255,6 +259,13 @@ export class ClinicBooking {
           appointment.child.adjustments = stringToArray(
             appointment.child.adjustments
           )
+        }
+
+        // Contact has parental responsibility?
+        if (appointment?.parentHasParentalResponsibility) {
+          appointment.parentHasParentalResponsibility =
+            stringToBoolean(appointment.parentHasParentalResponsibility) ||
+            false
         }
       }
     }

--- a/app/utils/clinic-appointment.js
+++ b/app/utils/clinic-appointment.js
@@ -26,27 +26,7 @@ export const getAllAppointmentPaths = (
   const pathsPerAppointment = appointments.map((appointment) => {
     const appointment_uuid = appointment.uuid
     return {
-      // Child details
-      [`/${booking_uuid}/new/${appointment_uuid}/child`]: {},
-      [`/${booking_uuid}/new/${appointment_uuid}/dob`]: {},
-      ...(appointments[0].uuid !== appointment_uuid &&
-      getPreviousAddressItems(appointments).length > 2
-        ? {
-            [`/${booking_uuid}/new/${appointment_uuid}/address-selection`]: {
-              [`/${booking_uuid}/new/${appointment_uuid}/parental-relationship`]:
-                () => sessionData.transaction.addressChoice !== 'new'
-            }
-          }
-        : {}),
-      [`/${booking_uuid}/new/${appointment_uuid}/address`]: {},
-      [`/${booking_uuid}/new/${appointment_uuid}/parental-relationship`]: {
-        [`/${booking_uuid}/new/${appointment_uuid}/parental-responsibility`]: {
-          data: 'appointment.parentHasParentalResponsibility',
-          value: 'false'
-        }
-      },
-
-      // Vaccinations (and types) and other appointment-length influences
+      // Vaccinations wanted
       [`/${booking_uuid}/new/${appointment_uuid}/programmes`]: {},
       ...(sessionData.appointment?.selected_programme_ids?.includes('flu')
         ? {
@@ -99,6 +79,30 @@ export const getAllAppointmentPaths = (
       [`/${booking_uuid}/new/${appointment_uuid}/clinic-date`]: {},
       [`/${booking_uuid}/new/${appointment_uuid}/appointment-time-range`]: {},
       [`/${booking_uuid}/new/${appointment_uuid}/appointment-time`]: {},
+
+      // Child details
+      [`/${booking_uuid}/new/${appointment_uuid}/child`]: {},
+      [`/${booking_uuid}/new/${appointment_uuid}/dob`]: {},
+      ...(appointments[0].uuid !== appointment_uuid &&
+      getPreviousAddressItems(appointments).length > 2
+        ? {
+            [`/${booking_uuid}/new/${appointment_uuid}/address-selection`]: {
+              [`/${booking_uuid}/new/${appointment_uuid}/contact`]: () =>
+                sessionData.transaction.addressChoice !== 'new'
+            }
+          }
+        : {}),
+      [`/${booking_uuid}/new/${appointment_uuid}/address`]: {},
+
+      // Parent contact details
+      [`/${booking_uuid}/new/${appointment_uuid}/contact`]: {
+        [`/${booking_uuid}/new/${appointment_uuid}/parental-responsibility`]: {
+          data: 'appointment.parentHasParentalResponsibility',
+          value: 'false'
+        }
+      },
+      [`/${booking_uuid}/new/contact-preference`]: {},
+
       [`/${booking_uuid}/new/${appointment_uuid}/check-appointment`]: {}
     }
   })

--- a/app/views/book-into-a-clinic/form/_parental-relationship.njk
+++ b/app/views/book-into-a-clinic/form/_parental-relationship.njk
@@ -1,0 +1,46 @@
+  {%- set fosterCarerHtml = radios({
+    fieldset: {
+      legend: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.delegatedLabel") }
+    },
+    hint: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.hint") },
+    items: getBooleanItems(),
+    decorate: "appointment.parentHasParentalResponsibility"
+  }) %}
+
+  {%- set guardianHtml = radios({
+    fieldset: {
+      legend: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.label") }
+    },
+    hint: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.hint") },
+    items: getBooleanItems(),
+    decorate: "appointment.parentHasParentalResponsibility"
+  }) %}
+
+  {%- set otherHtml = input({
+    label: { text: __("clinicBooking.parentalRelationship.relationshipOther.label") },
+    decorate: "appointment.parentalRelationshipOther"
+  }) + radios({
+    fieldset: {
+      legend: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.label") }
+    },
+    hint: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.hint") },
+    items: getBooleanItems(),
+    decorate: "appointment.parentHasParentalResponsibility"
+  }) %}
+
+  {# Add conditional html for ‘Foster carer’ option #}
+  {% set items = injectConditionalHtml(parentalRelationshipItems, ParentalRelationship.Fosterer, fosterCarerHtml) %}
+
+  {# Add conditional html for ‘Guardian’ option #}
+  {% set items = injectConditionalHtml(items, ParentalRelationship.Guardian, guardianHtml) %}
+
+  {# Add conditional html for ‘Other’ option #}
+  {% set items = injectConditionalHtml(items, ParentalRelationship.Other, otherHtml) %}
+
+  {{ radios({
+    fieldset: {
+      legend: { text: __("clinicBooking.parentalRelationship.relationship.label") }
+    },
+    items: items,
+    decorate: "appointment.parentalRelationship"
+  }) }}

--- a/app/views/book-into-a-clinic/form/check-appointment.njk
+++ b/app/views/book-into-a-clinic/form/check-appointment.njk
@@ -15,15 +15,14 @@
     },
     lastRowBorder: false,
     rows: summaryRows(appointment, {
-      nameAndAge: {
+      fullName: {
         href: appointment.uri.new + "/child"
+      },
+      dob: {
+        href: appointment.uri.new + "/dob"
       },
       homeAddress: {
         href: appointment.uri.new + "/address"
-      },
-      parentalRelationship: {
-        href: appointment.uri.new + "/parental-relationship",
-        value: wizardAppointment.formatted.parentalRelationship
       }
     })
   }) }}
@@ -62,6 +61,39 @@
       },
       timeSlot: {
         href: appointment.uri.new + "/appointment-time-range"
+      }
+    })
+  }) }}
+
+  {{ summaryList({
+    card: {
+      heading: __("clinicBooking.check-appointment.summary.contact"),
+      headingSize: "m"
+    },
+    lastRowBorder: false,
+    rows: summaryRows(booking.contact, {
+      fullName: {
+        href: appointment.uri.new + "/contact"
+      },
+      relationship: {
+        href: appointment.uri.new + "/contact",
+        value: wizardAppointment.formatted.parentalRelationship
+      },
+      hasParentalResponsibility: {
+        href: appointment.uri.new + "/contact",
+        value: wizardAppointment.parentHasParentalResponsibility
+      },
+      email: {
+        href: appointment.uri.new + "/contact"
+      },
+      tel: {
+        href: appointment.uri.new + "/contact"
+      },
+      sms: {
+        href: appointment.uri.new + "/contact"
+      },
+      contactPreference: {
+        href: booking.uri.new + "/contact-preference"
       }
     })
   }) }}

--- a/app/views/book-into-a-clinic/form/contact.njk
+++ b/app/views/book-into-a-clinic/form/contact.njk
@@ -16,6 +16,8 @@
       decorate: "booking.contact.fullName"
     }) }}
 
+    {% include "book-into-a-clinic/form/_parental-relationship.njk" %}
+
     {{ input({
       label: { text: __("clinicBooking.contact.email.label") },
       hint: { text: __("clinicBooking.contact.email.hint") },

--- a/app/views/book-into-a-clinic/form/parental-relationship.njk
+++ b/app/views/book-into-a-clinic/form/parental-relationship.njk
@@ -8,50 +8,9 @@
     caption: __("clinicBooking.appointment.caption", fullName) if childCount > 1
   }) }}
 
-  {%- set fosterCarerHtml = radios({
-    fieldset: {
-      legend: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.delegatedLabel") }
-    },
-    hint: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.hint") },
-    items: getBooleanItems(),
-    decorate: "appointment.parentHasParentalResponsibility"
-  }) %}
-
-  {%- set guardianHtml = radios({
-    fieldset: {
-      legend: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.label") }
-    },
-    hint: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.hint") },
-    items: getBooleanItems(),
-    decorate: "appointment.parentHasParentalResponsibility"
-  }) %}
-
-  {%- set otherHtml = input({
-    label: { text: __("clinicBooking.parentalRelationship.relationshipOther.label") },
-    decorate: "appointment.parentalRelationshipOther"
-  }) + radios({
-    fieldset: {
-      legend: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.label") }
-    },
-    hint: { text: __("clinicBooking.parentalRelationship.hasParentalResponsibility.hint") },
-    items: getBooleanItems(),
-    decorate: "appointment.parentHasParentalResponsibility"
-  }) %}
-
-  {# Add conditional html for ‘Foster carer’ option #}
-  {% set items = injectConditionalHtml(parentalRelationshipItems, ParentalRelationship.Fosterer, fosterCarerHtml) %}
-
-  {# Add conditional html for ‘Guardian’ option #}
-  {% set items = injectConditionalHtml(items, ParentalRelationship.Guardian, guardianHtml) %}
-
-  {# Add conditional html for ‘Other’ option #}
-  {% set items = injectConditionalHtml(items, ParentalRelationship.Other, otherHtml) %}
-
-  {{ radios({
-    fieldset: {
-      legend: { text: __("clinicBooking.parentalRelationship.relationship.label") }
-    },
-    items: items,
-    decorate: "appointment.parentalRelationship"
-  }) }}
+  {# 
+    This question is for use in multi-child journeys, when we reinstate them, as we
+    need to be able to define the contact's relationship with each child separately
+  #}
+  {% include "book-into-a-clinic/form/_parental-relationship.njk" %}
 {% endblock %}

--- a/app/views/book-into-a-clinic/form/programmes.njk
+++ b/app/views/book-into-a-clinic/form/programmes.njk
@@ -1,29 +1,22 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("clinicBooking.programmes.title", firstName) %}
+{% set title = __mf("clinicBooking.programmes.title", {
+  count: programmeItems.length,
+  firstName: firstName
+}) %}
 
 {% block form %}
-  {{ appHeading({
-    title: title,
-    caption: __("clinicBooking.appointment.caption", fullName) if childCount > 1
-  }) }}
-
-  {{
-    __("clinicBooking.programmes.description.matched",
-      {
-        firstName: firstName,
-        programmeNames: data.clinicInvite.programmeNames
-      }) | nhsukMarkdown
-  }}
-
   {{ checkboxes({
     fieldset: {
       legend: {
-        text: __("clinicBooking.programmes.label", firstName),
-        size: "m"
+        html: appHeading({
+          title: title,
+          caption: __("clinicBooking.appointment.caption", fullName) if childCount > 1
+        }),
+        size: "l"
       }
     },
-    hint: { text: __("clinicBooking.programmes.hint") },
+    hint: { text: __("clinicBooking.programmes.hint") } if programmeItems.length > 1,
     items: programmeItems,
     decorate: "appointment.selected_programme_ids"
   }) }}


### PR DESCRIPTION
We now ask to select a location immediately after choosing the vaccination(s). As a result, the journey has now dropped the idea of offering vaccinations based on the child's outstanding needs.

We now also present only a single-child journey (while maintaining mult-child capability in the back end). This has meant the parent relationship could be merged back into the contact page, and that contact info can be gathered as part of the appointment flow, including presenting it in the check answers page.

Finally, the health questions have been dropped from this flow (but I've left much of the code for now, in case we want to revert that after the pilot)