### PR TITLE
Add ability to set a session in progress

### DIFF
--- a/app/assets/stylesheets/components/_dev-tools.scss
+++ b/app/assets/stylesheets/components/_dev-tools.scss
@@ -1,0 +1,22 @@
+@use "../vendor/nhsuk-frontend" as *;
+
+.app-dev-tools {
+  background-color: nhsuk-colour("pale-yellow");
+  background-image: linear-gradient(
+    -45deg,
+    nhsuk-colour("warm-yellow") 25%,
+    nhsuk-colour("pale-yellow") 25%,
+    nhsuk-colour("pale-yellow") 50%,
+    nhsuk-colour("warm-yellow") 50%,
+    nhsuk-colour("warm-yellow") 75%,
+    nhsuk-colour("pale-yellow") 75%,
+    nhsuk-colour("pale-yellow") 100%
+  );
+  background-repeat: repeat-x;
+  background-size: nhsuk-spacing(2) nhsuk-spacing(2);
+
+  @include nhsuk-clearfix;
+  @include nhsuk-print-hide;
+  @include nhsuk-responsive-padding(5, bottom);
+  @include nhsuk-responsive-padding(5, top);
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -6,6 +6,7 @@
 @forward "copy";
 @forward "count";
 @forward "details";
+@forward "dev-tools";
 @forward "environment";
 @forward "filters";
 @forward "header";

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -1026,6 +1026,20 @@ export const sessionController = {
   /**
    * @type {import("express").RequestHandler}
    */
+  makeActive(request, response) {
+    const { __, session } = response.locals
+    const { data } = request.session
+
+    Session.update(session.id, { date: today() }, data)
+
+    request.flash('success', __('session.makeActive.success'))
+
+    return response.redirect(session.uri)
+  },
+
+  /**
+   * @type {import("express").RequestHandler}
+   */
   inviteToClinic(request, response) {
     const { account } = request.app.locals
     const { session_id } = request.params

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2461,6 +2461,9 @@ export const en = {
       cancel: 'No, return to the session page',
       success: '{{session.name}} cancelled'
     },
+    makeActive: {
+      success: 'Session is now in progress'
+    },
     academicYear: {
       label: 'Academic year'
     },

--- a/app/routes/session.js
+++ b/app/routes/session.js
@@ -36,6 +36,7 @@ router.post('/:session_id/invite-to-clinic', session.inviteToClinic)
 router.post('/:session_id/instructions', session.giveInstructions)
 router.post('/:session_id/reminders', session.sendReminders)
 router.post('/:session_id/cancel', session.cancelSession)
+router.post('/:session_id/status', session.makeActive)
 
 router.all('/:session_id/:view', session.readPatientSessions)
 router.post('/:session_id/:view', session.filterPatientSessions)

--- a/app/views/_layouts/session.njk
+++ b/app/views/_layouts/session.njk
@@ -34,4 +34,23 @@
       </form>
     </main>
   </div>
+
+  {% if not session.isActive %}
+  <form class="app-dev-tools" action="{{ session.uri }}/status" method="post">
+    <div class="nhsuk-width-container">
+      {{ appHeading({
+        title: "Prototype tools",
+        size: "s"
+      }) }}
+
+      {{ "Vaccinations can only be recorded if a session is in progress. If you want to test vaccination recording, you can set this session as in progress for today." | nhsukMarkdown }}
+
+      {{ button({
+        classes: "nhsuk-u-margin-bottom-0",
+        text: "Set session in progress for today",
+        variant: "secondary"
+      }) }}
+    </div>
+  </form>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Copies a feature available in the main Mavis application (that appears in non-production environments) that allows you to set a given session as in progress:

<img width="1170" height="425" alt="Screenshot of banner with button that lets you set a session as in progress." src="https://github.com/user-attachments/assets/26650d93-87ac-4920-a788-87b665b68761" />