### PR TITLE
Add ability to edit child’s year and registration groups

### DIFF
--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -401,7 +401,16 @@ export const patientController = {
       patient = Patient.create(patient, data.wizard)
     }
 
-    response.locals.patient = new Patient(patient, data)
+    patient = new Patient(patient, data)
+
+    response.locals.patient = patient
+
+    response.locals.academicYearGroupItems = patient.school.yearGroups.map(
+      (yearGroup) => ({
+        text: formatYearGroup(yearGroup),
+        value: yearGroup
+      })
+    )
 
     response.locals.paths = {
       back: `${patient.uri}/edit`,

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1729,7 +1729,12 @@ export const en = {
       label: 'School'
     },
     yearGroup: {
-      label: 'Year group'
+      label: 'Year group',
+      title: 'What year group is the child in?'
+    },
+    registrationGroup: {
+      label: 'Registration group',
+      title: 'What registration group is the child in?'
     },
     yearGroupWithRegistration: {
       label: 'Year group'

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -46,6 +46,7 @@ import { formatList, formatYearGroup, stringToArray } from '../utils/string.js'
  * @property {boolean} [immunocompromised] - Immunocompromised
  * @property {object} [address] - Address
  * @property {string} [gpSurgery] - GP surgery
+ * @property {number} [academicYearGroup] - Academic year group (override)
  * @property {string} [registrationGroup] - Registration group
  * @property {string} [school_id] - School
  */
@@ -70,6 +71,7 @@ export class Child {
     this.immunocompromised = options?.immunocompromised
     this.address = options?.address
     this.gpSurgery = options?.gpSurgery
+    this.academicYearGroup = options?.academicYearGroup || this.yearGroup
     this.registrationGroup = options?.registrationGroup
 
     if (!this.agedOutOfProgrammes) {
@@ -223,7 +225,7 @@ export class Child {
    */
   get yearGroup() {
     if (!this.agedOutOfProgrammes) {
-      return getYearGroup(this.dob)
+      return this.academicYearGroup || getYearGroup(this.dob)
     }
   }
 

--- a/app/views/patient/edit.njk
+++ b/app/views/patient/edit.njk
@@ -100,6 +100,32 @@
       }
     }, {
       key: {
+        text: __("patient.yearGroup.label")
+      },
+      value: {
+        text: patient.formatted.yearGroup
+      },
+      actions: {
+        items: [{
+          text: __("actions.change"),
+          href: "edit/year-group"
+        }]
+      }
+    }, {
+      key: {
+        text: __("patient.registrationGroup.label")
+      },
+      value: {
+        text: patient.registrationGroup or "Not provided"
+      },
+      actions: {
+        items: [{
+          text: __("actions.change"),
+          href: "edit/registration-group"
+        }]
+      }
+    }, {
+      key: {
         text: __("patient.gpSurgery.label")
       },
       value: {

--- a/app/views/patient/form/registration-group.njk
+++ b/app/views/patient/form/registration-group.njk
@@ -1,0 +1,15 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("patient.registrationGroup.title") %}
+
+{% block form %}
+  {{ input({
+    label: {
+      isPageHeading: true,
+      text: __("patient.registrationGroup.title"),
+      size: "l"
+    },
+    decorate: "patient.registrationGroup",
+    width: 5
+  }) }}
+{% endblock %}

--- a/app/views/patient/form/year-group.njk
+++ b/app/views/patient/form/year-group.njk
@@ -1,0 +1,19 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("patient.yearGroup.title") %}
+
+{% block form %}
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--l",
+        html: appHeading({
+          caption: patient.fullName,
+          title: title
+        })
+      }
+    },
+    items: academicYearGroupItems,
+    decorate: "patient.academicYearGroup"
+  }) }}
+{% endblock %}


### PR DESCRIPTION
We calculate a child’s year group based on their date or birth. However sometimes a child may be moved up or down a year, so teams need the ability to override this value.

Also, while we’re here, add the ability to add/edit a child’s registration group. 

<img width="2360" height="2668" alt="Edit child record – Manage vaccinations in schools – NHS" src="https://github.com/user-attachments/assets/374f3e2e-ef9a-45c4-953c-878b782e392b" />

<img width="2360" height="2182" alt="Year group - Manage vaccinations in schools – NHS" src="https://github.com/user-attachments/assets/468b58a4-a25c-4652-8ed7-dfefbf7a0bf9" />

<img width="2360" height="1640" alt="Registration group - Manage vaccinations in schools – NHS" src="https://github.com/user-attachments/assets/a1b46f35-d9c5-4ff9-b462-ef44e5ebeb36" />

