### PR TITLE
Clinic unmatched appointments

### DIFF
--- a/app/controllers/consent.js
+++ b/app/controllers/consent.js
@@ -212,6 +212,9 @@ export const consentController = {
     // Update session data
     const consent = Consent.update(consent_uuid, { invalid: true, note }, data)
 
+    data.counts.consents--
+    data.counts.review--
+
     request.flash('success', __(`consent.invalidate.success`, { consent }))
 
     return response.redirect(consentsPath)

--- a/app/controllers/unmatched-appointment.js
+++ b/app/controllers/unmatched-appointment.js
@@ -33,7 +33,9 @@ export const unmatchedAppointmentController = {
     const { session_id } = request.params
     let appointments = ClinicBooking.findAll(request.session.data)
       ?.flatMap(({ appointments }) => appointments)
-      .filter(({ patient_uuid }) => !patient_uuid)
+      .filter(
+        (appointment) => !appointment.patient_uuid && !appointment.archived
+      )
 
     // Sort
     appointments = _.sortBy(appointments, 'startAt')
@@ -66,7 +68,7 @@ export const unmatchedAppointmentController = {
 
   list(request, response) {
     response.render('appointments/list')
-  }
+  },
 
   // readMatches(request, response, next) {
   //   let { hasMissingNhsNumber, page, limit, q } = request.query
@@ -179,20 +181,37 @@ export const unmatchedAppointmentController = {
   //   response.redirect(consentsPath)
   // },
 
-  // invalidate(request, response) {
-  //   const { note } = request.body.consent
-  //   const { consent_uuid } = request.params
-  //   const { data } = request.session
-  //   const { __, consentsPath } = response.locals
+  archive(request, response) {
+    const { note } = request.body.appointment
+    const { appointment_uuid } = request.params
+    const { data } = request.session
+    const { __, appointmentsPath } = response.locals
 
-  //   // Clean up session data
-  //   delete data.consent
+    // Clean up session data
+    delete data.appointment
 
-  //   // Update session data
-  //   const consent = Consent.update(consent_uuid, { invalid: true, note }, data)
+    // Update session data
+    const booking_uuid = ClinicAppointment.findOne(
+      appointment_uuid,
+      data
+    )?.booking_uuid
+    if (booking_uuid) {
+      const booking = ClinicBooking.findOne(booking_uuid, data)
+      const appointment = booking.findAppointment(appointment_uuid)
+      appointment.archived = true
+      appointment.note = note
 
-  //   request.flash('success', __(`consent.invalidate.success`, { consent }))
+      ClinicBooking.update(booking_uuid, booking, data)
 
-  //   response.redirect(consentsPath)
-  // }
+      data.counts.appointments--
+      data.counts.review--
+
+      request.flash(
+        'success',
+        __(`appointments.archive.success`, { appointment })
+      )
+    }
+
+    response.redirect(appointmentsPath)
+  }
 }

--- a/app/controllers/unmatched-appointment.js
+++ b/app/controllers/unmatched-appointment.js
@@ -1,11 +1,30 @@
 import _ from 'lodash'
 
-import { ClinicBooking, Session } from '../models.js'
+import { ClinicAppointment, ClinicBooking, Session } from '../models.js'
 import { getResults, getPagination } from '../utils/pagination.js'
 
 export const unmatchedAppointmentController = {
   read(request, response, next, appointment_uuid) {
-    console.log(`read: ${appointment_uuid}`)
+    const { session_id } = request.params
+    const { referrer } = request.session
+
+    const appointment = ClinicAppointment.findOne(
+      appointment_uuid,
+      request.session.data
+    )
+    const back = session_id
+      ? `/sessions/${session_id}/unmatched-appointments`
+      : '/unmatched-appointments'
+
+    response.locals.back = referrer || back
+    response.locals.appointment = appointment
+
+    response.locals.appointmentPath = session_id
+      ? `/sessions/${session_id}${appointment.uri.unmatched}`
+      : appointment.uri.unmatched
+    response.locals.appointmentsPath = session_id
+      ? `/sessions/${session_id}/unmatched-appointments`
+      : '/unmatched-appointments'
 
     next()
   },

--- a/app/controllers/unmatched-appointment.js
+++ b/app/controllers/unmatched-appointment.js
@@ -1,6 +1,12 @@
 import _ from 'lodash'
 
-import { ClinicAppointment, ClinicBooking, Session } from '../models.js'
+import {
+  ClinicAppointment,
+  ClinicBooking,
+  Patient,
+  PatientSession,
+  Session
+} from '../models.js'
 import { getResults, getPagination } from '../utils/pagination.js'
 
 export const unmatchedAppointmentController = {
@@ -145,41 +151,54 @@ export const unmatchedAppointmentController = {
   //   response.redirect(consentsPath)
   // },
 
-  // add(request, response) {
-  //   const { consent_uuid } = request.params
-  //   const { data } = request.session
-  //   const { __, consent, consentsPath } = response.locals
+  add(request, response) {
+    const { appointment_uuid } = request.params
+    const { data } = request.session
+    const { __, appointmentsPath } = response.locals
 
-  //   // Create patient
-  //   const patient = Patient.create(consent.child, data)
+    // Get the booking we'll need to update
+    const booking = ClinicBooking.findOne(
+      response.locals.appointment.booking_uuid,
+      data
+    )
+    const appointment = booking.findAppointment(appointment_uuid)
 
-  //   // Create and add patient session
-  //   const patientSession = PatientSession.create(
-  //     {
-  //       patient_uuid: patient.uuid,
-  //       programme_id: consent.programme_id,
-  //       session_id: consent.session_id
-  //     },
-  //     data
-  //   )
+    // Create patient
+    const patient = Patient.create(appointment.child, data)
 
-  //   // Add to session
-  //   patient.addToSession(patientSession)
+    // Create and add patient session for each programme they've signed up for
+    for (const programme_id of appointment.selected_programme_ids) {
+      const patientSession = PatientSession.create(
+        {
+          patient_uuid: patient.uuid,
+          programme_id: programme_id,
+          session_id: appointment.session_id
+        },
+        data
+      )
 
-  //   // Invite contact to give consent
-  //   patient.requestConsent(patientSession)
+      // Add to session
+      patient.addToSession(patientSession)
+    }
 
-  //   // Link consent with patient record
-  //   consent.linkToPatient(patient)
+    // Link appointment to patient record
+    appointment.patient_uuid = patient.uuid
 
-  //   // Update session data
-  //   Consent.update(consent_uuid, consent, data)
-  //   Patient.update(patient.uuid, patient, data)
+    // Update session data
+    ClinicBooking.update(booking.uuid, booking, data)
+    Patient.update(patient.uuid, patient, data)
 
-  //   request.flash('success', __(`consent.add.success`, { consent, patient }))
+    // Update the review badges
+    data.counts.appointments--
+    data.counts.review--
 
-  //   response.redirect(consentsPath)
-  // },
+    request.flash(
+      'success',
+      __(`consent.add.success`, { appointment, patient })
+    )
+
+    response.redirect(appointmentsPath)
+  },
 
   archive(request, response) {
     const { note } = request.body.appointment
@@ -190,12 +209,12 @@ export const unmatchedAppointmentController = {
     // Clean up session data
     delete data.appointment
 
-    // Update session data
     const booking_uuid = ClinicAppointment.findOne(
       appointment_uuid,
       data
     )?.booking_uuid
     if (booking_uuid) {
+      // Update session data
       const booking = ClinicBooking.findOne(booking_uuid, data)
       const appointment = booking.findAppointment(appointment_uuid)
       appointment.archived = true
@@ -203,6 +222,7 @@ export const unmatchedAppointmentController = {
 
       ClinicBooking.update(booking_uuid, booking, data)
 
+      // Update the review badges
       data.counts.appointments--
       data.counts.review--
 

--- a/app/controllers/unmatched-appointment.js
+++ b/app/controllers/unmatched-appointment.js
@@ -10,7 +10,11 @@ import {
 import { getResults, getPagination } from '../utils/pagination.js'
 
 export const unmatchedAppointmentController = {
+  /**
+   * @type {import("express").RequestParamHandler}
+   */
   read(request, response, next, appointment_uuid) {
+    const { patient_uuid } = request.query
     const { session_id } = request.params
     const { referrer } = request.session
 
@@ -24,6 +28,10 @@ export const unmatchedAppointmentController = {
 
     response.locals.back = referrer || back
     response.locals.appointment = appointment
+    response.locals.patient = Patient.findOne(
+      String(patient_uuid),
+      request.session.data
+    )
 
     response.locals.appointmentPath = session_id
       ? `/sessions/${session_id}${appointment.uri.unmatched}`
@@ -32,9 +40,14 @@ export const unmatchedAppointmentController = {
       ? `/sessions/${session_id}/unmatched-appointments`
       : '/unmatched-appointments'
 
+    delete request.session.referrer
+
     next()
   },
 
+  /**
+   * @type {import("express").RequestHandler}
+   */
   readAll(request, response, next) {
     const { session_id } = request.params
     let appointments = ClinicBooking.findAll(request.session.data)
@@ -63,94 +76,137 @@ export const unmatchedAppointmentController = {
     response.locals.results = getResults(appointments, request.query)
     response.locals.pages = getPagination(appointments, request.query)
 
-    next()
+    return next()
   },
 
+  /**
+   * @type {import("express").RequestHandler}
+   */
   show(request, response) {
     const view = request.params.view || 'show'
 
-    response.render(`appointments/${view}`)
+    return response.render(`appointments/${view}`)
   },
 
+  /**
+   * @type {import("express").RequestHandler}
+   */
   list(request, response) {
-    response.render('appointments/list')
+    return response.render('appointments/list')
   },
 
-  // readMatches(request, response, next) {
-  //   let { hasMissingNhsNumber, page, limit, q } = request.query
-  //   const { data } = request.session
+  /**
+   * @type {import("express").RequestHandler}
+   */
+  readMatches(request, response, next) {
+    let { hasMissingNhsNumber, q } = request.query
+    const { data } = request.session
 
-  //   let patients = Patient.findAll(data)
+    let patients = Patient.findAll(data)
 
-  //   // Sort
-  //   patients = _.sortBy(patients, 'lastName')
+    // Sort
+    patients = _.sortBy(patients, 'lastName')
 
-  //   // Paginate
-  //   page = parseInt(page) || 1
-  //   limit = parseInt(limit) || 50
+    // Query
+    if (q) {
+      patients = patients.filter((patient) =>
+        patient.tokenized.includes(String(q).toLowerCase())
+      )
+    }
 
-  //   // Query
-  //   if (q) {
-  //     patients = patients.filter((patient) =>
-  //       patient.tokenized.includes(String(q).toLowerCase())
-  //     )
-  //   }
+    // Filter by missing NHS number
+    if (hasMissingNhsNumber) {
+      patients = patients.filter((patient) => patient.hasMissingNhsNumber)
+    }
 
-  //   // Filter by missing NHS number
-  //   if (hasMissingNhsNumber) {
-  //     patients = patients.filter((patient) => patient.hasMissingNhsNumber)
-  //   }
+    // Toggle initial view
+    response.locals.initial =
+      Object.keys(request.query).filter((key) => key !== 'referrer').length ===
+      0
 
-  //   // Toggle initial view
-  //   response.locals.initial =
-  //     Object.keys(request.query).filter((key) => key !== 'referrer').length ===
-  //     0
+    // Results
+    response.locals.patients = patients
+    response.locals.results = getResults(patients, request.query)
+    response.locals.pages = getPagination(patients, request.query)
 
-  //   // Results
-  //   response.locals.patients = patients
-  //   response.locals.results = getResults(patients, page, limit)
-  //   response.locals.pages = getPagination(patients, request.query)
+    // Clean up session data
+    delete data.hasMissingNhsNumber
+    delete data.q
 
-  //   // Clean up session data
-  //   delete data.hasMissingNhsNumber
-  //   delete data.q
+    return next()
+  },
 
-  //   next()
-  // },
+  /**
+   * @type {import("express").RequestHandler}
+   */
+  filterMatches(request, response) {
+    const { hasMissingNhsNumber, q } = request.body
+    const { appointment } = response.locals
+    const params = new URLSearchParams()
 
-  // filterMatches(request, response) {
-  //   const { hasMissingNhsNumber, q } = request.body
-  //   const { consent } = response.locals
-  //   const params = new URLSearchParams()
+    if (q) {
+      params.append('q', String(q))
+    }
 
-  //   if (q) {
-  //     params.append('q', String(q))
-  //   }
+    if (hasMissingNhsNumber?.includes('true')) {
+      params.append('hasMissingNhsNumber', 'true')
+    }
 
-  //   if (hasMissingNhsNumber?.includes('true')) {
-  //     params.append('hasMissingNhsNumber', 'true')
-  //   }
+    return response.redirect(`${appointment.uri.unmatched}/match?${params}`)
+  },
 
-  //   response.redirect(`${consent.uri}/match?${params}`)
-  // },
+  /**
+   * @type {import("express").RequestHandler}
+   */
+  link(request, response) {
+    const { appointment_uuid } = request.params
+    const { data } = request.session
+    const { __, patient, appointmentsPath } = response.locals
 
-  // link(request, response) {
-  //   const { consent_uuid } = request.params
-  //   const { data } = request.session
-  //   const { __, consent, patient, consentsPath } = response.locals
+    // Get the booking we'll need to update
+    const booking = ClinicBooking.findOne(
+      response.locals.appointment.booking_uuid,
+      data
+    )
+    const appointment = booking.findAppointment(appointment_uuid)
 
-  //   // Link consent with patient record
-  //   consent.linkToPatient(patient)
+    // Create and add patient session for each programme they've signed up for
+    for (const programme_id of appointment.selected_programme_ids) {
+      const patientSession = PatientSession.create(
+        {
+          patient_uuid: patient.uuid,
+          programme_id: programme_id,
+          session_id: appointment.session_id
+        },
+        data
+      )
 
-  //   // Update session data
-  //   Consent.update(consent_uuid, consent, data)
-  //   Patient.update(patient.uuid, patient, data)
+      // Add to session
+      patient.addToSession(patientSession)
+    }
 
-  //   request.flash('success', __(`consent.link.success`, { consent, patient }))
+    // Link appointment to patient record
+    appointment.patient_uuid = patient.uuid
 
-  //   response.redirect(consentsPath)
-  // },
+    // Update session data
+    ClinicBooking.update(booking.uuid, booking, data)
+    Patient.update(patient.uuid, patient, data)
 
+    // Update the review badges
+    data.counts.appointments--
+    data.counts.review--
+
+    request.flash(
+      'success',
+      __(`appointments.link.success`, { appointment, patient })
+    )
+
+    return response.redirect(appointmentsPath)
+  },
+
+  /**
+   * @type {import("express").RequestHandler}
+   */
   add(request, response) {
     const { appointment_uuid } = request.params
     const { data } = request.session
@@ -197,9 +253,12 @@ export const unmatchedAppointmentController = {
       __(`consent.add.success`, { appointment, patient })
     )
 
-    response.redirect(appointmentsPath)
+    return response.redirect(appointmentsPath)
   },
 
+  /**
+   * @type {import("express").RequestHandler}
+   */
   archive(request, response) {
     const { note } = request.body.appointment
     const { appointment_uuid } = request.params
@@ -232,6 +291,6 @@ export const unmatchedAppointmentController = {
       )
     }
 
-    response.redirect(appointmentsPath)
+    return response.redirect(appointmentsPath)
   }
 }

--- a/app/generators/clinic-appointment.js
+++ b/app/generators/clinic-appointment.js
@@ -28,6 +28,9 @@ export function generateClinicAppointment(patient, session, booking) {
       firstName: patient.firstName,
       lastName: patient.lastName,
       dob: patient.dob,
+      address: {
+        ...patient.address
+      },
       adjustments: [...patient.adjustments],
       adjustmentsOther: patient.adjustmentsOther,
       impairments: [...patient.impairments],
@@ -41,16 +44,15 @@ export function generateClinicAppointment(patient, session, booking) {
       'dob'
     ])
     child = {
-      firstName:
-        wrongness === 'firstName'
-          ? faker.person.firstName()
-          : patient.firstName,
-      lastName:
-        wrongness === 'lastName' ? faker.person.lastName() : patient.lastName,
+      firstName: patient.firstName + (wrongness === 'firstName' ? 'e' : ''),
+      lastName: patient.lastName + (wrongness === 'lastName' ? 's' : ''),
       dob:
         wrongness === 'dob'
           ? addYears(patient.dob, faker.helpers.arrayElement([-2, -1, 1, 2]))
           : patient.dob,
+      address: {
+        ...patient.address
+      },
       adjustments: [...patient.adjustments],
       adjustmentsOther: patient.adjustmentsOther,
       impairments: [...patient.impairments],

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -242,7 +242,7 @@ export const en = {
       title: 'Unmatched clinic appointments'
     },
     show: {
-      title: 'Clinic appointment booked by %s'
+      title: 'Clinic appointment made by %s'
     },
     count: {
       total:
@@ -251,7 +251,12 @@ export const en = {
         '{count, plural, =0 {No unmatched clinic appointments at {location}} one {1 unmatched clinic appointment at {location}} other {{count} unmatched clinic appointments at {location}}}'
     },
     add: {
-      label: 'Create new record'
+      label: 'Create new record',
+      title: 'Create a new child record from this clinic appointment?',
+      caption: 'Clinic appointment made by {{contact.fullName}}',
+      confirm: 'Create a new child record',
+      success:
+        '[{{patient.fullName}}]({{patient.uri}})’s record created from a clinic appointment made by {{appointment.contact.fullName}}'
     },
     results:
       '{count, plural, =0 {No unmatched appointments matching your search criteria were found} one {Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> unmatched appointment} other {Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> unmatched appointments}}',
@@ -278,13 +283,13 @@ export const en = {
     },
     archive: {
       label: 'Archive',
-      caption: 'Clinic appointment booked by {{appointment.contact.fullName}}',
+      caption: 'Clinic appointment made by {{appointment.contact.fullName}}',
       title: 'Archive response',
       description:
         'The unmatched clinic appointment will be hidden. This cannot be undone.',
       confirm: 'Archive this appointment',
       success:
-        'Clinic appointment booked by {{appointment.contact.fullName}} archived'
+        'Clinic appointment made by {{appointment.contact.fullName}} archived'
     }
   },
   clinicAppointment: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -273,8 +273,18 @@ export const en = {
     match: {
       label: 'Match'
     },
+    note: {
+      label: 'Notes'
+    },
     archive: {
-      label: 'Archive'
+      label: 'Archive',
+      caption: 'Clinic appointment booked by {{appointment.contact.fullName}}',
+      title: 'Archive response',
+      description:
+        'The unmatched clinic appointment will be hidden. This cannot be undone.',
+      confirm: 'Archive this appointment',
+      success:
+        'Clinic appointment booked by {{appointment.contact.fullName}} archived'
     }
   },
   clinicAppointment: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -236,15 +236,22 @@ export const en = {
     }
   },
   appointments: {
+    label: 'Clinic appointment',
     list: {
       label: 'Clinic appointments',
       title: 'Unmatched clinic appointments'
+    },
+    show: {
+      title: 'Clinic appointment booked by %s'
     },
     count: {
       total:
         '{count, plural, =0 {No unmatched clinic appointments} one {1 unmatched clinic appointment} other {{count} unmatched clinic appointments}}',
       session:
         '{count, plural, =0 {No unmatched clinic appointments at {location}} one {1 unmatched clinic appointment at {location}} other {{count} unmatched clinic appointments at {location}}}'
+    },
+    add: {
+      label: 'Create new record'
     },
     results:
       '{count, plural, =0 {No unmatched appointments matching your search criteria were found} one {Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> unmatched appointment} other {Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> unmatched appointments}}',
@@ -310,6 +317,9 @@ export const en = {
     },
     parentalRelationship: {
       label: 'Your relationship'
+    },
+    programmeTags: {
+      label: 'Programmes'
     }
   },
   clinicBooking: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -275,8 +275,26 @@ export const en = {
     vaccinations: {
       label: 'Programmes'
     },
+    link: {
+      title: 'Link clinic appointment with child record?',
+      caption: 'Clinic appointment made by {{contact.fullName}}',
+      summary: 'Compare child details',
+      confirm: 'Link appointment with record',
+      success:
+        'Clinic appointment made by {{appointment.contact.fullName}} linked to [{{patient.fullName}}]({{patient.uri}})’s record'
+    },
     match: {
-      label: 'Match'
+      label: 'Match',
+      title: 'Search for a child record to match with {{child.fullName}}',
+      caption: 'Consent response from {{contact.formatted.fullName}}',
+      child: {
+        fullAndPreferredNames: {
+          label: 'Child’s name'
+        }
+      },
+      contact: {
+        label: 'Parent'
+      }
     },
     note: {
       label: 'Notes'

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -109,7 +109,7 @@ export class Child {
   get fullName() {
     if (!this.firstName || !this.lastName) return ''
 
-    return [this.firstName, this.lastName].join(' ')
+    return [this.lastName.toUpperCase(), this.firstName].join(', ')
   }
 
   /**

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -466,4 +466,33 @@ export class ClinicAppointment {
     const { context, ...rest } = this
     return rest
   }
+
+  /**
+   * Find all
+   *
+   * @param {object} context - Context
+   * @returns {Array<ClinicAppointment>|undefined} Clinic appointments
+   * @static
+   */
+  static findAll(context) {
+    return ClinicBooking.findAll(context).flatMap(
+      ({ appointments }) => appointments
+    )
+  }
+
+  /**
+   * Find one
+   *
+   * @param {string|string[]} appointment_uuid - ClinicAppointment UUID
+   * @param {object} context - Context
+   * @returns {ClinicAppointment|undefined} Clinic appointment
+   * @static
+   */
+  static findOne(appointment_uuid, context) {
+    appointment_uuid = String(appointment_uuid)
+
+    return ClinicAppointment.findAll(context).find(
+      ({ uuid }) => uuid === appointment_uuid
+    )
+  }
 }

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -48,6 +48,8 @@ import {
  * @property {boolean} fluAlternative - accept the alternative flu vaccine if nasal not suitable?
  * @property {boolean} mmrAlternative - want the vaccine that doesn't contain gelatine?
  * @property {object} [healthAnswers] - Answers to health questions
+ * @property {boolean} archived - Has this appointment been archived?
+ * @property {string} [note] - Note about this clinic appointment
  */
 export class ClinicAppointment {
   constructor(options, context) {
@@ -75,6 +77,9 @@ export class ClinicAppointment {
     this.fluAlternative = options?.fluAlternative
     this.mmrAlternative = options?.mmrAlternative
     this.healthAnswers = options?.healthAnswers || {}
+
+    this.archived = options?.archived
+    this.note = options?.note
   }
 
   /**

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -29,6 +29,7 @@ import { getPreferredNames } from '../utils/reply.js'
 import {
   formatLink,
   formatLinkWithSecondaryText,
+  formatList,
   formatNhsNumber,
   formatOther,
   formatWithSecondaryText,
@@ -483,7 +484,10 @@ export class Patient extends Child {
         : 'No reminders sent',
       clinicProgramme_ids: this.clinicProgramme_ids
         .map((id) => this.programmes[id].programme.nameTag)
-        .join(' ')
+        .join(' '),
+      contacts: formatList(
+        this.contacts.map((contact) => contact.fullNameAndRelationship)
+      )
     }
   }
 

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -591,18 +591,21 @@ export class Session {
   /**
    * Get all appointments for this clinic
    *
-   * @returns {Array<ClinicAppointment>} - the appointments made for unmatched children
+   * @returns {Array<ClinicAppointment>} - the appointments made for this session
    */
   get appointments() {
     if (this.type !== SessionType.Clinic) {
       throw new Error(
-        'Unmatched clinic appointments are only relevant to clinic sessions'
+        'Clinic appointments are only relevant to clinic sessions'
       )
     }
 
     const appointments = ClinicBooking.findAll(this.context)
       ?.flatMap(({ appointments }) => appointments)
-      .filter(({ session_id }) => session_id === this.id)
+      .filter(
+        (appointment) =>
+          appointment.session_id === this.id && !appointment.archived
+      )
 
     return appointments
   }

--- a/app/routes/unmatched-appointment.js
+++ b/app/routes/unmatched-appointment.js
@@ -15,6 +15,6 @@ router.param('appointment_uuid', controller.read)
 // router.post('/:appointment_uuid/link', controller.link)
 // router.post('/:appointment_uuid/add', controller.add)
 
-// router.get('/:appointment_uuid{/:view}', controller.show)
+router.get('/:appointment_uuid{/:view}', controller.show)
 
 export const unmatchedAppointmentRoutes = router

--- a/app/routes/unmatched-appointment.js
+++ b/app/routes/unmatched-appointment.js
@@ -11,7 +11,7 @@ router.param('appointment_uuid', controller.read)
 // router.all('/:appointment_uuid/match', controller.readMatches)
 // router.post('/:appointment_uuid/match', controller.filterMatches)
 
-// router.post('/:appointment_uuid/invalidate', controller.invalidate)
+router.post('/:appointment_uuid/archive', controller.archive)
 // router.post('/:appointment_uuid/link', controller.link)
 // router.post('/:appointment_uuid/add', controller.add)
 

--- a/app/routes/unmatched-appointment.js
+++ b/app/routes/unmatched-appointment.js
@@ -8,12 +8,12 @@ router.get('/', controller.readAll, controller.list)
 
 router.param('appointment_uuid', controller.read)
 
-// router.all('/:appointment_uuid/match', controller.readMatches)
-// router.post('/:appointment_uuid/match', controller.filterMatches)
+router.all('/:appointment_uuid/match', controller.readMatches)
+router.post('/:appointment_uuid/match', controller.filterMatches)
+router.post('/:appointment_uuid/link', controller.link)
 
-router.post('/:appointment_uuid/archive', controller.archive)
-// router.post('/:appointment_uuid/link', controller.link)
 router.post('/:appointment_uuid/add', controller.add)
+router.post('/:appointment_uuid/archive', controller.archive)
 
 router.get('/:appointment_uuid{/:view}', controller.show)
 

--- a/app/routes/unmatched-appointment.js
+++ b/app/routes/unmatched-appointment.js
@@ -13,7 +13,7 @@ router.param('appointment_uuid', controller.read)
 
 router.post('/:appointment_uuid/archive', controller.archive)
 // router.post('/:appointment_uuid/link', controller.link)
-// router.post('/:appointment_uuid/add', controller.add)
+router.post('/:appointment_uuid/add', controller.add)
 
 router.get('/:appointment_uuid{/:view}', controller.show)
 

--- a/app/views/appointments/add.njk
+++ b/app/views/appointments/add.njk
@@ -1,0 +1,43 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("appointments.add.title") %}
+{% set confirmButtonText = __("appointments.add.confirm") %}
+
+{% block form %}
+  {{ super() }}
+
+  {{ appHeading({
+    caption: __("appointments.add.caption", { contact: appointment.contact } ),
+    title: title
+  }) }}
+
+  {{ summaryList({
+    card: {
+      heading: __("patient.label"),
+      headingSize: "m"
+    },
+    lastRowBorder: false,
+    rows: summaryRows(appointment.child, {
+      fullName: {},
+      preferredNames: {},
+      dob: {},
+      address: {}
+    })
+  }) }}
+
+  {{ summaryList({
+    card: {
+      heading: __("appointments.label"),
+      headingSize: "m"
+    },
+    lastRowBorder: false,
+    rows: summaryRows(appointment, {
+      programmeTags: {},
+      fluVaccineType: {},
+      mmrVaccineType: {},
+      location: {},
+      date: {},
+      timeSlot: {}
+    })
+  }) }}
+{% endblock %}

--- a/app/views/appointments/archive.njk
+++ b/app/views/appointments/archive.njk
@@ -1,0 +1,22 @@
+{% extends "_layouts/form.njk" %}
+
+{% set confirmButtonVariant = "warning" %}
+{% set confirmButtonText = __("appointments.archive.confirm") %}
+{% set title = __("appointments.archive.title") %}
+
+{% block form %}
+  {{ appHeading({
+    caption: __("appointments.archive.caption", { appointment: appointment }),
+    title: title
+  }) }}
+
+  {{ __("appointments.archive.description") | nhsukMarkdown }}
+
+  {{ textarea({
+    label: {
+      classes: "nhsuk-label--m nhsuk-u-margin-bottom-2",
+      text: __("appointments.note.label")
+    },
+    decorate: "appointment.note"
+  }) }}
+{% endblock %}

--- a/app/views/appointments/link.njk
+++ b/app/views/appointments/link.njk
@@ -1,0 +1,66 @@
+{% extends "_layouts/form.njk" %}
+
+{% set gridColumns = "full" %}
+{% set title = __("appointments.link.title") %}
+{% set confirmButtonText = __("appointments.link.confirm") %}
+{% set paths = { back: appointmentPath + "/match" } %}
+
+{% block form %}
+  {{ super() }}
+
+  {{ appHeading({
+    caption: __("appointments.link.caption", { contact: appointment.contact } ),
+    title: title
+  }) }}
+
+  <div class="nhsuk-grid-row nhsuk-card-group">
+    <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+      {{ summaryList({
+        card: {
+          feature: true,
+          heading: __("appointments.label"),
+          headingSize: "m"
+        },
+        lastRowBorder: false,
+        rows: summaryRows(appointment.child, {
+          fullName: {
+            value: appointment.child.fullName | highlightDifference(patient.fullName)
+          },
+          dob: {
+            value: appointment.child.formatted.dob | highlightDifference(patient.formatted.dob)
+          },
+          address: {
+            value: appointment.child.formatted.address | highlightDifference(patient.formatted.address)
+          },
+          schoolName: {
+            value: appointment.child.formatted.schoolName | highlightDifference(patient.formatted.schoolName)
+          },
+          gpSurgery: {
+            value: appointment.child.formatted.gpSurgery | highlightDifference(patient.formatted.gpSurgery)
+          },
+          contact: {
+            value: appointment.contact.fullNameAndRelationship
+          }
+        })
+      }) }}
+    </div>
+    <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+      {{ summaryList({
+        card: {
+          feature: true,
+          heading: __("patient.label"),
+          headingSize: "m"
+        },
+        lastRowBorder: false,
+        rows: summaryRows(patient, {
+          fullName: {},
+          dob: {},
+          address: {},
+          schoolName: {},
+          gpSurgery: {},
+          contacts: {}
+        })
+      }) if patient }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/appointments/match.njk
+++ b/app/views/appointments/match.njk
@@ -1,0 +1,105 @@
+{% from "_macros/patient-search.njk" import appPatientSearch with context %}
+
+{% extends "_layouts/form.njk" %}
+
+{% set dateOfBirth = true %}
+{% set gridColumns = "full" %}
+{% set hideConfirmButton = true %}
+{% set title = __("appointments.match.title", { child: appointment.child }) %}
+
+{% block form %}
+  {{ super() }}
+
+  {{ appHeading({
+    title: title
+  }) }}
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-one-third" data-module="app-sticky">
+      {% call card({
+        feature: true,
+        heading: __("appointments.label"),
+        headingLevel: 3
+      }) %}
+        {{ summaryList({
+          classes: "nhsuk-u-margin-bottom-4 app-summary-list--full-width",
+          border: false,
+          rows: summaryRows(appointment.child, {
+            fullAndPreferredNames: {
+              label: __("appointments.match.child.fullAndPreferredNames.label")
+            },
+            dob: {},
+            postalCode: {},
+            schoolName: {},
+            contact: {
+              label: __("appointments.match.contact.label"),
+              value: consent.formatted.contact
+            }
+          })
+        }) }}
+
+        {{ link(appointmentPath + "?referrer=" + appointmentPath + "/match", "View full clinic appointment") | nhsukMarkdown }}
+
+        {{ actionLink({
+          href: appointmentPath + "/add",
+          text: __("appointments.add.label")
+        }) }}
+      {% endcall %}
+    </div>
+
+    <div class="nhsuk-grid-column-two-thirds">
+      {{ appPatientSearch({
+        hideProgrammeStatuses: true,
+        hideClinicStatuses: true,
+        clear: consentPath + "/match"
+      }) }}
+
+      {% if initial %}
+        {{ appHeading({
+          level: 3,
+          size: "m",
+          title: __("search.results"),
+          summary: __("search.initial") | safe
+        }) }}
+      {% else %}
+        {{ appHeading({
+          level: 3,
+          size: "m",
+          title: __("search.results"),
+          summary: __mf("patient.results.summary", {
+            from: results.from,
+            to: results.to,
+            count: results.count
+          }) | safe
+        }) }}
+
+        {% for patient in results.page %}
+          {{ summaryList({
+            card: {
+              classes: "app-card--compact",
+              heading: patient.fullName | highlightQuery(data.q) | safe,
+              headingLevel: 4,
+              clickable: true,
+              href: appointmentPath + "/link?patient_uuid=" + patient.uuid
+            },
+            lastRowBorder: false,
+            rows: summaryRows(patient, {
+              dob: {},
+              postalCode: {
+                value: patient.postalCode | highlightQuery(data.q)
+              },
+              schoolName: {
+                value: patient.school.name | highlightQuery(data.q)
+              },
+              contacts: {
+                value: patient.formatted.contacts | highlightQuery(data.q)
+              }
+            })
+          }) }}
+        {% endfor %}
+
+        {{ pagination(pages) }}
+      {% endif %}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/appointments/show.njk
+++ b/app/views/appointments/show.njk
@@ -1,0 +1,76 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = __("appointments.show.title", appointment.contact.formatted.fullName) %}
+
+{% block content %}
+  <div class="nhsuk-u-width-three-quarters">
+    {{ super() }}
+
+    {{ appHeading({
+      title: title
+    }) }}
+
+    {{ appActionList({
+      items: [{
+        text: __("appointments.match.label"),
+        href: appointmentPath + "/match?referrer=" + appointmentPath
+      }, {
+        text: __("appointments.add.label"),
+        href: appointmentPath + "/add?referrer=" + appointmentPath
+      }, {
+        text: __("appointments.archive.label"),
+        href: appointmentPath + "/archive?referrer=" + appointmentPath
+      }]
+    }) }}
+
+    {{ summaryList({
+      card: {
+        heading: __("appointments.label"),
+        headingSize: "m"
+      },
+      lastRowBorder: false,
+      rows: summaryRows(appointment, {
+        programmeTags: {},
+        fluVaccineType: {},
+        mmrVaccineType: {},
+        location: {},
+        date: {},
+        timeSlot: {}
+      })
+    }) }}
+
+    {{ summaryList({
+      card: {
+        heading: __("contact.label"),
+        headingSize: "m"
+      },
+      lastRowBorder: false,
+      rows: summaryRows(appointment.contact, {
+        fullName: {},
+        relationship: {},
+        hasParentalResponsibility: {},
+        email: {},
+        tel: {},
+        contactPreference: {},
+        sms: {}
+      })
+    }) if appointment.contact }}
+
+    {{ summaryList({
+      card: {
+        heading: __("child.label"),
+        headingSize: "m"
+      },
+      lastRowBorder: false,
+      rows: summaryRows(appointment.child, {
+        fullName: {},
+        preferredFirstName: {},
+        preferredLastName: {},
+        dob: {},
+        address: {},
+        gpSurgery: {},
+        schoolName: {}
+      })
+    }) if appointment.child }}
+  </div>
+{% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1676,9 +1676,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1698,9 +1695,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1722,9 +1716,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1744,9 +1735,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1768,9 +1756,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1790,9 +1775,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2238,9 +2220,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2255,9 +2234,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2272,9 +2248,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2289,9 +2262,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2306,9 +2276,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2323,9 +2290,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2340,9 +2304,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2357,9 +2318,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2374,9 +2332,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2391,9 +2346,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13634,7 +13586,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13651,7 +13602,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13668,7 +13618,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13685,7 +13634,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13702,7 +13650,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13719,7 +13666,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": "musl",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13736,7 +13682,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13753,7 +13698,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": "glibc",
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
Following the pattern established by the resolution of unmatched consent responses, this change does the same for unmatched clinic appointments.

Additionally, when a child record is linked to the appointment, a patient session record is created for each of the programmes for which the child was booked in and, accordingly, the child appears in the Children in session tab of the clinic session. And when you archive the appointment, that appointment disappears from the Appointments tab within the clinic session and the slot is freed up for further booking.