### PR TITLE
Parent clinic booking: complete the booking and handle a total lack of appointments

### DIFF
--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -96,6 +96,26 @@ export const bookIntoClinicController = {
   /**
    * @type {import("express").RequestHandler}
    */
+  update(request, response) {
+    const { booking_uuid } = request.params
+    const { data } = request.session
+    const { booking, paths } = response.locals
+
+    // Clean up session data
+    delete data.booking
+    delete data.appointment
+    delete data.transaction
+    delete data.clinicInvite
+
+    // Save to the global context
+    ClinicBooking.update(booking_uuid, booking, data)
+
+    return response.redirect(paths.next)
+  },
+
+  /**
+   * @type {import("express").RequestHandler}
+   */
   readForm(request, response, next) {
     const { appointment_uuid, booking_uuid } = request.params
     const { data, referrer } = request.session
@@ -161,10 +181,7 @@ export const bookIntoClinicController = {
     let { booking_uuid } = request.params
     let view = String(request.params.view)
 
-    if (view === 'child') {
-      console.log(request.originalUrl)
-      console.log(JSON.stringify(appointment, null, 2))
-    } else if (view === 'address-selection') {
+    if (view === 'address-selection') {
       // Build the options for the selection of a home address address from those already entered
       const booking = ClinicBooking.findOne(booking_uuid, data.wizard)
       response.locals.previousAddressItems = getPreviousAddressItems(

--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -78,7 +78,10 @@ export const bookIntoClinicController = {
     data.transaction = {}
 
     // Create a new clinic booking in the wizard context
-    const booking = ClinicBooking.create({}, data.wizard)
+    const booking = ClinicBooking.create(
+      { invited_programme_ids: data.clinicInvite.programme_ids },
+      data.wizard
+    )
     booking.addAppointment()
     const firstAppointment = booking.appointments[0]
 

--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -16,6 +16,10 @@ import {
   getPreviousAddressItems,
   getPreviousSessionItems
 } from '../utils/clinic-appointment.js'
+import {
+  getBookableClinicSessions,
+  getScheduledClinicLocationItems
+} from '../utils/clinic-booking.js'
 import { setMidday } from '../utils/date.js'
 import {
   ConjunctionType,
@@ -50,24 +54,41 @@ export const bookIntoClinicController = {
       programme_ids = Array.isArray(programme_id)
         ? programme_id
         : [programme_id]
+    } else {
+      programme_ids = Programme.findAll(data)
+        .filter(({ hidden }) => !hidden)
+        .map(({ id }) => id)
+    }
 
-      data.clinicInvite = {
-        programme_ids,
-        programmes: Programme.findAll(data)
-          .map((programme) => {
-            delete programme.context
-            return programme
-          })
-          .filter(({ id }) => programme_ids.includes(id)),
-        programmeNames: programmeNamesListForSentence(
+    // Track details of the invite for pages that need to show the invited programmes
+    data.clinicInvite = {
+      programme_ids,
+      programmes: Programme.findAll(data)
+        .map((programme) => {
+          delete programme.context
+          return programme
+        })
+        .filter(({ id }) => programme_ids.includes(id)),
+      programmeNames: {
+        and: programmeNamesListForSentence(
           programme_ids,
           ConjunctionType.and,
+          data
+        ),
+        or: programmeNamesListForSentence(
+          programme_ids,
+          ConjunctionType.or,
           data
         )
       }
     }
 
-    response.redirect(`/book-into-a-clinic/start`)
+    const bookableSessions = getBookableClinicSessions(data, programme_ids)
+    response.redirect(
+      bookableSessions.length > 0
+        ? '/book-into-a-clinic/start'
+        : '/book-into-a-clinic/availability'
+    )
   },
 
   /**
@@ -227,34 +248,18 @@ export const bookIntoClinicController = {
           }
         }
       })
+    } else if (view === 'availability') {
+      response.locals.programmeNames = programmeNamesListForSentence(
+        appointment.selected_programme_ids,
+        ConjunctionType.or,
+        data
+      )
     } else if (view === 'clinic-location') {
-      const scheduledClinics = Session.findAll(data).filter(
-        (session) =>
-          session.type === SessionType.Clinic &&
-          session.status === SessionStatus.Planned
+      const clinicLocationItems = getScheduledClinicLocationItems(
+        data,
+        appointment.selected_programme_ids,
+        data.transaction?.outOfArea
       )
-
-      const sessionsByLocation = _.groupBy(
-        scheduledClinics,
-        (session) => session.clinic_id
-      )
-
-      let distanceToClinic = data.transaction?.outOfArea ? 100.5 : 0.5
-      const clinicLocationItems = []
-      Object.entries(sessionsByLocation).forEach(([clinic_id, sessions]) => {
-        const firstSession = sessions.reduce((earliest, current) => {
-          return current.date < earliest.date ? current : earliest
-        })
-
-        clinicLocationItems.push({
-          text: sessions[0].formatted.location,
-          value: clinic_id,
-          hint: {
-            text: `${distanceToClinic.toFixed(1)} miles away, next date is ${firstSession.formatted.date}`
-          }
-        })
-        distanceToClinic += 2.1
-      })
       response.locals.clinicLocationItems = clinicLocationItems
     } else if (view === 'clinic-date') {
       const scheduledClinicSessions = _.sortBy(
@@ -367,6 +372,12 @@ export const bookIntoClinicController = {
         location: session.formatted.location,
         date: session.formatted.date
       }
+    } else if (view === 'fully-booked') {
+      response.locals.programmeNames = programmeNamesListForSentence(
+        appointment.selected_programme_ids,
+        ConjunctionType.and,
+        data
+      )
     }
 
     // All health questions use the same view

--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -109,7 +109,7 @@ export const bookIntoClinicController = {
         const currentAppointment = booking.findAppointment(appointment_uuid)
         response.locals.appointment = currentAppointment
 
-        // The check-appointment page needs a version of the appointment that can find its booking on the context
+        // The check-answers page needs a version of the appointment that can find its booking on the context
         response.locals.wizardAppointment =
           wizardBooking?.findAppointment(appointment_uuid)
 

--- a/app/generators/clinic-booking.js
+++ b/app/generators/clinic-booking.js
@@ -5,17 +5,19 @@ import { ClinicBooking } from '../models.js'
 /**
  * Generate fake clinic booking (initially without any appointments, which can be added later)
  *
- * @param {object} context
+ * @param {Array<string>} invited_programme_ids - the IDs of programmes to which the child is being invited
+ * @param {object} context - the context to use in the booking
  * @returns {ClinicBooking} ClinicBooking
  */
-export function generateEmptyClinicBooking(context) {
+export function generateEmptyClinicBooking(invited_programme_ids, context) {
   const uuid = faker.string.uuid()
   const bookingReference = ClinicBooking.generateReference()
 
   return new ClinicBooking(
     {
       uuid,
-      bookingReference
+      bookingReference,
+      invited_programme_ids
     },
     context
   )

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -574,7 +574,7 @@ export const en = {
       appointmentsAvailable:
         '{count, plural, =0 {No appointments available} one {1 appointment available} other {{count} appointments available}}'
     },
-    'check-appointment': {
+    'check-answers': {
       title: 'Check and confirm %s’s appointment details',
       summary: {
         child: 'Child details',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -384,6 +384,24 @@ export const en = {
           'If you cannot use this form, you can book an appointment by phoning %s.'
       }
     },
+    availability: {
+      title: {
+        invited: 'Book an appointment for your child’s vaccination',
+        selected:
+          '{count, plural, one {There are no clinics scheduled for your preferred vaccination} other {There are no clinics scheduled for your preferred vaccinations}}'
+      },
+      problem:
+        'There are no clinics scheduled for {{ programmes }} vaccinations at this time.',
+      guidance:
+        'Contact your local vaccinations team, who may be able to arrange an appointment at another clinic, by phoning {{ team.tel }} or emailing {{ team.email }}.'
+    },
+    fullyBooked: {
+      title: 'All clinics are now fully booked',
+      problem:
+        'All clinics scheduled for {{ programmes }} vaccinations are fully booked.',
+      guidance:
+        'Contact your local vaccinations team, who may be able to arrange an appointment at another clinic, by phoning {{ team.tel }} or emailing {{ team.email }}.'
+    },
     childCount: {
       title: 'How many children do you need to book appointments for?',
       description:

--- a/app/models/clinic-booking.js
+++ b/app/models/clinic-booking.js
@@ -15,6 +15,7 @@ import {
  * @property {object} [context] - Context
  * @property {string} uuid - Clinic booking UUID
  * @property {string} bookingReference - Booking reference number
+ * @property {Array<string>} invited_programme_ids - IDs of programmes for which child was invited
  * @property {Contact} contact - Contact details for the booking; see appointments for parental relationship details
  * @property {Array<ClinicAppointment>} appointments - the appointments created in this booking (one per child)
  */
@@ -24,6 +25,10 @@ export class ClinicBooking {
     this.uuid = options?.uuid || faker.string.uuid()
     this.bookingReference =
       options?.bookingReference || ClinicBooking.generateReference()
+    this.invited_programme_ids = options?.invited_programme_ids
+      ? [...options.invited_programme_ids]
+      : []
+
     this.contact =
       (options?.contact && new Contact(options.contact)) ?? new Contact({})
 

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -283,6 +283,19 @@ export class Session {
   }
 
   /**
+   * Is this clinic session still open to booking?
+   *
+   * @returns {boolean} True if still open to booking, or false otherwise
+   */
+  get isOpenToBooking() {
+    return (
+      this.type === SessionType.Clinic &&
+      this.isPlanned &&
+      this.daysLeftToBook >= 1
+    )
+  }
+
+  /**
    * Is active session
    *
    * @returns {boolean} Is active session

--- a/app/routes/book-into-a-clinic.js
+++ b/app/routes/book-into-a-clinic.js
@@ -23,8 +23,10 @@ router.get(
 )
 router.get('/:booking_uuid/new/:view', bookIntoClinic.showForm)
 
-// TODO: save the completed booking to the global context
-// router.post('/:booking_uuid/new/check-answers', bookIntoClinic.update)
+router.post(
+  '/:booking_uuid/new/:appointment_uuid/check-answers',
+  bookIntoClinic.update
+)
 
 router.post(
   '/:booking_uuid/new/:appointment_uuid/:view',

--- a/app/utils/clinic-appointment.js
+++ b/app/utils/clinic-appointment.js
@@ -3,8 +3,9 @@ import _ from 'lodash'
 import { LocationSearchType, ReplyDecision } from '../enums.js'
 import { ClinicAppointment, ClinicBooking, Session } from '../models.js'
 
+import { getBookableClinicSessions } from './clinic-booking.js'
 import { getLocationSearchType } from './geolocation.js'
-import { camelToKebabCase } from './string.js'
+import { camelToKebabCase, stringToArray } from './string.js'
 
 /**
  * Get wizard journey paths and forking details for all appointments in the given clinic booking
@@ -27,7 +28,16 @@ export const getAllAppointmentPaths = (
     const appointment_uuid = appointment.uuid
     return {
       // Vaccinations wanted
-      [`/${booking_uuid}/new/${appointment_uuid}/programmes`]: {},
+      [`/${booking_uuid}/new/${appointment_uuid}/programmes`]: {
+        [`/${booking_uuid}/new/${appointment_uuid}/availability`]: () => {
+          const programme_ids = stringToArray(
+            sessionData.appointment?.selected_programme_ids
+          )
+          return (
+            getBookableClinicSessions(sessionData, programme_ids).length === 0
+          )
+        }
+      },
       ...(sessionData.appointment?.selected_programme_ids?.includes('flu')
         ? {
             [`/${booking_uuid}/new/${appointment_uuid}/flu-choice`]: {}
@@ -44,7 +54,7 @@ export const getAllAppointmentPaths = (
           }
         : {}),
 
-      // Clinic and slot selection
+      // Clinic location preference
       ...(appointments[0].uuid !== appointment_uuid &&
       getPreviousSessionItems(appointments, sessionData).length > 2
         ? {
@@ -78,10 +88,48 @@ export const getAllAppointmentPaths = (
         }
       },
       [`/${booking_uuid}/new/${appointment_uuid}/clinic-distance`]: {}, // only used for place matching path (for demo/test purposes)
-      [`/${booking_uuid}/new/${appointment_uuid}/clinic-location`]: {},
-      [`/${booking_uuid}/new/${appointment_uuid}/clinic-date`]: {},
-      [`/${booking_uuid}/new/${appointment_uuid}/appointment-time-range`]: {},
-      [`/${booking_uuid}/new/${appointment_uuid}/appointment-time`]: {},
+
+      // Session and slot selection
+      [`/${booking_uuid}/new/${appointment_uuid}/clinic-location`]: {
+        [`/${booking_uuid}/new/${appointment_uuid}/fully-booked`]: () => {
+          return (
+            getBookableClinicSessions(
+              sessionData,
+              appointment.selected_programme_ids
+            ).length === 0
+          )
+        }
+      },
+      [`/${booking_uuid}/new/${appointment_uuid}/clinic-date`]: {
+        [`/${booking_uuid}/new/${appointment_uuid}/fully-booked`]: () => {
+          return (
+            getBookableClinicSessions(
+              sessionData,
+              appointment.selected_programme_ids
+            ).length === 0
+          )
+        }
+      },
+      [`/${booking_uuid}/new/${appointment_uuid}/appointment-time-range`]: {
+        [`/${booking_uuid}/new/${appointment_uuid}/fully-booked`]: () => {
+          return (
+            getBookableClinicSessions(
+              sessionData,
+              appointment.selected_programme_ids
+            ).length === 0
+          )
+        }
+      },
+      [`/${booking_uuid}/new/${appointment_uuid}/appointment-time`]: {
+        [`/${booking_uuid}/new/${appointment_uuid}/fully-booked`]: () => {
+          return (
+            getBookableClinicSessions(
+              sessionData,
+              appointment.selected_programme_ids
+            ).length === 0
+          )
+        }
+      },
 
       // Child details
       [`/${booking_uuid}/new/${appointment_uuid}/child`]: {},

--- a/app/utils/clinic-appointment.js
+++ b/app/utils/clinic-appointment.js
@@ -108,7 +108,7 @@ export const getAllAppointmentPaths = (
       },
       [`/${booking_uuid}/new/contact-preference`]: {},
 
-      [`/${booking_uuid}/new/${appointment_uuid}/check-appointment`]: {}
+      [`/${booking_uuid}/new/${appointment_uuid}/check-answers`]: {}
     }
   })
 

--- a/app/utils/clinic-booking.js
+++ b/app/utils/clinic-booking.js
@@ -1,5 +1,8 @@
+import _ from 'lodash'
+
 import programmesData from '../datasets/programmes.js'
-import { SessionPresets } from '../enums.js'
+import { SessionPresets, SessionStatus, SessionType } from '../enums.js'
+import { Session } from '../models.js'
 
 /**
  * Generate a URL to book into a clinic for vaccination in the given presets' programmes
@@ -31,4 +34,63 @@ export const getClinicInviteUrlForProgrammes = (programme_ids) => {
   }
 
   return `/book-into-a-clinic/?${searchParams.toString()}`
+}
+
+/**
+ * Get a list of clinic sessions serving any of the given programmes and that are open to booking
+ *
+ * @param {object} context - the data context for the models to check
+ * @param {Array<string>} programme_ids - the programmes that must be served at the clinics
+ * @returns {Array<Session>} the list of sessions open to booking serving the given programmes
+ */
+export const getBookableClinicSessions = (context, programme_ids) => {
+  const scheduledClinics = Session.findAll(context).filter(
+    (session) =>
+      session.type === SessionType.Clinic &&
+      session.status === SessionStatus.Planned &&
+      session.programme_ids.some((id) => programme_ids.includes(id)) &&
+      session.isOpenToBooking &&
+      session.availableAppointmentCount > 0
+  )
+
+  return scheduledClinics
+}
+
+/**
+ * Get the clinic location options to present to the user
+ *
+ * @param {object} context - the data context for the models to check
+ * @param {Array<string>} programme_ids - the programmes that must be served at the clinics
+ * @param {boolean|undefined} fakeOutOfArea - flag to say whether to pretend all clinics are a long way away
+ * @returns {Array<object>} a set of radio buttons to present to the user, one per location
+ */
+export const getScheduledClinicLocationItems = (
+  context,
+  programme_ids,
+  fakeOutOfArea
+) => {
+  const scheduledClinics = getBookableClinicSessions(context, programme_ids)
+  const sessionsByLocation = _.groupBy(
+    scheduledClinics,
+    (session) => session.clinic_id
+  )
+
+  let distanceToClinic = fakeOutOfArea ? 100.5 : 0.5
+  const clinicLocationItems = []
+  Object.entries(sessionsByLocation).forEach(([clinic_id, sessions]) => {
+    const firstSession = sessions.reduce((earliest, current) => {
+      return current.date < earliest.date ? current : earliest
+    })
+
+    clinicLocationItems.push({
+      text: sessions[0].formatted.location,
+      value: clinic_id,
+      hint: {
+        text: `${distanceToClinic.toFixed(1)} miles away, next date is ${firstSession.formatted.date}`
+      }
+    })
+    distanceToClinic += 2.1
+  })
+
+  return clinicLocationItems
 }

--- a/app/views/book-into-a-clinic/availability.njk
+++ b/app/views/book-into-a-clinic/availability.njk
@@ -1,0 +1,20 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = false %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      {{ appHeading({
+        size: "xl",
+        title: __("clinicBooking.availability.title.invited")
+      }) }}
+
+      {% call insetText() %}
+        {{ __("clinicBooking.availability.problem", { programmes: data.clinicInvite.programmeNames.or }) | nhsukMarkdown }}
+      {% endcall %}
+
+      {{ __("clinicBooking.availability.guidance", { team: data.team }) | nhsukMarkdown }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/book-into-a-clinic/form/add-another.njk
+++ b/app/views/book-into-a-clinic/form/add-another.njk
@@ -19,7 +19,7 @@
         html: appActionList({
           items: [{
             text: __("actions.change"),
-            href: appointment.uri.new + "/check-appointment"
+            href: appointment.uri.new + "/check-answers"
           }, {
             text: __("actions.delete"),
             href: appointment.uri.new + "/delete-appointment"

--- a/app/views/book-into-a-clinic/form/availability.njk
+++ b/app/views/book-into-a-clinic/form/availability.njk
@@ -1,0 +1,16 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __mf("clinicBooking.availability.title.selected", { count: appointment.selected_programme_ids.length }) %}
+{% set hideConfirmButton = true %}
+
+{% block form %}
+  {{ appHeading({
+    title: title
+  }) }}
+
+  {% call insetText() %}
+    {{ __("clinicBooking.availability.problem", { programmes: programmeNames }) | nhsukMarkdown }}
+  {% endcall %}
+
+  {{ __("clinicBooking.availability.guidance", { team: data.team }) | nhsukMarkdown }}
+{% endblock %}

--- a/app/views/book-into-a-clinic/form/check-answers.njk
+++ b/app/views/book-into-a-clinic/form/check-answers.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/form.njk" %}
 
-{% set confirmButtonText = __("clinicBooking.check-appointment.confirm") %}
-{% set title = __("clinicBooking.check-appointment.title", firstName) %}
+{% set confirmButtonText = __("clinicBooking.check-answers.confirm") %}
+{% set title = __("clinicBooking.check-answers.title", firstName) %}
 
 {% block form %}
   {{ appHeading({
@@ -10,7 +10,7 @@
 
   {{ summaryList({
     card: {
-      heading: __("clinicBooking.check-appointment.summary.child"),
+      heading: __("clinicBooking.check-answers.summary.child"),
       headingSize: "m"
     },
     lastRowBorder: false,
@@ -38,7 +38,7 @@
 
   {{ summaryList({
     card: {
-      heading: __("clinicBooking.check-appointment.summary.appointment"),
+      heading: __("clinicBooking.check-answers.summary.appointment"),
       headingSize: "m"
     },
     lastRowBorder: false,
@@ -66,7 +66,7 @@
 
   {{ summaryList({
     card: {
-      heading: __("clinicBooking.check-appointment.summary.contact"),
+      heading: __("clinicBooking.check-answers.summary.contact"),
       headingSize: "m"
     },
     lastRowBorder: false,

--- a/app/views/book-into-a-clinic/form/fully-booked.njk
+++ b/app/views/book-into-a-clinic/form/fully-booked.njk
@@ -1,0 +1,19 @@
+{% extends "_layouts/default.njk" %}
+
+{% set title = __("clinicBooking.fullyBooked.title") %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      {{ appHeading({
+        title: title
+      }) }}
+
+      {% call insetText() %}
+        {{ __("clinicBooking.fullyBooked.problem", { programmes: programmeNames }) | nhsukMarkdown }}
+      {% endcall %}
+
+      {{ __("clinicBooking.fullyBooked.guidance", { team: data.team }) | nhsukMarkdown }}
+    </div>
+  </div>
+{% endblock %}

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -586,7 +586,10 @@ for (const patient of Patient.findAll(context)) {
 
   // Create a single child's appointment and containing booking
   // TODO: find or create siblings to add as well
-  const booking = generateEmptyClinicBooking(context)
+  const booking = generateEmptyClinicBooking(
+    patient.clinicProgramme_ids,
+    context
+  )
   const appointment = generateClinicAppointment(patient, session, booking)
 
   // Store the booking on the context


### PR DESCRIPTION
Changes in this PR:

- A clinic appointment (unmatched) is actually created at the end of the journey now
- We now track the programmes to which the child was invited as well as those selected, in case we want to repeat the invite
- The booking journey is now ended if:
  - there are no clinics scheduled for the invited programes (journey has an alternative landing page)
  - there are no clinics scheduled for the selected programmes
  - all slots in all matching clinics get filled while the parent chooses theirs