### PR TITLE
Factor in current date when calculating which year child becomes eligible for flu again

### DIFF
--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -1,4 +1,4 @@
-import { addMonths, addWeeks } from 'date-fns'
+import { addMonths, addWeeks, isAfter } from 'date-fns'
 
 import {
   AuditEventType,
@@ -95,7 +95,14 @@ export class PatientProgramme {
     }
 
     if (this.programme.type === ProgrammeType.Flu) {
-      return getCurrentAcademicYear()
+      const academicYear = getCurrentAcademicYear()
+
+      // If flu season has finished, make eligible for next year’s programme
+      if (isAfter(today(), `${academicYear + 1}-03-31`)) {
+        return academicYear + 1
+      }
+
+      return academicYear
     }
 
     const yearsUntilEligible =


### PR DESCRIPTION
If today’s date is outside of flu season, show children as eligible for the flu from 1st September of the next academic year.

This means that clinic sessions held in the summer won’t show children who missed a flu vaccination.