### PR TITLE
Allow SAIS teams to generate a booking link for clinics

### DIFF
--- a/app/assets/stylesheets/components/_copy.scss
+++ b/app/assets/stylesheets/components/_copy.scss
@@ -1,0 +1,24 @@
+@use "../vendor/nhsuk-frontend" as *;
+
+.nhsuk-copy-container {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.nhsuk-copy-text {
+  margin-bottom: 0;
+  word-break: break-all;
+}
+
+.nhsuk-copy-button {
+  display: none;
+  flex-shrink: 0; /* prevent the button being squashed */
+  margin-bottom: 0;
+}
+
+// Show the Copy button only when JavaScript is enabled
+.js-enabled .nhsuk-copy-button {
+  display: inline-block;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -3,6 +3,7 @@
 @forward "autocomplete";
 @forward "button";
 @forward "card";
+@forward "copy";
 @forward "count";
 @forward "details";
 @forward "environment";

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -10,6 +10,7 @@ import {
   RegistrationOutcome,
   SchoolPhase,
   SessionPresetName,
+  SessionStatus,
   SessionType,
   VaccineMethod
 } from '../enums.js'
@@ -19,18 +20,28 @@ import {
   Instruction,
   PatientSession,
   Patient,
+  Programme,
   School,
   Session,
   Team
 } from '../models.js'
+import { getClinicInviteUrlForProgrammes } from '../utils/clinic-booking.js'
 import {
   convertIsoDateToObject,
   getDateValueDifference,
   today
 } from '../utils/date.js'
 import { getResults, getPagination } from '../utils/pagination.js'
+import {
+  ConjunctionType,
+  programmeNamesListForSentence
+} from '../utils/programme.js'
 import { getSessionYearGroups } from '../utils/session.js'
-import { formatYearGroup } from '../utils/string.js'
+import {
+  formatMonospace,
+  formatYearGroup,
+  stringToArray
+} from '../utils/string.js'
 
 export const sessionController = {
   /**
@@ -85,7 +96,14 @@ export const sessionController = {
    * @type {import("express").RequestHandler}
    */
   readAll(request, response, next) {
-    response.locals.sessions = Session.findAll(request.session.data)
+    const sessions = Session.findAll(request.session.data)
+    const scheduledClinics = sessions.filter(
+      (session) =>
+        session.type === SessionType.Clinic &&
+        session.status === SessionStatus.Planned
+    )
+    response.locals.sessions = sessions
+    response.locals.clinicsAreScheduled = scheduledClinics.length > 0
 
     return next()
   },
@@ -122,6 +140,90 @@ export const sessionController = {
     )
 
     return response.redirect(`${session.uri}/new/type`)
+  },
+
+  /**
+   * @type {import("express").RequestHandler}
+   */
+  advertise(request, response) {
+    // Handling a GET for /sessions/advertise
+    const { data } = request.session
+    const { __mf } = response.locals
+
+    // Any refresh will reset stuff
+    delete data.clinicAdvert
+
+    // Set up the programme radio buttons
+    const sessions = Session.findAll(data)
+    const scheduledClinics = sessions.filter(
+      (session) =>
+        session.type === SessionType.Clinic &&
+        session.status === SessionStatus.Planned
+    )
+    const scheduledProgrammes = scheduledClinics
+      .flatMap(({ programme_ids }) => programme_ids)
+      .sort((a, b) => a.localeCompare(b))
+    const programmeFrequencyMap = _.countBy(scheduledProgrammes)
+
+    response.locals.programmeItems = Object.entries(programmeFrequencyMap).map(
+      ([programme_id, count]) => ({
+        text: Programme.findOne(programme_id, data)?.name,
+        value: programme_id,
+        hint: {
+          text: __mf('session.advertise.programmes.programme.hint', { count })
+        }
+      })
+    )
+
+    return response.render('session/advert-programmes')
+  },
+
+  /**
+   * @type {import("express").RequestHandler}
+   */
+  updateAdvertLink(request, response) {
+    // Handling a POST for /sessions/advertise
+    const { clinicAdvert } = request.session.data
+    const { data } = request.session
+
+    clinicAdvert.selected_programme_ids = stringToArray(
+      clinicAdvert.selected_programme_ids
+    )
+
+    clinicAdvert.link = formatMonospace(
+      `https://www.manage-vaccinations-in-schools.nhs.uk${getClinicInviteUrlForProgrammes(clinicAdvert.selected_programme_ids)}`
+    )
+    clinicAdvert.programmeNames = programmeNamesListForSentence(
+      clinicAdvert.selected_programme_ids,
+      ConjunctionType.and,
+      data
+    )
+
+    return response.redirect('/sessions/advert-link')
+  },
+
+  /**
+   * @type {import("express").RequestHandler}
+   */
+  showAdvertLink(request, response) {
+    // Handling a GET for /sessions/advert-link
+
+    return response.render('session/advert-link')
+  },
+
+  /**
+   * @type {import("express").RequestHandler}
+   */
+  copyAdvertLink(request, response) {
+    // Handling a POST for /sessions/advert-link
+    const action = request.body.action
+    if (action === 'return') {
+      return response.redirect('/sessions')
+    }
+
+    request.session.data.clinicAdvert.copied = true
+
+    return response.redirect('/sessions/advert-link')
   },
 
   /**

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2797,6 +2797,28 @@ export const en = {
       confirm: 'Send clinic invitations',
       success:
         '{count, plural, =0 {No children} one {1 child} other {# children}} invited to the clinic'
+    },
+    advertise: {
+      label: 'Advertise scheduled clinics',
+      programmes: {
+        title: 'Select the clinic programmes to advertise',
+        hint: 'The selected programmes will be combined into a single link that parents can use to book appointments.',
+        programme: {
+          hint: '{count, plural, one {1 clinic session is scheduled} other {{count} clinic sessions are scheduled}}'
+        }
+      },
+      link: {
+        title: 'Copy this link into your advert',
+        copy: {
+          label: 'Copy'
+        },
+        copied: {
+          label: 'Copied'
+        },
+        description:
+          'The link will allow parents to book appointments for {{programmeNames}} vaccinations at a clinic session.',
+        confirm: 'Return to the sessions page'
+      }
     }
   },
   texts: {

--- a/app/middleware/navigation.js
+++ b/app/middleware/navigation.js
@@ -1,6 +1,6 @@
 import { SessionPresetName } from '../enums.js'
 import { Session } from '../models.js'
-import { getClinicInviteUrl } from '../utils/clinic-booking.js'
+import { getClinicInviteUrlForPresets } from '../utils/clinic-booking.js'
 import { formatDate, today } from '../utils/date.js'
 import { getSessionConsentUrl } from '../utils/session.js'
 
@@ -29,15 +29,15 @@ export const navigation = (request, response, next) => {
       'MMR(V)': getSessionConsentUrl(sessions, SessionPresetName.MMR)
     },
     clinicInviteUrl: {
-      Flu: getClinicInviteUrl([SessionPresetName.Flu]),
-      HPV: getClinicInviteUrl([SessionPresetName.HPV]),
-      Doubles: getClinicInviteUrl([SessionPresetName.Doubles]),
-      'MMR(V)': getClinicInviteUrl([SessionPresetName.MMR]),
-      'adolescent programmes': getClinicInviteUrl([
+      Flu: getClinicInviteUrlForPresets([SessionPresetName.Flu]),
+      HPV: getClinicInviteUrlForPresets([SessionPresetName.HPV]),
+      Doubles: getClinicInviteUrlForPresets([SessionPresetName.Doubles]),
+      'MMR(V)': getClinicInviteUrlForPresets([SessionPresetName.MMR]),
+      'adolescent programmes': getClinicInviteUrlForPresets([
         SessionPresetName.HPV,
         SessionPresetName.Doubles
       ]),
-      'all but flu': getClinicInviteUrl([
+      'all but flu': getClinicInviteUrlForPresets([
         SessionPresetName.HPV,
         SessionPresetName.Doubles,
         SessionPresetName.MMR

--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -11,6 +11,11 @@ router.post('/', session.filter)
 
 router.get('/new', session.new)
 
+router.get('/advertise', session.advertise)
+router.post('/advertise', session.updateAdvertLink)
+router.get('/advert-link', session.showAdvertLink)
+router.post('/advert-link', session.copyAdvertLink)
+
 router.param('session_id', session.read)
 
 router.get('/:session_id/download', download.new(DownloadType.Session))

--- a/app/utils/clinic-booking.js
+++ b/app/utils/clinic-booking.js
@@ -2,12 +2,12 @@ import programmesData from '../datasets/programmes.js'
 import { SessionPresets } from '../enums.js'
 
 /**
- * Generate a URL for booking into a clinic whose primary programme is given by the session preset
+ * Generate a URL to book into a clinic for vaccination in the given presets' programmes
  *
- * @param {Array<string>} sessionPresetNames - the programmes for which the child has been invited to clinic
+ * @param {Array<string>} sessionPresetNames - the presets for which the child has been invited to clinic
  * @returns {string} - path to the start of the clinic booking journey for the given programme
  */
-export const getClinicInviteUrl = (sessionPresetNames) => {
+export const getClinicInviteUrlForPresets = (sessionPresetNames) => {
   const sessionPresets = SessionPresets.filter((preset) =>
     sessionPresetNames.includes(preset.name)
   )
@@ -15,6 +15,16 @@ export const getClinicInviteUrl = (sessionPresetNames) => {
     preset.programmeTypes.map((type) => programmesData[type].id)
   )
 
+  return getClinicInviteUrlForProgrammes(programme_ids)
+}
+
+/**
+ * Generate a URL to book into a clinic for vaccination in the given programmes
+ *
+ * @param {Array<string>} programme_ids - the programmes for which the child has been invited to clinic
+ * @returns {string} - path to the start of the clinic booking journey for the given programme
+ */
+export const getClinicInviteUrlForProgrammes = (programme_ids) => {
   const searchParams = new URLSearchParams()
   for (const programme_id of programme_ids) {
     searchParams.append('programme_id', programme_id)

--- a/app/views/session/advert-link.njk
+++ b/app/views/session/advert-link.njk
@@ -1,0 +1,34 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.advertise.link.title") %}
+{% set hideConfirmButton = true %}
+
+{% block form %}
+  {% set linkHtml %}
+    <div class="nhsuk-copy-container">
+      <span class="nhsuk-copy-text nhsuk-body">
+        {{ data.clinicAdvert.link | safe }}
+      </span>
+
+      {{ button({
+        text: __("session.advertise.link.copied.label") if data.clinicAdvert.copied else __("session.advertise.link.copy.label"),
+        name: "action",
+        value: "copy",
+        variant: "reverse"
+      }) }}
+    </div>
+  {% endset %}
+
+  {{ panel({
+    titleText: title,
+    html: linkHtml
+  }) }}
+
+  {{ __("session.advertise.link.description", { programmeNames: data.clinicAdvert.programmeNames }) | nhsukMarkdown }}
+
+  {{ button({
+    text: __("session.advertise.link.confirm"),
+    name: "action",
+    value: "return"
+  }) }}
+{% endblock %}

--- a/app/views/session/advert-programmes.njk
+++ b/app/views/session/advert-programmes.njk
@@ -1,0 +1,19 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.advertise.programmes.title") %}
+
+{% block form %}
+  {{ checkboxes({
+    fieldset: {
+      legend: {
+        html: appHeading({
+          title: title
+        }),
+        size: "l"
+      }
+    },
+    hint: { text: __("session.advertise.programmes.hint") },
+    items: programmeItems,
+    decorate: "clinicAdvert.selected_programme_ids"
+  }) }}
+{% endblock %}

--- a/app/views/session/list.njk
+++ b/app/views/session/list.njk
@@ -19,6 +19,12 @@
     href: "/sessions/new"
   }) }}
 
+  {{ actionLink({
+    text: __("session.advertise.label"),
+    href: "/sessions/advertise",
+    classes: "nhsuk-u-margin-left-5"
+  }) if clinicsAreScheduled }}
+
   <div class="nhsuk-grid-row">
     <app-auto-submit class="app-grid-column-filters">
       {{ appSessionSearch({


### PR DESCRIPTION
There's a new action link at the top of the Sessions page, if you have scheduled clinics:
<img width="1139" height="596" alt="image" src="https://github.com/user-attachments/assets/ee55f5e0-c45e-4bb0-b3ad-02ce6d15759c" />

Following that link asks you which programmes you want the link to invite people to clinic for:
<img width="1139" height="596" alt="image" src="https://github.com/user-attachments/assets/faffcfb7-0f6a-4a38-98e1-cac9c3d1a9cc" />

Then you're onto the page that gives you the link itself:
<img width="1139" height="661" alt="image" src="https://github.com/user-attachments/assets/1d14c514-de89-4863-84b6-1b7ff6e92f0a" />

The Copy button on there is faked; it doesn't actually work (though it does change to Copied if clicked)