### PR TITLE
Support clinic bookings for patient sessions

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -35,8 +35,10 @@ export const patientSessionController = {
     )
 
     const {
+      clinicAppointment,
       consent,
       consentGiven,
+      consentGivenInResponse,
       patient,
       programme,
       record,
@@ -57,6 +59,12 @@ export const patientSessionController = {
     const patientProgramme = Object.values(patient.programmes).find(
       (patientProgramme) => patientProgramme.programme_id === programme_id
     )
+
+    // Only show consent responses in clinics if prior consent response
+    let showConsent = true
+    if (clinicAppointment && !consentGivenInResponse) {
+      showConsent = false
+    }
 
     // National protocol
     // Nurses can record all vaccines
@@ -96,6 +104,8 @@ export const patientSessionController = {
         consent === ConsentOutcome.NoResponse,
       // Perform Gillick assessment
       canGillick: session.isActive && !vaccinated && !consentGiven,
+      // Show consent options and previous responses
+      showConsent,
       // Patient can be triaged
       canTriage: consentGiven,
       // Patient needs triage

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1811,6 +1811,10 @@ export const en = {
     session: {
       label: 'Session'
     },
+    clinicAppointment: {
+      title: 'Clinic appointment',
+      label: 'Appointment slot'
+    },
     yearGroup: {
       label: 'Year group'
     },

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -309,8 +309,20 @@ export class Child {
             : yearGroup,
         schoolName: this?.school && this.school.name
       }),
-      adjustments: this.adjustments && formatList(this.adjustments),
-      impairments: this.impairments && formatList(this.impairments)
+      adjustments:
+        this.adjustments &&
+        formatList(
+          this.adjustments.filter(
+            (adjustment) => adjustment !== Adjustment.None
+          )
+        ),
+      impairments:
+        this.impairments &&
+        formatList(
+          this.impairments.filter(
+            (impairment) => impairment !== Impairment.None
+          )
+        )
     }
   }
 

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -1,4 +1,5 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
+import { formatDuration, intervalToDuration } from 'date-fns'
 
 import {
   Adjustment,
@@ -287,6 +288,17 @@ export class ClinicAppointment {
     }
 
     return adjustments.length && !adjustments.includes(Adjustment.None)
+  }
+
+  /**
+   * Get duration of appointment
+   *
+   * @returns {string} Formatted duration
+   */
+  get duration() {
+    return formatDuration(
+      intervalToDuration({ start: this.startAt, end: this.endAt })
+    )
   }
 
   /**

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -291,6 +291,18 @@ export class ClinicAppointment {
   }
 
   /**
+   * Administer alternative vaccine
+   *
+   * @returns {boolean} Administer alternative vaccine
+   */
+  get alternative() {
+    return (
+      this.fluDecision === ReplyDecision.OnlyAlternativeInjection ||
+      this.mmrAlternative
+    )
+  }
+
+  /**
    * Get duration of appointment
    *
    * @returns {string} Formatted duration

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -125,9 +125,11 @@ export class PatientProgramme {
    * @returns {Array<import('./patient-session.js').PatientSession>} Patient sessions
    */
   get patientSessions() {
-    return this.patient?.patientSessions.filter(
-      (patientSession) => patientSession?.programme_id === this.programme_id
-    )
+    return this.patient?.patientSessions
+      .filter(
+        (patientSession) => patientSession?.programme_id === this.programme_id
+      )
+      .sort((a, b) => getDateValueDifference(a.session.date, b.session.date))
   }
 
   /**

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -371,10 +371,10 @@ export class PatientSession {
     const standardVaccine = this.programme?.vaccines.find((vaccine) => vaccine)
     const alternativeVaccine = this.programme?.alternativeVaccine
 
-    // Need consent response(s) or a clinic appointment before we can determine
+    // Need consent response (or a clinic appointment) before we can determine
     // the chosen method.
     // We only want to instruct on patients being vaccinated using nasal spray
-    if (!this.clinicAppointment && !this.consentGiven) {
+    if (!this.consentGiven) {
       return
     }
 
@@ -416,7 +416,7 @@ export class PatientSession {
     }
 
     // Need consent response(s) before we can determine the chosen method
-    if (!this.clinicAppointment && !this.consentGiven) {
+    if (!this.consentGiven) {
       return
     }
 
@@ -679,6 +679,10 @@ export class PatientSession {
    * @returns {boolean} Consent has been given
    */
   get consentGiven() {
+    if (this.clinicAppointment) {
+      return true
+    }
+
     return [
       ConsentOutcome.Given,
       ConsentOutcome.GivenForAlternativeInjection,
@@ -730,7 +734,9 @@ export class PatientSession {
 
     switch (this.screen) {
       case ScreenOutcome.NeedsTriage:
-        return `You need to decide if it’s safe to vaccinate ${patient.firstName}.`
+        return this.clinicAppointment
+          ? `You need to review the health questions with the parent to decide if it’s safe to vaccinate ${patient.firstName}.`
+          : `You need to decide if it’s safe to vaccinate ${patient.firstName}.`
       case ScreenOutcome.InviteToClinic:
         return `${user.fullName} decided that ${patient.firstName}’s vaccination should take place at a clinic.`
       case ScreenOutcome.DelayVaccination:
@@ -1055,6 +1061,7 @@ export class PatientSession {
     this.patient?.addEvent({
       name: activity.triage.decision(event),
       note: event.note,
+      type: AuditEventType.ProgrammeNote,
       outcome: event.outcome,
       outcomeAt_: event.outcomeAt_,
       createdAt: event.createdAt,

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -371,9 +371,10 @@ export class PatientSession {
     const standardVaccine = this.programme?.vaccines.find((vaccine) => vaccine)
     const alternativeVaccine = this.programme?.alternativeVaccine
 
-    // Need consent response(s) before we can determine the chosen method
+    // Need consent response(s) or a clinic appointment before we can determine
+    // the chosen method.
     // We only want to instruct on patients being vaccinated using nasal spray
-    if (!this.consentGiven) {
+    if (!this.clinicAppointment && !this.consentGiven) {
       return
     }
 
@@ -383,7 +384,7 @@ export class PatientSession {
     }
 
     // Administered vaccine was the alternative
-    if (this.alternative) {
+    if (this.clinicAppointment?.alternative || this.alternative) {
       return alternativeVaccine
     }
 
@@ -415,7 +416,7 @@ export class PatientSession {
     }
 
     // Need consent response(s) before we can determine the chosen method
-    if (!this.consentGiven) {
+    if (!this.clinicAppointment && !this.consentGiven) {
       return
     }
 

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -334,9 +334,7 @@ export class PatientSession {
    */
   get clinicAppointment() {
     if (this.session.type !== SessionType.Clinic) {
-      throw new Error(
-        'Clinic appointments are only relevant to clinic sessions'
-      )
+      return
     }
 
     return ClinicBooking.findAll(this.context)

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -683,6 +683,15 @@ export class PatientSession {
       return true
     }
 
+    return this.consentGivenInResponse
+  }
+
+  /**
+   * Consent has been given in a consent response
+   *
+   * @returns {boolean} Consent has been given in a consent response
+   */
+  get consentGivenInResponse() {
     return [
       ConsentOutcome.Given,
       ConsentOutcome.GivenForAlternativeInjection,

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -148,7 +148,7 @@ export const getReportOutcome = (patientSession) => {
     }
   }
 
-  // Has triage outcome
+  // Keep in triage
   if (patientSession.screen === ScreenOutcome.NeedsTriage) {
     return PatientStatus.Triage
   }

--- a/app/utils/triage.js
+++ b/app/utils/triage.js
@@ -123,10 +123,15 @@ export const getScreenOutcome = (patientSession) => {
     .filter((event) => event.outcome)
     .at(-1)
 
-  // Triage completed without any answers to health questions
   if (responsesToTriage.length === 0) {
+    // Triage completed without any answers to health questions
     if (lastTriageNoteWithOutcome) {
       return lastTriageNoteWithOutcome.outcome
+    }
+
+    // Clinic appointment without answers to health questions
+    if (patientSession.clinicAppointment) {
+      return ScreenOutcome.NeedsTriage
     }
 
     return false

--- a/app/views/patient-session/_appointment.njk
+++ b/app/views/patient-session/_appointment.njk
@@ -1,0 +1,18 @@
+{% call card({
+  heading: __("patientSession.clinicAppointment.title"),
+  headingSize: "m"
+}) %}
+  {# Description #}
+{% filter nhsukMarkdown %}
+  {{ patientSession.clinicAppointment.formatted.dateAndTime }}
+  ({{ patientSession.clinicAppointment.duration }})
+{% endfilter %}
+
+  {{ summaryList({
+    lastRowBorder: false,
+    rows: summaryRows(patientSession.clinicAppointment.child, {
+      impairments: {},
+      adjustments: {}
+    })
+  }) if patientSession.clinicAppointment.child.formatted.impairments or patientSession.clinicAppointment.child.formatted.adjustments }}
+{% endcall %}

--- a/app/views/patient-session/_record.njk
+++ b/app/views/patient-session/_record.njk
@@ -55,7 +55,7 @@
     decorate: "patientSession.preScreen.selfId"
   }) }}
 
-  <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--m">
+  <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--l">
 
   {{ appHeading({
     classes: "nhsuk-u-margin-bottom-2",
@@ -100,7 +100,7 @@
     }
   }) if options.hasSupplier }}
 
-  <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--m">
+  <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--l">
 
   {% set vaccinationSiteHtml = radios({
     fieldset: {

--- a/app/views/patient-session/_register.njk
+++ b/app/views/patient-session/_register.njk
@@ -7,7 +7,7 @@
 
   {# Actions #}
   {% if patientSession.register == RegistrationOutcome.Pending %}
-    <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--m">
+    <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--l">
 
     {{ radios({
       fieldset: {

--- a/app/views/patient-session/_triage.njk
+++ b/app/views/patient-session/_triage.njk
@@ -7,6 +7,17 @@
   {# Description #}
   {{ patientSession.screenDescription | nhsukMarkdown }}
 
+  {% if not patientSession.consentHealthAnswers %}
+    {{ appHeading({
+      classes: "nhsuk-u-margin-bottom-2",
+      level: 3,
+      size: "s",
+      title: "Health questions"
+    }) }}
+
+    {{ patientSession.vaccine.formatted.healthQuestions | nhsukMarkdown }}
+  {% endif %}
+
   {# Actions #}
   {{ actionLink({
     text: __("triage.edit.title"),
@@ -56,9 +67,11 @@
     }) }}
   {% endif %}
 
-  {% if options.needsTriage %}
-    <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--m">
+  {% if options.needsTriage and not triageNoteRows.length %}
+    <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--l">
+  {% endif %}
 
+  {% if options.needsTriage %}
     {% set psdRadiosHtml = radios({
       fieldset: { legend: { text: __("triage.psd.label") } },
       inline: true,

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -68,7 +68,7 @@
         {% include "patient-session/_gillick.njk" %}
       {% endif %}
 
-      {% if not patientSession.clinicAppointment %}
+      {% if options.showConsent %}
         {% include "patient-session/_consent.njk" %}
       {% endif %}
 

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -68,7 +68,9 @@
         {% include "patient-session/_gillick.njk" %}
       {% endif %}
 
-      {% include "patient-session/_consent.njk" %}
+      {% if not patientSession.clinicAppointment %}
+        {% include "patient-session/_consent.njk" %}
+      {% endif %}
 
       {% if options.canTriage %}
         {% include "patient-session/_triage.njk" %}

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -60,6 +60,10 @@
         }) }}
       {% endfor %}
 
+      {% if patientSession.clinicAppointment %}
+        {% include "patient-session/_appointment.njk" %}
+      {% endif %}
+
       {% if options.canGillick or patientSession.gillick %}
         {% include "patient-session/_gillick.njk" %}
       {% endif %}

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -116,6 +116,10 @@
                   label: __("patientSession.report.label"),
                   value: reportStatusHtml
                 },
+                clinicAppointment: {
+                  label: __("patientSession.clinicAppointment.label"),
+                  value: patientSession.clinicAppointment.formatted.timeSlot
+                },
                 notes: {
                   label: __("patientSession.sessionNotes.label"),
                   value: appEvent({


### PR DESCRIPTION
This PR updates patient sessions to support clinic sessions by:

- Inferring the consented vaccine method from a clinic appointment
- Showing details of a clinic appointment on patient cards and on the patient session page
- Showing children with clinic appointment and no answers to health questions as needing triage

## Session → Children in this session

- Show booked appointment slot on patient card

<img width="2360" height="3200" alt="session-patients" src="https://github.com/user-attachments/assets/7f36b70a-f589-4558-a759-b2f521c61702" />

## Session → Patient session (with prior consent and a clinic appointment)

- Show details of clinic appointment (time, date, impairments and adjustments)
- Previous consent responses and health questions shown
- Child can be vaccinated without further triage 

<img width="2360" height="8976" alt="session-patient-consent-given" src="https://github.com/user-attachments/assets/f8038276-e4eb-411f-83f4-d6e4c48a6148" />

## Session → Patient session (with clinic appointment, health answers need triage)

- Triage needed, and health questions shown within triage card 

<img width="2360" height="5320" alt="session-patient-needs-triage" src="https://github.com/user-attachments/assets/b22b337e-1594-4963-be08-70f4103a8289" />

## Session → Patient session (with clinic appointment, triage completed)

- Triage completed
- Child can now be vaccinated

<img width="2360" height="6556" alt="session-patient-triage-completed" src="https://github.com/user-attachments/assets/aa49a924-73c1-4c74-83ed-ed7768508493" />