### PR TITLE
Patient clinic session refinements, triage sub-statuses

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -35,10 +35,8 @@ export const patientSessionController = {
     )
 
     const {
-      clinicAppointment,
       consent,
       consentGiven,
-      consentGivenInResponse,
       patient,
       programme,
       record,
@@ -59,12 +57,6 @@ export const patientSessionController = {
     const patientProgramme = Object.values(patient.programmes).find(
       (patientProgramme) => patientProgramme.programme_id === programme_id
     )
-
-    // Only show consent responses in clinics if prior consent response
-    let showConsent = true
-    if (clinicAppointment && !consentGivenInResponse) {
-      showConsent = false
-    }
 
     // National protocol
     // Nurses can record all vaccines
@@ -104,8 +96,6 @@ export const patientSessionController = {
         consent === ConsentOutcome.NoResponse,
       // Perform Gillick assessment
       canGillick: session.isActive && !vaccinated && !consentGiven,
-      // Show consent options and previous responses
-      showConsent,
       // Patient can be triaged
       canTriage: consentGiven,
       // Patient needs triage

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -96,8 +96,6 @@ export const patientSessionController = {
         consent === ConsentOutcome.NoResponse,
       // Perform Gillick assessment
       canGillick: session.isActive && !vaccinated && !consentGiven,
-      // Patient can be triaged
-      canTriage: consentGiven,
       // Patient needs triage
       needsTriage: report === PatientStatus.Triage,
       // Patient already triaged

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -122,6 +122,7 @@ export const patientController = {
       patientConsent: request.query.patientConsent || 'none',
       patientDeferred: request.query.patientDeferred || 'none',
       patientRefused: request.query.patientRefused || 'none',
+      patientTriage: request.query.patientTriage || 'none',
       patientVaccinated: request.query.patientVaccinated || 'none',
       vaccineCriteria: request.query.vaccineCriteria || 'none'
     }
@@ -174,6 +175,7 @@ export const patientController = {
       [PatientStatus.Deferred]: 'patientDeferred',
       [PatientStatus.Due]: 'vaccineCriteria',
       [PatientStatus.Refused]: 'patientRefused',
+      [PatientStatus.Triage]: 'patientTriage',
       [PatientStatus.Vaccinated]: 'patientVaccinated'
     })) {
       if (filters.report === patientStatus && filters[status] !== 'none') {
@@ -245,6 +247,7 @@ export const patientController = {
     delete data.patientConsent
     delete data.patientDeferred
     delete data.patientRefused
+    delete data.patientTriage
     delete data.patientVaccinated
     delete data.programme_id
     delete data.q
@@ -319,6 +322,7 @@ export const patientController = {
       'patientConsent',
       'patientDeferred',
       'patientRefused',
+      'patientTriage',
       'patientVaccinated',
       'programme_id',
       'vaccineCriteria',

--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -151,6 +151,7 @@ export const schoolController = {
       patientConsent: request.query.patientConsent || 'none',
       patientDeferred: request.query.patientDeferred || 'none',
       patientRefused: request.query.patientRefused || 'none',
+      patientTriage: request.query.patientTriage || 'none',
       patientVaccinated: request.query.patientVaccinated || 'none',
       vaccineCriteria: request.query.vaccineCriteria || 'none'
     }
@@ -200,6 +201,7 @@ export const schoolController = {
       [PatientStatus.Deferred]: 'patientDeferred',
       [PatientStatus.Due]: 'vaccineCriteria',
       [PatientStatus.Refused]: 'patientRefused',
+      [PatientStatus.Triage]: 'patientTriage',
       [PatientStatus.Vaccinated]: 'patientVaccinated'
     })) {
       if (filters.report === patientStatus && filters[status] !== 'none') {
@@ -267,6 +269,7 @@ export const schoolController = {
     delete data.patientConsent
     delete data.patientDeferred
     delete data.patientRefused
+    delete data.patientTriage
     delete data.patientVaccinated
     delete data.programme_id
     delete data.q
@@ -299,6 +302,7 @@ export const schoolController = {
       'patientConsent',
       'patientDeferred',
       'patientRefused',
+      'patientTriage',
       'patientVaccinated',
       'programme_id',
       'vaccineCriteria',

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -428,6 +428,7 @@ export const sessionController = {
       patientConsent: request.query.patientConsent || 'none',
       patientDeferred: request.query.patientDeferred || 'none',
       patientRefused: request.query.patientRefused || 'none',
+      patientTriage: request.query.patientTriage || 'none',
       patientVaccinated: request.query.patientVaccinated || 'none',
       vaccineCriteria: request.query.vaccineCriteria || 'none'
     }
@@ -447,6 +448,7 @@ export const sessionController = {
       [PatientStatus.Deferred]: 'patientDeferred',
       [PatientStatus.Due]: 'vaccineCriteria',
       [PatientStatus.Refused]: 'patientRefused',
+      [PatientStatus.Triage]: 'patientTriage',
       [PatientStatus.Vaccinated]: 'patientVaccinated'
     })) {
       if (filters.report === programmeOutcome && filters[status] !== 'none') {
@@ -567,6 +569,7 @@ export const sessionController = {
     delete data.patientConsent
     delete data.patientDeferred
     delete data.patientRefused
+    delete data.patientTriage
     delete data.patientVaccinated
     delete data.programme_id
     delete data.q
@@ -600,6 +603,7 @@ export const sessionController = {
       'patientConsent',
       'patientDeferred',
       'patientRefused',
+      'patientTriage',
       'patientVaccinated',
       'programme_id',
       'vaccineCriteria',

--- a/app/enums.js
+++ b/app/enums.js
@@ -363,6 +363,15 @@ export const PatientConsentStatus = {
  * @readonly
  * @enum {string}
  */
+export const PatientTriageStatus = {
+  Responses: 'Review health questions',
+  Consultation: 'Triage in person'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
 export const PatientDueStatus = {
   Only: 'Due vaccination',
   First: 'Due 1st dose',

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -511,6 +511,8 @@ export class PatientProgramme {
           : `Eligible from 1 September ${this.year}`
       case PatientStatus.Vaccinated:
         return `Vaccinated on ${this.lastVaccinationGiven.formatted.createdAt_dateShort}`
+      case PatientStatus.Triage:
+        return this.lastPatientSession.patientTriage
       case PatientStatus.Due:
         return this.lastPatientSession.vaccineCriteria
       case PatientStatus.Deferred:

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -19,7 +19,8 @@ import {
   VaccinationOutcome,
   ProgrammeType,
   PatientClinicStatus,
-  SessionType
+  SessionType,
+  PatientTriageStatus
 } from '../enums.js'
 import {
   AuditEvent,
@@ -39,10 +40,11 @@ import {
   getSessionOutcome
 } from '../utils/patient-session.js'
 import {
+  countAnswersNeedingTriage,
   getConsentOutcome,
   getConsentHealthAnswers,
   getConsentRefusalReasons,
-  countAnswersNeedingTriage
+  getRepliesWithHealthAnswers
 } from '../utils/reply.js'
 import {
   getConsentOutcomeStatus,
@@ -539,6 +541,24 @@ export class PatientSession {
         return PatientRefusedStatus.Conflict
       case ConsentOutcome.Refused:
         return PatientRefusedStatus.Refusal
+    }
+  }
+
+  /**
+   * Get patient triage status
+   *
+   * @returns {PatientTriageStatus|undefined} Patient triage status
+   */
+  get patientTriage() {
+    const responses = Object.values(this.responses)
+    const responsesToTriage = getRepliesWithHealthAnswers(responses)
+
+    if (this.screen === ScreenOutcome.NeedsTriage) {
+      if (responsesToTriage.length > 0) {
+        return PatientTriageStatus.Responses
+      } else if (this.clinicAppointment) {
+        return PatientTriageStatus.Consultation
+      }
     }
   }
 

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -679,15 +679,17 @@ export class PatientSession {
    * @returns {boolean} Consent has been given
    */
   get consentGiven() {
-    if (this.clinicAppointment) {
+    if (this.consent) {
+      return [
+        ConsentOutcome.Given,
+        ConsentOutcome.GivenForAlternativeInjection,
+        ConsentOutcome.GivenForIntranasal
+      ].includes(this.consent)
+    } else if (this.clinicAppointment) {
       return true
     }
 
-    return [
-      ConsentOutcome.Given,
-      ConsentOutcome.GivenForAlternativeInjection,
-      ConsentOutcome.GivenForIntranasal
-    ].includes(this.consent)
+    return false
   }
 
   /**

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -683,15 +683,6 @@ export class PatientSession {
       return true
     }
 
-    return this.consentGivenInResponse
-  }
-
-  /**
-   * Consent has been given in a consent response
-   *
-   * @returns {boolean} Consent has been given in a consent response
-   */
-  get consentGivenInResponse() {
     return [
       ConsentOutcome.Given,
       ConsentOutcome.GivenForAlternativeInjection,

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -753,11 +753,12 @@ export class PatientSession {
 
     const triageNote = triageNotes.at(-1)
     const user = triageNote?.createdBy || { fullName: 'Jane Joy' }
+    const person = this.patient.post16 ? 'child' : 'parent'
 
     switch (this.screen) {
       case ScreenOutcome.NeedsTriage:
         return this.clinicAppointment
-          ? `You need to review the health questions with the parent to decide if it’s safe to vaccinate ${patient.firstName}.`
+          ? `You need to review the health questions with the ${person} to decide if it’s safe to vaccinate ${patient.firstName}.`
           : `You need to decide if it’s safe to vaccinate ${patient.firstName}.`
       case ScreenOutcome.InviteToClinic:
         return `${user.fullName} decided that ${patient.firstName}’s vaccination should take place at a clinic.`

--- a/app/utils/reply.js
+++ b/app/utils/reply.js
@@ -49,7 +49,7 @@ export function getRepliesWithHealthAnswers(replies) {
   return replies.filter(
     (reply) =>
       reply.healthAnswers &&
-      Object.values(reply.healthAnswers).some((value) => value.answer !== 'No')
+      Object.values(reply.healthAnswers).some((value) => value?.answer !== 'No')
   )
 }
 

--- a/app/utils/triage.js
+++ b/app/utils/triage.js
@@ -124,13 +124,14 @@ export const getScreenOutcome = (patientSession) => {
     .at(-1)
 
   if (responsesToTriage.length === 0) {
-    // Triage completed without any answers to health questions
+    // Triage completed without any ‘Yes’ answers to health questions
     if (lastTriageNoteWithOutcome) {
+      console.log(lastTriageNoteWithOutcome)
       return lastTriageNoteWithOutcome.outcome
     }
 
-    // Clinic appointment without answers to health questions
-    if (patientSession.clinicAppointment) {
+    // Clinic appointment without any answers to health questions
+    if (!responses.length && patientSession.clinicAppointment) {
       return ScreenOutcome.NeedsTriage
     }
 

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -141,7 +141,14 @@
           })
         } if data.report == PatientStatus.Refused
       }, {
-        text: PatientStatus.Triage
+        text: PatientStatus.Triage,
+        conditional: {
+          html: checkboxes({
+            small: true,
+            items: enumItems(PatientTriageStatus),
+            decorate: "patientTriage"
+          })
+        } if data.report == PatientStatus.Triage
       }, {
         text: PatientStatus.Due,
         conditional: {

--- a/app/views/patient-session/_consent.njk
+++ b/app/views/patient-session/_consent.njk
@@ -16,28 +16,30 @@
   {% endif %}
 
   {# Actions #}
-  {{ actionLink({
-    text: __("reply.new.title"),
-    href: patientSession.uri + "/replies/new?referrer=" + referrer
-  }) if not isVaccinated }}
+  {% if not isVaccinated and not patientSession.patient.post16 %}
+    {{ actionLink({
+      text: __("reply.new.title"),
+      href: patientSession.uri + "/replies/new?referrer=" + referrer
+    }) if not isVaccinated }}
 
-  {{ appButtonGroup({
-    buttons: [{
-      text: __("remind.new.title"),
-      variant: "secondary",
-      attributes: {
-        formaction: patientSession.uri + "/new/remind",
-        formmethod: "post"
-      }
-    } if options.canRemind, {
-      text: __("patientSession.invite.label"),
-      variant: "secondary",
-      attributes: {
-        formaction: patientSession.uri + "/new/invite",
-        formmethod: "post"
-      }
-    }]
-  }) if not isVaccinated and not patientSession.patient.post16 }}
+    {{ appButtonGroup({
+      buttons: [{
+        text: __("remind.new.title"),
+        variant: "secondary",
+        attributes: {
+          formaction: patientSession.uri + "/new/remind",
+          formmethod: "post"
+        }
+      } if options.canRemind, {
+        text: __("patientSession.invite.label"),
+        variant: "secondary",
+        attributes: {
+          formaction: patientSession.uri + "/new/invite",
+          formmethod: "post"
+        }
+      }]
+    }) }}
+  {% endif %}
 
   {% if patientSession.replies | length %}
     {# Requests with responses or requests that couldn’t be delivered #}

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -68,9 +68,7 @@
         {% include "patient-session/_gillick.njk" %}
       {% endif %}
 
-      {% if options.showConsent %}
-        {% include "patient-session/_consent.njk" %}
-      {% endif %}
+      {% include "patient-session/_consent.njk" %}
 
       {% if options.canTriage %}
         {% include "patient-session/_triage.njk" %}

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -70,9 +70,7 @@
 
       {% include "patient-session/_consent.njk" %}
 
-      {% if options.canTriage %}
-        {% include "patient-session/_triage.njk" %}
-      {% endif %}
+      {% include "patient-session/_triage.njk" %}
 
       {% if options.hasInstruct %}
         {% include "patient-session/_instruct.njk" %}

--- a/app/views/session/_session-programme-summary.njk
+++ b/app/views/session/_session-programme-summary.njk
@@ -13,6 +13,7 @@
   }) }}
 
   <div class="nhsuk-grid-row nhsuk-card-group">
+    {% if session.type == SessionType.School %}
     <div class="nhsuk-grid-column-one-{{ columnWidth }} nhsuk-card-group__item">
       {{ appDataCard({
         heading: PatientStatus.Consent,
@@ -23,6 +24,7 @@
         href: session.uri + "/report?report=" + PatientStatus.Consent + "&programme_id=" + programme.id
       }) }}
     </div>
+    {% endif %}
     <div class="nhsuk-grid-column-one-{{ columnWidth }} nhsuk-card-group__item">
       {{ appDataCard({
         heading: PatientStatus.Triage,


### PR DESCRIPTION
Refinements to the changes made in #313:

- Always show consent content regardless of whether school or clinic session
- Hide ‘Needs consent’ count card on session overview page for clinic sessions
- Add triage sub-statuses, allowing teams to filter children needing triage with answers to health questions
- Adjust message about needing to review answers with a parent to say ‘child’ instead if the child is 16+
- Don’t show consent-related actions if a child is 16+
- Fix always showing triage card on patient session page