### PR TITLE
Update clinic session presets

### DIFF
--- a/app/enums.js
+++ b/app/enums.js
@@ -460,7 +460,10 @@ export const SessionPresetName = {
   Flu: 'Flu',
   HPV: 'HPV',
   Doubles: 'Doubles',
-  MMR: 'MMR(V)'
+  MMR: 'MMR(V)',
+  AutumnCatchup: 'Flu and MMR(V)',
+  SpringCatchup: 'HPV and MMR(V)',
+  SummerCatchup: 'HPV, MenACWY, Td/IPV and MMR(V)'
 }
 
 /**
@@ -476,6 +479,7 @@ export const SessionMMRConsent = {
  * @typedef {object} SessionPreset
  * @property {SessionPresetName} name - Session preset name
  * @property {boolean} active - Whether preset is active
+ * @property {boolean} [clinicOnly] - Whether preset is for clinics only
  * @property {boolean} [adolescent] - Adolescent programme flag
  * @property {Array<ProgrammeType>} programmeTypes - Preset programme types
  * @property {SchoolTerm} term - School term to schedule session
@@ -516,6 +520,35 @@ export const SessionPresets = [
     programmeTypes: [ProgrammeType.MMR],
     term: SchoolTerm.Spring,
     slug: 'mmr'
+  },
+  {
+    name: SessionPresetName.AutumnCatchup,
+    active: true,
+    clinicOnly: true,
+    programmeTypes: [ProgrammeType.Flu, ProgrammeType.MMR],
+    term: SchoolTerm.Autumn,
+    slug: 'autumn-catch-up'
+  },
+  {
+    name: SessionPresetName.SpringCatchup,
+    active: true,
+    clinicOnly: true,
+    programmeTypes: [ProgrammeType.HPV, ProgrammeType.MMR],
+    term: SchoolTerm.Spring,
+    slug: 'spring-catch-up'
+  },
+  {
+    name: SessionPresetName.SummerCatchup,
+    active: true,
+    clinicOnly: true,
+    programmeTypes: [
+      ProgrammeType.HPV,
+      ProgrammeType.MenACWY,
+      ProgrammeType.TdIPV,
+      ProgrammeType.MMR
+    ],
+    term: SchoolTerm.Summer,
+    slug: 'summer-catch-up'
   }
 ]
 

--- a/app/middleware/navigation.js
+++ b/app/middleware/navigation.js
@@ -33,14 +33,14 @@ export const navigation = (request, response, next) => {
       HPV: getClinicInviteUrlForPresets([SessionPresetName.HPV]),
       Doubles: getClinicInviteUrlForPresets([SessionPresetName.Doubles]),
       'MMR(V)': getClinicInviteUrlForPresets([SessionPresetName.MMR]),
-      'adolescent programmes': getClinicInviteUrlForPresets([
-        SessionPresetName.HPV,
-        SessionPresetName.Doubles
+      'Flu and MMR(V)': getClinicInviteUrlForPresets([
+        SessionPresetName.AutumnCatchup
       ]),
-      'all but flu': getClinicInviteUrlForPresets([
-        SessionPresetName.HPV,
-        SessionPresetName.Doubles,
-        SessionPresetName.MMR
+      'HPV and MMR(V)': getClinicInviteUrlForPresets([
+        SessionPresetName.SpringCatchup
+      ]),
+      'HPV, MenACWY, Td/IPV and MMR(V)': getClinicInviteUrlForPresets([
+        SessionPresetName.SummerCatchup
       ])
     }
   }

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -52,7 +52,7 @@
       }) }}
 
       {% for preset in SessionPresets %}
-        {% if preset.active %}
+        {% if preset.active and not preset.clinicOnly %}
           {{ actionLink({
             classes: "nhsuk-u-margin-bottom-2",
             text: "Start page for parents to give or refuse consent for " + preset.name | replace("Flu", "flu"),
@@ -79,7 +79,7 @@
       }) }}
 
       {% for preset in SessionPresets %}
-        {% if preset.active %}
+        {% if preset.active and preset.clinicOnly %}
           {{ actionLink({
             classes: "nhsuk-u-margin-bottom-2",
             text: "Start page for parents to book into a clinic for " + preset.name | replace("Flu", "flu"),
@@ -87,17 +87,6 @@
           }) }}
         {% endif %}
       {% endfor %}
-      {{ actionLink({
-        classes: "nhsuk-u-margin-bottom-2",
-        text: "Start page for parents to book into a clinic for the adolescent programmes",
-        href: navigation.clinicInviteUrl["adolescent programmes"]
-      }) }}
-      {{ actionLink({
-        classes: "nhsuk-u-margin-bottom-2",
-        text: "Start page for parents to book into a clinic for all but flu",
-        href: navigation.clinicInviteUrl["all but flu"]
-      }) }}
-
     </main>
   </div>
 {% endblock %}

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -205,32 +205,37 @@ context.sessions = {}
 for (const preset of Object.values(SessionPresets)) {
   const year = getCurrentAcademicYear()
 
-  const ids = Object.values(context.schools)
-    .filter(({ phase }) =>
-      // Adolescent programmes are only held at secondary schools
-      preset.adolescent ? phase === SchoolPhase.Secondary : phase
-    )
-    .map(({ id }) => id)
-
   // Schedule school sessions
-  for (const school_id of ids) {
-    const schoolSession = generateSession(preset, year, nurse, { school_id })
-    if (schoolSession) {
-      context.sessions[schoolSession.id] = new Session(schoolSession, context)
+  if (!preset.clinicOnly) {
+    const ids = Object.values(context.schools)
+      .filter(({ phase }) =>
+        // Adolescent programmes are only held at secondary schools
+        preset.adolescent ? phase === SchoolPhase.Secondary : phase
+      )
+      .map(({ id }) => id)
+
+    // Schedule school sessions
+    for (const school_id of ids) {
+      const schoolSession = generateSession(preset, year, nurse, { school_id })
+      if (schoolSession) {
+        context.sessions[schoolSession.id] = new Session(schoolSession, context)
+      }
     }
   }
 
   // Schedule clinic sessions
-  const clinicsPerPreset = 3
-  const clinic_ids = faker.helpers.arrayElements(
-    Object.values(context.teams).flatMap((team) => team.clinic_ids),
-    clinicsPerPreset
-  )
-  for (const clinic_id of clinic_ids) {
-    const clinicSession = generateSession(preset, year, nurse, { clinic_id })
-    if (clinicSession) {
-      generateClinicVaccinationPeriods(clinicSession)
-      context.sessions[clinicSession.id] = new Session(clinicSession, context)
+  if (preset.clinicOnly) {
+    const clinicsPerPreset = 3
+    const clinic_ids = faker.helpers.arrayElements(
+      Object.values(context.teams).flatMap((team) => team.clinic_ids),
+      clinicsPerPreset
+    )
+    for (const clinic_id of clinic_ids) {
+      const clinicSession = generateSession(preset, year, nurse, { clinic_id })
+      if (clinicSession) {
+        generateClinicVaccinationPeriods(clinicSession)
+        context.sessions[clinicSession.id] = new Session(clinicSession, context)
+      }
     }
   }
 }


### PR DESCRIPTION
Use three distinct presets for generated clinics:

- Autumn term: Flu and MMR(V)
- Spring term: HPV and MMR(V)
- Summer term: HPV, MenACWY, Td/IPV and MMR(V)

While some teams may have different combinations, its beneficial to data creation for our examples to be more predictable and contain more children.