### PR TITLE
Consolidate type imports using JSDoc import

### DIFF
--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -2,7 +2,7 @@ import { UserRole } from '../enums.js'
 
 export const accountController = {
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   changeRole(request, response) {
     request.session.data.token.role = request.body.role
@@ -13,7 +13,7 @@ export const accountController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   cis2(request, response) {
     const { data } = request.session
@@ -27,7 +27,7 @@ export const accountController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   login(request, response) {
     const { data } = request.session
@@ -42,7 +42,7 @@ export const accountController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   logout(request, response) {
     delete request.session.data.token
@@ -50,3 +50,7 @@ export const accountController = {
     return response.redirect('/start')
   }
 }
+
+/**
+ * @import { RequestHandler } from 'express'
+ */

--- a/app/controllers/activity.js
+++ b/app/controllers/activity.js
@@ -17,7 +17,7 @@ import {
 
 export const activityController = {
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     const { data } = request.session
@@ -355,3 +355,7 @@ export const activityController = {
     return response.render('activity/list', { activityLog })
   }
 }
+
+/**
+ * @import { RequestHandler } from 'express'
+ */

--- a/app/controllers/batch.js
+++ b/app/controllers/batch.js
@@ -2,7 +2,7 @@ import { Batch, DefaultBatch } from '../models.js'
 
 export const batchController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, batch_id) {
     const batch = Batch.findOne(batch_id, request.session.data)
@@ -13,7 +13,7 @@ export const batchController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   form(request, response) {
     return response.render('batch/form')
@@ -21,7 +21,7 @@ export const batchController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   action(type) {
     return (request, response) => {
@@ -30,7 +30,7 @@ export const batchController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   create(request, response) {
     const { vaccine_snomed } = request.params
@@ -51,7 +51,7 @@ export const batchController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   update(request, response) {
     const { batch_id } = request.params
@@ -70,7 +70,7 @@ export const batchController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   archive(request, response) {
     const { batch_id } = request.params
@@ -88,3 +88,7 @@ export const batchController = {
     return response.redirect('/vaccines')
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -33,6 +33,9 @@ import {
 } from '../utils/string.js'
 
 export const bookIntoClinicController = {
+  /**
+   * @type {RequestHandler}
+   */
   setupServiceHeader(request, response, next) {
     const serviceName = 'Book into a clinic'
 
@@ -40,9 +43,12 @@ export const bookIntoClinicController = {
     response.locals.serviceName = serviceName
     response.locals.headerOptions = { service: { text: serviceName } }
 
-    next()
+    return next()
   },
 
+  /**
+   * @type {RequestHandler}
+   */
   readProgrammes(request, response) {
     // Handling GET request for '/'
     const { data } = request.session
@@ -84,7 +90,8 @@ export const bookIntoClinicController = {
     }
 
     const bookableSessions = getBookableClinicSessions(data, programme_ids)
-    response.redirect(
+
+    return response.redirect(
       bookableSessions.length > 0
         ? '/book-into-a-clinic/start'
         : '/book-into-a-clinic/availability'
@@ -92,7 +99,7 @@ export const bookIntoClinicController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   new(request, response) {
     const { data } = request.session
@@ -115,7 +122,7 @@ export const bookIntoClinicController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   update(request, response) {
     const { booking_uuid } = request.params
@@ -135,7 +142,7 @@ export const bookIntoClinicController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readForm(request, response, next) {
     const { appointment_uuid, booking_uuid } = request.params
@@ -194,7 +201,7 @@ export const bookIntoClinicController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     const { __, __mf, appointment } = response.locals
@@ -422,7 +429,7 @@ export const bookIntoClinicController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response) {
     const { booking_uuid, appointment_uuid, view } = request.params
@@ -553,7 +560,7 @@ export const bookIntoClinicController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const view = request.params.view || 'start'
@@ -566,3 +573,7 @@ export const bookIntoClinicController = {
     return response.render(`book-into-a-clinic/${view}`)
   }
 }
+
+/**
+ * @import { RequestHandler } from 'express'
+ */

--- a/app/controllers/clinic-booking.js
+++ b/app/controllers/clinic-booking.js
@@ -3,7 +3,7 @@ import { getResults, getPagination } from '../utils/pagination.js'
 
 export const clinicBookingController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, clinic_booking_uuid) {
     response.locals.clinicBooking = ClinicBooking.findOne(
@@ -15,7 +15,7 @@ export const clinicBookingController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     const clinicBookings = ClinicBooking.findAll(request.session.data)
@@ -31,16 +31,20 @@ export const clinicBookingController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     return response.render('clinic-booking/show')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.render('clinic-booking/list')
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/clinic.js
+++ b/app/controllers/clinic.js
@@ -2,7 +2,7 @@ import { Clinic } from '../models.js'
 
 export const clinicController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, clinic_id) {
     const clinic = Clinic.findOne(clinic_id, request.session.data)
@@ -18,7 +18,7 @@ export const clinicController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   form(type) {
     return (request, response) => {
@@ -28,7 +28,7 @@ export const clinicController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   action(type) {
     return (request, response) => {
@@ -37,7 +37,7 @@ export const clinicController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   create(request, response) {
     const { team_id } = request.params
@@ -58,7 +58,7 @@ export const clinicController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   update(request, response) {
     const { clinic_id } = request.params
@@ -77,7 +77,7 @@ export const clinicController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   delete(request, response) {
     const { clinic_id } = request.params
@@ -91,3 +91,7 @@ export const clinicController = {
     return response.redirect(paths.next)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/consent.js
+++ b/app/controllers/consent.js
@@ -5,7 +5,7 @@ import { getResults, getPagination } from '../utils/pagination.js'
 
 export const consentController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, consent_uuid) {
     const { patient_uuid } = request.query
@@ -36,7 +36,7 @@ export const consentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     const { session_id } = request.params
@@ -63,7 +63,7 @@ export const consentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const view = request.params.view || 'show'
@@ -72,14 +72,14 @@ export const consentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.render('consent/list')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readMatches(request, response, next) {
     let { hasMissingNhsNumber, q } = request.query
@@ -120,7 +120,7 @@ export const consentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filterMatches(request, response) {
     const { hasMissingNhsNumber, q } = request.body
@@ -139,7 +139,7 @@ export const consentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   link(request, response) {
     const { consent_uuid } = request.params
@@ -159,7 +159,7 @@ export const consentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   add(request, response) {
     const { consent_uuid } = request.params
@@ -198,7 +198,7 @@ export const consentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   invalidate(request, response) {
     const { note } = request.body.consent
@@ -220,3 +220,7 @@ export const consentController = {
     return response.redirect(consentsPath)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/contact.js
+++ b/app/controllers/contact.js
@@ -2,7 +2,7 @@ import { Contact, Patient } from '../models.js'
 
 export const contactController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, contact_uuid) {
     response.locals.contact = Contact.findOne(
@@ -14,7 +14,7 @@ export const contactController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   new(request, response) {
     const { patient_uuid } = request.query
@@ -32,7 +32,7 @@ export const contactController = {
 
   /**
    * @param {string} [type] - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   update(type) {
     return (request, response) => {
@@ -71,7 +71,7 @@ export const contactController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   readForm(type) {
     return (request, response, next) => {
@@ -93,7 +93,7 @@ export const contactController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     return response.render(`contact/form/edit`)
@@ -110,7 +110,7 @@ export const contactController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   action(type) {
     return (request, response) => {
@@ -124,7 +124,7 @@ export const contactController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   delete(request, response) {
     const { contact_uuid } = request.params
@@ -138,3 +138,7 @@ export const contactController = {
     return response.redirect(`/patients/${contact.patient_uuid}/contacts`)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/default-batch.js
+++ b/app/controllers/default-batch.js
@@ -26,14 +26,14 @@ export const defaultBatchController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     return response.render('default-batch/edit')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   update(request, response) {
     const { data } = request.session
@@ -51,3 +51,7 @@ export const defaultBatchController = {
     return response.redirect(paths.next)
   }
 }
+
+/**
+ * @import { RequestHandler } from 'express'
+ */

--- a/app/controllers/download.js
+++ b/app/controllers/download.js
@@ -7,7 +7,7 @@ import { getResults, getPagination } from '../utils/pagination.js'
 
 export const downloadController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, download_id) {
     response.locals.download = Download.findOne(
@@ -19,7 +19,7 @@ export const downloadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     response.locals.downloads = Download.findAll(request.session.data)
@@ -28,7 +28,7 @@ export const downloadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     const { type } = request.query
@@ -58,7 +58,7 @@ export const downloadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filterList(request, response) {
     const params = new URLSearchParams()
@@ -76,7 +76,7 @@ export const downloadController = {
 
   /**
    * @param {string} [type] - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   new(type) {
     return (request, response) => {
@@ -108,7 +108,7 @@ export const downloadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   update(request, response) {
     const { download_id } = request.params
@@ -215,7 +215,7 @@ export const downloadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     const { view } = request.params
@@ -223,6 +223,9 @@ export const downloadController = {
     return response.render(`download/form/${view}`)
   },
 
+  /**
+   * @type {RequestHandler}
+   */
   updateForm(request, response, next) {
     const { download_id } = request.params
     const { data } = request.session
@@ -234,7 +237,7 @@ export const downloadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   download(request, response) {
     const { data } = request.session
@@ -249,3 +252,7 @@ export const downloadController = {
     return response.end(buffer)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/give-or-refuse-consent.js
+++ b/app/controllers/give-or-refuse-consent.js
@@ -14,7 +14,7 @@ import { formatList, kebabToCamelCase } from '../utils/string.js'
 
 export const giveOrRefuseConsentController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, session_id) {
     const session = Session.findOne(session_id, request.session.data)
@@ -33,7 +33,7 @@ export const giveOrRefuseConsentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   redirect(request, response) {
     const { session } = response.locals
@@ -42,7 +42,7 @@ export const giveOrRefuseConsentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const view = request.params.view || 'show'
@@ -80,7 +80,7 @@ export const giveOrRefuseConsentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   new(request, response) {
     const { data } = request.session
@@ -100,7 +100,7 @@ export const giveOrRefuseConsentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   update(request, response) {
     const { consent_uuid } = request.params
@@ -120,7 +120,7 @@ export const giveOrRefuseConsentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readForm(request, response, next) {
     const { session_id, consent_uuid } = request.params
@@ -339,7 +339,7 @@ export const giveOrRefuseConsentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     let view = String(request.params.view)
@@ -368,7 +368,7 @@ export const giveOrRefuseConsentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response) {
     const { decision } = request.body
@@ -397,3 +397,7 @@ export const giveOrRefuseConsentController = {
     return response.redirect(paths.next)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -3,7 +3,7 @@ import { Notice } from '../models.js'
 
 export const homeController = {
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   redirect(request, response) {
     const { account } = request.app.locals
@@ -16,7 +16,7 @@ export const homeController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   dashboard(request, response) {
     const { account } = request.app.locals
@@ -32,9 +32,13 @@ export const homeController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   start(request, response) {
     return response.render('start')
   }
 }
+
+/**
+ * @import { RequestHandler } from 'express'
+ */

--- a/app/controllers/move.js
+++ b/app/controllers/move.js
@@ -5,7 +5,7 @@ import { getResults, getPagination } from '../utils/pagination.js'
 
 export const moveController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, move_uuid) {
     response.locals.move = Move.findOne(move_uuid, request.session.data)
@@ -14,7 +14,7 @@ export const moveController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     let moves = Move.findAll(request.session.data)
@@ -30,21 +30,21 @@ export const moveController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     return response.render('move/show')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.render('move/list')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   update(request, response) {
     const { decision } = request.body
@@ -64,3 +64,7 @@ export const moveController = {
     return response.redirect('/moves')
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/notice.js
+++ b/app/controllers/notice.js
@@ -2,7 +2,7 @@ import { Notice } from '../models.js'
 
 export const noticeController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, notice_uuid) {
     const notice = Notice.findOne(notice_uuid, request.session.data)
@@ -21,7 +21,7 @@ export const noticeController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.render('notice/list')
@@ -29,7 +29,7 @@ export const noticeController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   action(type) {
     return (request, response) => {
@@ -38,7 +38,7 @@ export const noticeController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   archive(request, response) {
     const { notice_uuid } = request.params
@@ -52,3 +52,7 @@ export const noticeController = {
     return response.redirect(paths.next)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -21,7 +21,7 @@ import { stringToBoolean } from '../utils/string.js'
 
 export const patientSessionController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, nhsn) {
     const { account } = request.app.locals
@@ -172,7 +172,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const view = request.params.view || 'show'
@@ -181,7 +181,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readForm(request, response, next) {
     const { referrer } = request.session
@@ -195,7 +195,7 @@ export const patientSessionController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   showForm(type) {
     return (request, response) => {
@@ -206,7 +206,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   register(request, response) {
     const { account } = request.app.locals
@@ -260,7 +260,7 @@ export const patientSessionController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   gillick(type) {
     return (request, response) => {
@@ -287,7 +287,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   preScreen(request, response) {
     const { account } = request.app.locals
@@ -313,7 +313,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   invite(request, response) {
     const { __, back, patient, patientSession } = response.locals
@@ -330,7 +330,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   remind(request, response) {
     const { account } = request.app.locals
@@ -347,7 +347,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   triage(request, response) {
     const { account } = request.app.locals
@@ -384,7 +384,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   note(request, response) {
     const { account } = request.app.locals
@@ -419,7 +419,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   startCancel(request, response) {
     const { patientSession } = response.locals
@@ -430,7 +430,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showCancel(request, response) {
     const { view } = request.params
@@ -447,7 +447,7 @@ export const patientSessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateCancel(request, response) {
     const { account } = request.app.locals
@@ -483,3 +483,7 @@ export const patientSessionController = {
     return response.redirect(next)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -29,7 +29,7 @@ import { formatYearGroup, stringToArray } from '../utils/string.js'
 
 export const patientController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, patient_uuid) {
     const { data } = request.session
@@ -80,6 +80,9 @@ export const patientController = {
     next()
   },
 
+  /**
+   * @type {RequestHandler}
+   */
   readAll(request, response, next) {
     const { option, programme_id, q, yearGroup } = request.query
     const { data } = request.session
@@ -255,11 +258,11 @@ export const patientController = {
     delete data.vaccineCriteria
     delete data.yearGroup
 
-    next()
+    return next()
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const { patient } = response.locals
@@ -296,14 +299,14 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.render('patient/list')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filterList(request, response) {
     const params = new URLSearchParams()
@@ -343,7 +346,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   edit(request, response) {
     const { patient_uuid } = request.params
@@ -364,7 +367,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   update(request, response) {
     const { patient_uuid } = request.params
@@ -389,7 +392,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readForm(request, response, next) {
     const { patient_uuid } = request.params
@@ -412,7 +415,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     let { view } = request.params
@@ -427,7 +430,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response) {
     const { patient_uuid } = request.params
@@ -440,7 +443,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readProgramme(request, response, next) {
     const { programme_id } = request.params
@@ -460,14 +463,14 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showProgramme(request, response) {
     return response.render(`patient/programme`)
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   inviteOneToClinic(request, response) {
     const { patient_uuid } = request.params
@@ -506,7 +509,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showInviteManyToClinic(request, response) {
     const { data } = request.session
@@ -586,7 +589,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   inviteManyToClinic(request, response) {
     let { clinicProgramme_ids } = request.body
@@ -644,7 +647,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   archive(request, response) {
     const { account } = request.app.locals
@@ -667,7 +670,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   note(request, response) {
     const { account } = request.app.locals
@@ -689,7 +692,7 @@ export const patientController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   record(request, response) {
     const { account } = request.app.locals
@@ -767,7 +770,7 @@ export const patientController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   vaccination(type) {
     return (request, response) => {
@@ -805,3 +808,7 @@ export const patientController = {
     }
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/pds-record.js
+++ b/app/controllers/pds-record.js
@@ -7,14 +7,14 @@ import { getResults, getPagination } from '../utils/pagination.js'
 
 export const pdsRecordController = {
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   redirect(request, response) {
     return response.redirect('/patients')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   start(request, response) {
     const { data } = request.session
@@ -36,7 +36,7 @@ export const pdsRecordController = {
   },
 
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, pdsRecord_uuid) {
     const { data } = request.session
@@ -47,7 +47,7 @@ export const pdsRecordController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   update(request, response) {
     const { pdsRecord_uuid } = request.params
@@ -77,6 +77,9 @@ export const pdsRecordController = {
     return response.redirect(patient.uri)
   },
 
+  /**
+   * @type {RequestHandler}
+   */
   readAll(request, response, next) {
     const { q } = request.query
     const { data } = request.session
@@ -101,9 +104,12 @@ export const pdsRecordController = {
     // Clean up session data
     delete data.q
 
-    next()
+    return next()
   },
 
+  /**
+   * @type {RequestHandler}
+   */
   readForm(request, response, next) {
     const { pdsRecord_uuid } = request.params
     const { data, referrer } = request.session
@@ -147,11 +153,11 @@ export const pdsRecordController = {
       ...(referrer && { back: referrer })
     }
 
-    next()
+    return next()
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     let { view } = request.params
@@ -160,7 +166,7 @@ export const pdsRecordController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response, next) {
     const { pdsRecord_uuid } = request.params
@@ -178,3 +184,7 @@ export const pdsRecordController = {
     return paths?.next ? response.redirect(paths.next) : next()
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -25,7 +25,7 @@ import {
 
 export const replyController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, reply_uuid) {
     const { nhsn, programme_id } = request.params
@@ -41,7 +41,7 @@ export const replyController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   redirect(request, response) {
     const { nhsn, programme_id, session_id } = request.params
@@ -52,14 +52,14 @@ export const replyController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     return response.render('reply/show')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   new(request, response) {
     const { account } = request.app.locals
@@ -96,7 +96,7 @@ export const replyController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   update(type) {
     return (request, response) => {
@@ -185,7 +185,7 @@ export const replyController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   readForm(type) {
     return (request, response, next) => {
@@ -330,7 +330,7 @@ export const replyController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     const { view } = request.params
@@ -349,7 +349,7 @@ export const replyController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response) {
     const { respondent } = request.body
@@ -410,7 +410,7 @@ export const replyController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   followUp(request, response) {
     const { decision } = request.body
@@ -448,7 +448,7 @@ export const replyController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   invalidate(request, response) {
     const { note } = request.body.reply
@@ -468,7 +468,7 @@ export const replyController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   withdraw(request, response) {
     const { account } = request.app.locals
@@ -522,3 +522,7 @@ export const replyController = {
     return response.redirect(patientSession.uri)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/report.js
+++ b/app/controllers/report.js
@@ -2,6 +2,9 @@ import { Programme, Vaccination } from '../models.js'
 import { formatYearGroup } from '../utils/string.js'
 
 export const reportController = {
+  /**
+   * @type {RequestHandler}
+   */
   readAll(request, response, next) {
     const { gender, yearGroup } = request.query
     const programme_id = request.query.programme_id || 'flu'
@@ -69,11 +72,11 @@ export const reportController = {
     delete data.programme_id
     delete data.yearGroup
 
-    next()
+    return next()
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const view = request.params.view || 'vaccinations'
@@ -82,14 +85,14 @@ export const reportController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.redirect('/reports/vaccinations')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filterList(request, response) {
     const view = request.params.view || 'vaccinations'
@@ -120,3 +123,7 @@ export const reportController = {
     return response.redirect(`/reports/${view}?${params}`)
   }
 }
+
+/**
+ * @import { RequestHandler } from 'express'
+ */

--- a/app/controllers/review.js
+++ b/app/controllers/review.js
@@ -1,8 +1,12 @@
 export const reviewController = {
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.redirect('/notices')
   }
 }
+
+/**
+ * @import { RequestHandler } from 'express'
+ */

--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -9,7 +9,7 @@ import { formatYearGroup } from '../utils/string.js'
 
 export const schoolController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, school_id) {
     const { data } = request.session
@@ -21,7 +21,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     response.locals.schools = School.findAll(request.session.data)
@@ -30,7 +30,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const view = request.params.view || 'show'
@@ -40,7 +40,7 @@ export const schoolController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   new(type) {
     return (request, response) => {
@@ -59,7 +59,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     const { phase, q } = request.query
@@ -95,7 +95,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filterList(request, response) {
     const params = new URLSearchParams()
@@ -112,7 +112,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readPatients(request, response, next) {
     const { option, programme_id, q, yearGroup } = request.query
@@ -281,7 +281,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filterPatients(request, response) {
     const { school } = response.locals
@@ -323,7 +323,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readSessions(request, response) {
     const { school } = response.locals
@@ -334,7 +334,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   edit(request, response) {
     const { school_id } = request.params
@@ -356,7 +356,7 @@ export const schoolController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   update(type) {
     return (request, response) => {
@@ -384,7 +384,7 @@ export const schoolController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   readForm(type) {
     return (request, response, next) => {
@@ -442,7 +442,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     const { view } = request.params
@@ -451,7 +451,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response) {
     const { school_id, view } = request.params
@@ -501,7 +501,7 @@ export const schoolController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   action(type) {
     return (request, response) => {
@@ -510,7 +510,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   delete(request, response) {
     const { school_id } = request.params
@@ -527,7 +527,7 @@ export const schoolController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   inviteToClinic(request, response) {
     const { school_id } = request.params
@@ -559,3 +559,7 @@ export const schoolController = {
     return response.redirect(school.uri)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -47,7 +47,7 @@ import {
 
 export const sessionController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, session_id) {
     const { view } = request.params
@@ -104,7 +104,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     const sessions = Session.findAll(request.session.data)
@@ -120,7 +120,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     let { view } = request.params
@@ -135,7 +135,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   new(request, response) {
     const { account } = request.app.locals
@@ -154,7 +154,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   advertise(request, response) {
     // Handling a GET for /sessions/advertise
@@ -200,7 +200,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateAdvertLink(request, response) {
     // Handling a POST for /sessions/advertise
@@ -222,7 +222,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showAdvertLink(request, response) {
     // Handling a GET for /sessions/advert-link
@@ -231,7 +231,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   copyAdvertLink(request, response) {
     // Handling a POST for /sessions/advert-link
@@ -244,7 +244,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     const { programme_id, q } = request.query
@@ -348,7 +348,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filter(request, response) {
     const params = new URLSearchParams()
@@ -377,6 +377,9 @@ export const sessionController = {
     return response.redirect(`/sessions?${params}`)
   },
 
+  /**
+   * @type {RequestHandler}
+   */
   readPatientSessions(request, response, next) {
     const { account } = request.app.locals
     const { view } = request.params
@@ -589,11 +592,11 @@ export const sessionController = {
     delete data.vaccineCriteria
     delete data.yearGroup
 
-    next()
+    return next()
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filterPatientSessions(request, response) {
     const { session_id, view } = request.params
@@ -633,6 +636,9 @@ export const sessionController = {
     return response.redirect(`/sessions/${session_id}/${view}?${params}`)
   },
 
+  /**
+   * @type {RequestHandler}
+   */
   showAppointments(request, response, next) {
     const { session } = response.locals
     const allAppointments = session.appointments
@@ -705,11 +711,11 @@ export const sessionController = {
 
     response.locals.vaccinationPeriodTables = vaccinationPeriodTables
 
-    next()
+    return next()
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   edit(request, response) {
     const { session_id } = request.params
@@ -750,7 +756,7 @@ export const sessionController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   update(type) {
     return (request, response) => {
@@ -779,7 +785,7 @@ export const sessionController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   readForm(type) {
     return (request, response, next) => {
@@ -900,7 +906,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     const { view } = request.params
@@ -909,7 +915,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response) {
     const { session_id, view } = request.params
@@ -999,7 +1005,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   giveInstructions(request, response) {
     const { account } = request.app.locals
@@ -1031,7 +1037,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   sendReminders(request, response) {
     const { __, session } = response.locals
@@ -1042,7 +1048,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   cancelSession(request, response) {
     const { __, session } = response.locals
@@ -1057,7 +1063,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   makeActive(request, response) {
     const { __, session } = response.locals
@@ -1071,7 +1077,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   inviteToClinic(request, response) {
     const { account } = request.app.locals
@@ -1133,7 +1139,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   startCancel(request, response) {
     const { session } = response.locals
@@ -1149,7 +1155,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showCancel(request, response) {
     const { view } = request.params
@@ -1174,7 +1180,7 @@ export const sessionController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateCancel(request, response) {
     const { view } = request.params
@@ -1208,3 +1214,7 @@ export const sessionController = {
     return response.redirect(next)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/team.js
+++ b/app/controllers/team.js
@@ -2,7 +2,7 @@ import { School, Team } from '../models.js'
 
 export const teamController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, team_id) {
     const { view } = request.params
@@ -26,7 +26,7 @@ export const teamController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   redirect(request, response) {
     const { team_id } = request.params
@@ -35,7 +35,7 @@ export const teamController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const view = request.params.view || 'show'
@@ -44,7 +44,7 @@ export const teamController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readForm(request, response, next) {
     const { view } = request.params
@@ -65,7 +65,7 @@ export const teamController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readSchool(request, response, next) {
     const { school_id } = request.params
@@ -77,14 +77,14 @@ export const teamController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showSchool(request, response) {
     return response.render(`team/school`)
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     const view = request.params.view || 'contact'
@@ -93,7 +93,7 @@ export const teamController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response) {
     const { team_id } = request.params
@@ -111,3 +111,7 @@ export const teamController = {
     return response.redirect(paths.next)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/unmatched-appointment.js
+++ b/app/controllers/unmatched-appointment.js
@@ -11,7 +11,7 @@ import { getResults, getPagination } from '../utils/pagination.js'
 
 export const unmatchedAppointmentController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, appointment_uuid) {
     const { patient_uuid } = request.query
@@ -46,7 +46,7 @@ export const unmatchedAppointmentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     const { session_id } = request.params
@@ -80,7 +80,7 @@ export const unmatchedAppointmentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const view = request.params.view || 'show'
@@ -89,14 +89,14 @@ export const unmatchedAppointmentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.render('appointments/list')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readMatches(request, response, next) {
     let { hasMissingNhsNumber, q } = request.query
@@ -137,7 +137,7 @@ export const unmatchedAppointmentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filterMatches(request, response) {
     const { hasMissingNhsNumber, q } = request.body
@@ -156,7 +156,7 @@ export const unmatchedAppointmentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   link(request, response) {
     const { appointment_uuid } = request.params
@@ -205,7 +205,7 @@ export const unmatchedAppointmentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   add(request, response) {
     const { appointment_uuid } = request.params
@@ -257,7 +257,7 @@ export const unmatchedAppointmentController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   archive(request, response) {
     const { note } = request.body.appointment
@@ -294,3 +294,7 @@ export const unmatchedAppointmentController = {
     return response.redirect(appointmentsPath)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/upload.js
+++ b/app/controllers/upload.js
@@ -8,7 +8,7 @@ import { formatYearGroup } from '../utils/string.js'
 
 export const uploadController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, upload_id) {
     response.locals.upload = Upload.findOne(upload_id, request.session.data)
@@ -17,7 +17,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     response.locals.uploads = Upload.findAll(request.session.data)
@@ -26,7 +26,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     const view = request.params.view || 'show'
@@ -35,7 +35,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     const { status, type } = request.query
@@ -71,7 +71,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   filterList(request, response) {
     const params = new URLSearchParams()
@@ -102,7 +102,7 @@ export const uploadController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   action(type) {
     return (request, response) => {
@@ -118,7 +118,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   new(request, response) {
     const { account } = request.app.locals
@@ -151,7 +151,7 @@ export const uploadController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   update(type) {
     return (request, response) => {
@@ -187,7 +187,7 @@ export const uploadController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   readForm(type) {
     return (request, response, next) => {
@@ -250,7 +250,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   showForm(request, response) {
     const { view } = request.params
@@ -259,7 +259,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response) {
     const { upload_id } = request.params
@@ -272,7 +272,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   delete(request, response) {
     const { upload_id } = request.params
@@ -287,7 +287,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   approve(request, response) {
     const { account } = request.app.locals
@@ -310,7 +310,7 @@ export const uploadController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   removeRelationships(request, response) {
     const { __, upload } = response.locals
@@ -320,3 +320,7 @@ export const uploadController = {
     return response.redirect(upload.uri)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -2,7 +2,7 @@ import { User } from '../models.js'
 
 export const userController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, user_uid) {
     response.locals.user = User.findOne(user_uid, request.session.data)
@@ -11,7 +11,7 @@ export const userController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     response.locals.users = User.findAll(request.session.data)
@@ -20,16 +20,20 @@ export const userController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     return response.render('user/show')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.render('user/list')
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -23,7 +23,7 @@ import { formatSequence } from '../utils/string.js'
 
 export const vaccinationController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, vaccination_uuid) {
     const { programme_id } = request.params
@@ -42,7 +42,7 @@ export const vaccinationController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   redirect(request, response) {
     const { id, nhsn } = request.params
@@ -51,14 +51,14 @@ export const vaccinationController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     return response.render('vaccination/show')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   edit(request, response) {
     const { vaccination_uuid } = request.params
@@ -79,7 +79,7 @@ export const vaccinationController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   new(request, response) {
     const { account } = request.app.locals
@@ -187,7 +187,7 @@ export const vaccinationController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   update(type) {
     return (request, response) => {
@@ -255,7 +255,7 @@ export const vaccinationController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   readForm(type) {
     return (request, response, next) => {
@@ -399,7 +399,7 @@ export const vaccinationController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   showForm(type) {
     return (request, response) => {
@@ -410,7 +410,7 @@ export const vaccinationController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   updateForm(request, response) {
     const { data } = request.session
@@ -462,3 +462,7 @@ export const vaccinationController = {
     return response.redirect(redirect)
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/controllers/vaccine.js
+++ b/app/controllers/vaccine.js
@@ -2,7 +2,7 @@ import { Vaccine } from '../models.js'
 
 export const vaccineController = {
   /**
-   * @type {import("express").RequestParamHandler}
+   * @type {RequestParamHandler}
    */
   read(request, response, next, vaccine_snomed) {
     const vaccine = Vaccine.findOne(vaccine_snomed, request.session.data)
@@ -21,7 +21,7 @@ export const vaccineController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   readAll(request, response, next) {
     response.locals.vaccines = Vaccine.findAll(request.session.data)
@@ -30,14 +30,14 @@ export const vaccineController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   show(request, response) {
     return response.render('vaccine/show')
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   list(request, response) {
     return response.render('vaccine/list')
@@ -45,7 +45,7 @@ export const vaccineController = {
 
   /**
    * @param {string} type - Form type
-   * @returns {import("express").RequestHandler} - Request handler
+   * @returns {RequestHandler} - Request handler
    */
   action(type) {
     return (request, response) => {
@@ -54,7 +54,7 @@ export const vaccineController = {
   },
 
   /**
-   * @type {import("express").RequestHandler}
+   * @type {RequestHandler}
    */
   delete(request, response) {
     const { vaccine_snomed } = request.params
@@ -68,3 +68,7 @@ export const vaccineController = {
     return response.redirect('/vaccines')
   }
 }
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ */

--- a/app/enums.js
+++ b/app/enums.js
@@ -2,7 +2,7 @@ import { getAllCountries } from 'countries-and-timezones'
 
 /**
  * @readonly
- * @enum {import('countries-and-timezones').Country}
+ * @enum {CountryData}
  */
 export const Country = Object.fromEntries(
   Object.entries(getAllCountries()).map(([key, value]) => [key, value.name])
@@ -872,3 +872,7 @@ export const LocationSearchType = {
   Outcode: 'Outcode',
   Place: 'Place'
 }
+
+/**
+ * @import { Country as CountryData } from 'countries-and-timezones'
+ */

--- a/app/generators/clinic-appointment.js
+++ b/app/generators/clinic-appointment.js
@@ -9,9 +9,9 @@ import { generateContact } from './contact.js'
 /**
  * Generate fake clinic appointment
  *
- * @param {import('../models.js').Patient} patient - The patient for whom the appointment is being created
- * @param {import('../models.js').Session} session - The clinic session into which we're booking the patient
- * @param {import('../models.js').ClinicBooking} booking - The booking this appointment will belong to
+ * @param {Patient} patient - The patient for whom the appointment is being created
+ * @param {Session} session - The clinic session into which we're booking the patient
+ * @param {ClinicBooking} booking - The booking this appointment will belong to
  * @returns {ClinicAppointment} A new, fake clinic appointment
  */
 export function generateClinicAppointment(patient, session, booking) {
@@ -147,3 +147,7 @@ export function generateClinicAppointment(patient, session, booking) {
     mmrAlternative
   })
 }
+
+/**
+ * @import { ClinicBooking, Patient, Session } from '../models.js'
+ */

--- a/app/generators/consent.js
+++ b/app/generators/consent.js
@@ -19,10 +19,10 @@ import {
 /**
  * Generate fake consent
  *
- * @param {import('../models.js').Programme} programme - Programme
- * @param {import('../models.js').Session} session - Session
- * @param {import('../models.js').PatientSession} patientSession - Patient session
- * @param {import('../models.js').Contact} contact - Contact
+ * @param {Programme} programme - Programme
+ * @param {Session} session - Session
+ * @param {PatientSession} patientSession - Patient session
+ * @param {Contact} contact - Contact
  * @param {Date} [lastConsentCreatedAt] - Date previous consent response created
  * @returns {Consent|undefined} Consent
  */
@@ -148,3 +148,7 @@ export function generateConsent(
     session_id: session.id
   })
 }
+
+/**
+ * @import { Contact, PatientSession, Programme, Session } from '../models.js'
+ */

--- a/app/generators/contact.js
+++ b/app/generators/contact.js
@@ -10,7 +10,7 @@ import { Contact } from '../models.js'
 /**
  * Generate fake contact
  *
- * @param {import('../models.js').Child|import('../models.js').Patient} patient - Child
+ * @param {Child|Patient} patient - Child
  * @param {boolean} [isMum] - Contact is child’s mother
  * @returns {Contact} Contact
  */
@@ -85,3 +85,7 @@ export function generateContact(patient, isMum) {
     patient_uuid: patient.uuid
   })
 }
+
+/**
+ * @import { Child, Patient } from '../models.js'
+ */

--- a/app/generators/instruction.js
+++ b/app/generators/instruction.js
@@ -6,10 +6,10 @@ import { removeDays } from '../utils/date.js'
 /**
  * Generate fake instruction
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
- * @param {import('../models.js').Programme} programme - Programme
- * @param {import('../models.js').Session} session - Session
- * @param {Array<import('../models.js').User>} users - Users
+ * @param {PatientSession} patientSession - Patient session
+ * @param {Programme} programme - Programme
+ * @param {Session} session - Session
+ * @param {Array<User>} users - Users
  * @returns {Instruction} Instruction
  */
 export function generateInstruction(patientSession, programme, session, users) {
@@ -22,3 +22,7 @@ export function generateInstruction(patientSession, programme, session, users) {
     patientSession_uuid: patientSession.uuid
   })
 }
+
+/**
+ * @import { PatientSession, Programme, Session, User } from '../models.js'
+ */

--- a/app/generators/notice.js
+++ b/app/generators/notice.js
@@ -3,8 +3,8 @@ import { Notice } from '../models.js'
 /**
  * Generate fake notice
  *
- * @param {import('../models.js').Patient} patient - Patient
- * @param {import('../enums.js').NoticeType} type - Notice type
+ * @param {Patient} patient - Patient
+ * @param {NoticeType} type - Notice type
  * @returns {Notice} Notice
  */
 export function generateNotice(patient, type) {
@@ -13,3 +13,8 @@ export function generateNotice(patient, type) {
     patient_uuid: patient?.uuid
   })
 }
+
+/**
+ * @import { NoticeType } from '../enums.js'
+ * @import { Patient } from '../models.js'
+ */

--- a/app/generators/session.js
+++ b/app/generators/session.js
@@ -8,9 +8,9 @@ import { getSessionYearGroups } from '../utils/session.js'
 /**
  * Generate fake session
  *
- * @param {import('../enums.js').SessionPreset} preset - Session preset
+ * @param {SessionPreset} preset - Session preset
  * @param {number} academicYear - Academic year
- * @param {import('../models.js').User} user - User
+ * @param {User} user - User
  * @param {object} options - Options
  * @param {string} [options.clinic_id] - Clinic ID
  * @param {string} [options.school_id] - School URN
@@ -78,3 +78,8 @@ export function generateSession(preset, academicYear, user, options) {
     ...(school_id && { type: SessionType.School, school_id, yearGroups })
   })
 }
+
+/**
+ * @import { SessionPreset } from '../enums.js'
+ * @import { User } from '../models.js'
+ */

--- a/app/generators/upload.js
+++ b/app/generators/upload.js
@@ -9,9 +9,9 @@ import { today } from '../utils/date.js'
  * Generate fake upload
  *
  * @param {Array<string>} patient_uuids - Patients
- * @param {import('../models.js').User} user - User
- * @param {import('../enums.js').UploadType} [type] - Upload type
- * @param {import('../models.js').School} [school] - School
+ * @param {User} user - User
+ * @param {UploadType} [type] - Upload type
+ * @param {School} [school] - School
  * @returns {Upload} Upload
  */
 export function generateUpload(
@@ -84,3 +84,7 @@ export function generateUpload(
     })
   })
 }
+
+/**
+ * @import { School, User } from '../models.js'
+ */

--- a/app/generators/vaccination.js
+++ b/app/generators/vaccination.js
@@ -7,10 +7,10 @@ import { Vaccination } from '../models.js'
 /**
  * Generate fake vaccination
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
- * @param {import('../models.js').Programme} programme - Programme
- * @param {import('../models.js').Batch} batch - Batch
- * @param {Array<import('../models.js').User>} users - Users
+ * @param {PatientSession} patientSession - Patient session
+ * @param {Programme} programme - Programme
+ * @param {Batch} batch - Batch
+ * @param {Array<User>} users - Users
  * @returns {Vaccination} Vaccination
  */
 export function generateVaccination(patientSession, programme, batch, users) {
@@ -76,3 +76,7 @@ export function generateVaccination(patientSession, programme, batch, users) {
     })
   })
 }
+
+/**
+ * @import { Batch, PatientSession, Programme, User } from '../models.js'
+ */

--- a/app/globals.js
+++ b/app/globals.js
@@ -510,7 +510,7 @@ export default () => {
   /**
    * Get vaccinator summary table row items
    *
-   * @param {import('./models.js').Session} session - Session
+   * @param {Session} session - Session
    * @returns {Array} Table row items
    */
   globals.vaccinationTableRows = function (session) {
@@ -641,3 +641,7 @@ export default () => {
 
   return globals
 }
+
+/**
+ * @import { Session } from './models.js'
+ */

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -13,7 +13,7 @@ import {
 const thisAcademicYear = Object.values(AcademicYear).at(-1)
 
 /**
- * @returns {import("i18n").LocaleCatalog}
+ * @returns {LocaleCatalog}
  */
 export const en = {
   actions: {
@@ -3737,3 +3737,7 @@ export const en = {
     }
   }
 }
+
+/**
+ * @import { LocaleCatalog } from 'i18n'
+ */

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -31,7 +31,7 @@ import {
  * @property {string} [createdBy_uid] - User who created event
  * @property {string} name - Name
  * @property {string} [note] - Note
- * @property {import('../enums.js').AuditEventType} [type] - Audit event type
+ * @property {AuditEventType} [type] - Audit event type
  * @property {object} [messageRecipient] - Message recipient
  * @property {string} [messageTemplate] - Message template
  * @property {Array} [updatedFields] - Updated fields
@@ -252,3 +252,7 @@ export class AuditEvent {
     return 'event'
   }
 }
+
+/**
+ * @import { AuditEventType } from '../enums.js'
+ */

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -34,10 +34,10 @@ import { formatList, formatYearGroup, stringToArray } from '../utils/string.js'
  * @property {Date} [dob] - Date of birth
  * @property {object} [dob_] - Date of birth (from `dateInput`)
  * @property {Date} [dod] - Date of death
- * @property {import('../enums.js').Gender} gender - Gender
+ * @property {Gender} gender - Gender
  * @property {EthnicGroup} [ethnicGroup] - Ethnic group
  * @property {string} [ethnicGroupOther] - Other ethnic group
- * @property {import('../enums.js').EthnicBackground} [ethnicBackground] - Ethnic background
+ * @property {EthnicBackground} [ethnicBackground] - Ethnic background
  * @property {string} [ethnicBackgroundOther] - Other ethnic background
  * @property {Array<Adjustment>} [adjustments] - Reasonable adjustments
  * @property {string} [adjustmentsOther] - Other adjustment
@@ -346,3 +346,7 @@ export class Child {
     return 'child'
   }
 }
+
+/**
+ * @import { Gender, EthnicBackground } from '../enums.js'
+ */

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -43,8 +43,8 @@ import {
  * @property {string} uuid - Unique ID for this clinic appointment
  * @property {string} booking_uuid - Unique ID for the booking under which this appointment was made
  * @property {string} [patient_uuid] - Patient UUID (if matched to a patient record)
- * @property {import('./child.js').Child} [child] - child details recorded from form input values
- * @property {import('../enums.js').ParentalRelationship} [parentalRelationship] - The relationship of the person booking the appointment to the child
+ * @property {Child} [child] - child details recorded from form input values
+ * @property {ParentalRelationship} [parentalRelationship] - The relationship of the person booking the appointment to the child
  * @property {string} [parentalRelationshipOther] - User-defined parental relationship to the child for this appointment
  * @property {boolean} [parentHasParentalResponsibility] - Does the contact have legal parental responsibility for the child?
  * @property {string} [session_id] - The ID of the clinic session in which the appointment's booked

--- a/app/models/consent.js
+++ b/app/models/consent.js
@@ -82,10 +82,14 @@ export class Consent extends Reply {
   /**
    * Link consent with patient record
    *
-   * @param {import('./patient.js').Patient} patient - Patient
+   * @param {Patient} patient - Patient
    */
   linkToPatient(patient) {
     this.patient_uuid = patient.uuid
     patient.addReply(this)
   }
 }
+
+/**
+ * @import { Patient } from '../models.js'
+ */

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -17,9 +17,9 @@ import { formatOther, formatContact, stringToBoolean } from '../utils/string.js'
  * @property {boolean} notify - Notify about consent and vaccination events
  * @property {string} tel - Phone number
  * @property {string} email - Email address
- * @property {import('../enums.js').NotifyEmailStatus} emailStatus - Email status
+ * @property {NotifyEmailStatus} emailStatus - Email status
  * @property {boolean} sms - Get updates via SMS
- * @property {import('../enums.js').NotifySmsStatus} smsStatus - SMS status
+ * @property {NotifySmsStatus} smsStatus - SMS status
  * @property {boolean} [contactPreference] - Preferred contact method
  * @property {string} [contactPreferenceDetails] - Contact method details
  * @property {string} [patient_uuid] - Patient UUID
@@ -208,3 +208,7 @@ export class Contact {
     delete context.contacts[String(uuid)]
   }
 }
+
+/**
+ * @import { NotifyEmailStatus, NotifySmsStatus } from '../enums.js'
+ */

--- a/app/models/instruction.js
+++ b/app/models/instruction.js
@@ -10,7 +10,7 @@ import { today } from '../utils/date.js'
  * @property {string} uuid - UUID
  * @property {Date} [createdAt] - Created date
  * @property {string} [createdBy_uid] - User who performed instruction
- * @property {import('../enums.js').InstructionOutcome} [outcome] - Outcome
+ * @property {InstructionOutcome} [outcome] - Outcome
  * @property {string} [patientSession_uuid] - Patient session UUID
  * @property {string} [programme_id] - Programme ID
  */
@@ -58,3 +58,7 @@ export class Instruction {
     return createdInstruction
   }
 }
+
+/**
+ * @import { InstructionOutcome } from '../enums.js'
+ */

--- a/app/models/move.js
+++ b/app/models/move.js
@@ -13,7 +13,7 @@ import { formatDate, getDateValueDifference, today } from '../utils/date.js'
  * @property {Date} [createdAt] - Reported date
  * @property {Date} [updatedAt] - Updated date
  * @property {boolean} ignored - Reported move is ignored
- * @property {import('../enums.js').MoveSource} source - Reporting source
+ * @property {MoveSource} source - Reporting source
  * @property {string} team_id - Team ID (moving from)
  * @property {string} from_urn - Current school URN (moving from)
  * @property {string} to_urn - Proposed school URN (moving to)
@@ -184,3 +184,7 @@ export class Move {
     Move.delete(uuid, context)
   }
 }
+
+/**
+ * @import { MoveSource } from '../enums.js'
+ */

--- a/app/models/notice.js
+++ b/app/models/notice.js
@@ -11,7 +11,7 @@ import { formatDate, getDateValueDifference, today } from '../utils/date.js'
  * @property {string} uuid - UUID
  * @property {Date} [createdAt] - Created date
  * @property {Date} [archivedAt] - Archived date
- * @property {import('../enums.js').NoticeType} type - Notice type
+ * @property {NoticeType} type - Notice type
  * @property {string} patient_uuid - Patient notice applies to
  */
 export class Notice {
@@ -120,3 +120,7 @@ export class Notice {
     return archivedNotice
   }
 }
+
+/**
+ * @import { NoticeType } from '../enums.js'
+ */

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -142,7 +142,7 @@ export class PatientProgramme {
   /**
    * Get most recent patient session
    *
-   * @returns {import('./patient-session.js').PatientSession|undefined} Patient session
+   * @returns {PatientSession|undefined} Patient session
    */
   get lastPatientSession() {
     if (this.patientSessions?.length > 0) {
@@ -293,7 +293,7 @@ export class PatientProgramme {
   /**
    * Get last vaccination outcome
    *
-   * @returns {import('./vaccination.js').Vaccination|undefined} Vaccination
+   * @returns {Vaccination|undefined} Vaccination
    */
   get lastVaccinationOutcome() {
     if (this.vaccinationOutcomes?.length > 0) {
@@ -335,7 +335,7 @@ export class PatientProgramme {
   /**
    * Get last vaccination outcome
    *
-   * @returns {import('./vaccination.js').Vaccination|undefined} Vaccination
+   * @returns {Vaccination|undefined} Vaccination
    */
   get lastVaccinationGiven() {
     if (this.vaccinationsGiven?.length > 0) {
@@ -538,7 +538,7 @@ export class PatientProgramme {
   /**
    * Get vaccine to administer (or was administered) in this patient session
    *
-   * @returns {import('../enums.js').RecordVaccineCriteria} Vaccine criteria
+   * @returns {RecordVaccineCriteria} Vaccine criteria
    */
   get vaccineCriteria() {
     return this.lastPatientSession.vaccineCriteria
@@ -582,3 +582,8 @@ export class PatientProgramme {
     return `/patients/${this.patient_uuid}/programmes/${this.programme_id}`
   }
 }
+
+/**
+ * @import { RecordVaccineCriteria } from '../enums.js'
+ * @import { PatientSession } from '../models.js'
+ */

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -116,7 +116,7 @@ export class PatientSession {
   /**
    * Get patient programme
    *
-   * @returns {import('./patient-programme.js').PatientProgramme|undefined} Patient programme
+   * @returns {PatientProgramme|undefined} Patient programme
    */
   get patientProgramme() {
     return this.patient?.programmes[this.programme_id]
@@ -286,7 +286,7 @@ export class PatientSession {
   /**
    * Get vaccination criteria consented to use if safe to vaccinate
    *
-   * @returns {import('../enums.js').ScreenVaccineCriteria|boolean|undefined} Criteria
+   * @returns {ScreenVaccineCriteria|boolean|undefined} Criteria
    */
   get screenVaccineCriteria() {
     if (this.programme && this.responses) {
@@ -367,7 +367,7 @@ export class PatientSession {
    * For all programmes besides flu, this will be an injection.
    * For the flu programme, this depends on consent responses
    *
-   * @returns {import('./vaccine.js').Vaccine|undefined} Vaccine method
+   * @returns {Vaccine|undefined} Vaccine method
    */
   get vaccine() {
     const standardVaccine = this.programme?.vaccines.find((vaccine) => vaccine)
@@ -409,7 +409,7 @@ export class PatientSession {
    * For all programmes besides flu, this will be an injection.
    * For the flu programme, this depends on consent responses
    *
-   * @returns {import('../enums.js').RecordVaccineCriteria|undefined} Vaccination method
+   * @returns {RecordVaccineCriteria|undefined} Vaccination method
    */
   get vaccineCriteria() {
     // If no programme does not offer alternatives, don’t return a method
@@ -471,7 +471,7 @@ export class PatientSession {
   /**
    * Get vaccinations for patient session
    *
-   * @returns {Array<import('./vaccination.js').Vaccination>|undefined} Vaccinations
+   * @returns {Array<Vaccination>|undefined} Vaccinations
    */
   get vaccinationOutcomes() {
     try {
@@ -488,7 +488,7 @@ export class PatientSession {
   /**
    * Get last recorded vaccination
    *
-   * @returns {import('./vaccination.js').Vaccination|undefined} Vaccination
+   * @returns {Vaccination|undefined} Vaccination
    */
   get lastVaccinationOutcome() {
     if (this.vaccinationOutcomes && this.vaccinationOutcomes.length > 0) {
@@ -804,7 +804,7 @@ export class PatientSession {
   /**
    * Get instruction outcome
    *
-   * @returns {import('../enums.js').InstructionOutcome|boolean} Instruction outcome
+   * @returns {InstructionOutcome|boolean} Instruction outcome
    */
   get instruct() {
     return getInstructionOutcome(this)
@@ -813,7 +813,7 @@ export class PatientSession {
   /**
    * Get registration outcome
    *
-   * @returns {import('../enums.js').RegistrationOutcome} Registration outcome
+   * @returns {RegistrationOutcome} Registration outcome
    */
   get register() {
     return getRegistrationOutcome(this)
@@ -849,7 +849,7 @@ export class PatientSession {
   /**
    * Get vaccination (session) outcome
    *
-   * @returns {import('../enums.js').VaccinationOutcome|undefined} Vaccination (session) outcome
+   * @returns {VaccinationOutcome|undefined} Vaccination (session) outcome
    */
   get outcome() {
     return getSessionOutcome(this)
@@ -1078,7 +1078,7 @@ export class PatientSession {
   /**
    * Record triage
    *
-   * @param {import('./audit-event.js').AuditEvent} event - Event
+   * @param {AuditEvent} event - Event
    */
   recordTriage(event) {
     this.patient?.addEvent({
@@ -1141,7 +1141,7 @@ export class PatientSession {
   /**
    * Register attendance
    *
-   * @param {import('./audit-event.js').AuditEvent} event - Event
+   * @param {AuditEvent} event - Event
    * @param {RegistrationOutcome} register - Registration
    */
   registerAttendance(event, register) {
@@ -1161,7 +1161,7 @@ export class PatientSession {
   /**
    * Record pre-screening interview
    *
-   * @param {import('./audit-event.js').AuditEvent} event - Event
+   * @param {AuditEvent} event - Event
    */
   preScreen(event) {
     this.patient?.addEvent({
@@ -1176,7 +1176,7 @@ export class PatientSession {
   /**
    * Save note
    *
-   * @param {import('./audit-event.js').AuditEvent} event - Event
+   * @param {AuditEvent} event - Event
    */
   saveNote(event) {
     this.patient?.addEvent({
@@ -1192,8 +1192,8 @@ export class PatientSession {
   /**
    * Send reminder
    *
-   * @param {import('../models.js').AuditEvent} event - Event
-   * @param {import('../models.js').Contact} contact - Contact
+   * @param {AuditEvent} event - Event
+   * @param {Contact} contact - Contact
    */
   sendReminder(event, contact) {
     this.patient?.addEvent({
@@ -1208,3 +1208,8 @@ export class PatientSession {
     })
   }
 }
+
+/**
+ * @import { InstructionOutcome, ScreenVaccineCriteria } from '../enums.js'
+ * @import { Contact, PatientProgramme, Vaccination, Vaccine } from '../models.js'
+ */

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -47,10 +47,10 @@ import {
  * @property {boolean} [sensitive] - Flagged as sensitive
  * @property {object} [address] - Address
  * @property {Patient} [pendingChanges] - Pending changes to record values
- * @property {import('../enums.js').ArchiveRecordReason} [archiveReason] - Archival reason
+ * @property {ArchiveRecordReason} [archiveReason] - Archival reason
  * @property {string} [archiveReasonOther] - Other archival reason
  * @property {Array<string>} [clinicProgramme_ids] - Clinic programme invitations
- * @property {Array<import('./audit-event.js').AuditEvent>} events - Events
+ * @property {Array<AuditEvent>} events - Events
  * @property {Array<string>} [reply_uuids] - Reply IDs
  * @property {Array<string>} [contact_uuids] - Contact UUIDS
  * @property {Array<string>} [patientSession_uuids] - Patient session IDs
@@ -657,7 +657,7 @@ export class Patient extends Child {
   /**
    * Add contact to patient
    *
-   * @param {import('../models').Contact} contact - Contact
+   * @param {Contact} contact - Contact
    */
   addContact(contact) {
     this.contact_uuids.push(contact.uuid)
@@ -671,7 +671,7 @@ export class Patient extends Child {
   /**
    * Add patient to session
    *
-   * @param {import('./patient-session.js').PatientSession} patientSession - PatientSession
+   * @param {PatientSession} patientSession - PatientSession
    */
   addToSession(patientSession) {
     this.patientSession_uuids.push(patientSession.uuid)
@@ -714,7 +714,7 @@ export class Patient extends Child {
   /**
    * Invite contact to give consent
    *
-   * @param {import('./patient-session.js').PatientSession} patientSession - Patient session
+   * @param {PatientSession} patientSession - Patient session
    */
   requestConsent(patientSession) {
     for (const contact of this.contacts) {
@@ -770,7 +770,7 @@ export class Patient extends Child {
   /**
    * Record vaccination
    *
-   * @param {import('./vaccination.js').Vaccination} vaccination - Vaccination
+   * @param {Vaccination} vaccination - Vaccination
    */
   recordVaccination(vaccination) {
     this.vaccination_uuids.push(vaccination.uuid)
@@ -832,7 +832,7 @@ export class Patient extends Child {
   /**
    * Save note
    *
-   * @param {import('./audit-event.js').AuditEvent} event - Event
+   * @param {AuditEvent} event - Event
    */
   saveNote(event) {
     this.addEvent({
@@ -846,7 +846,7 @@ export class Patient extends Child {
   /**
    * Add notice
    *
-   * @param {import('./notice.js').Notice} notice - Notice
+   * @param {Notice} notice - Notice
    */
   addNotice(notice) {
     let name
@@ -881,3 +881,8 @@ export class Patient extends Child {
     })
   }
 }
+
+/**
+ * @import { ArchiveRecordReason } from '../enums.js'
+ * @import { Notice } from '../models.js'
+ */

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -199,7 +199,7 @@ export class Programme {
   /**
    * Get patient session programme statuses
    *
-   * @param {import('../enums.js').PatientStatus} patientStatus - Patient status
+   * @param {PatientStatus} patientStatus - Patient status
    * @returns {Array<PatientSession>} Patient session programme statuses
    */
   report(patientStatus) {
@@ -295,3 +295,7 @@ export class Programme {
     }
   }
 }
+
+/**
+ * @import { PatientStatus } from '../enums.js'
+ */

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -47,8 +47,8 @@ import {
  * @property {Date} [createdAt] - Created date
  * @property {string} [createdBy_uid] - User who created reply
  * @property {Date} [updatedAt] - Updated date
- * @property {import('./models.js').Child} [child] - Child
- * @property {import('./models.js').Contact} [contact_] - Parent or guardian
+ * @property {Child} [child] - Child
+ * @property {Contact} [contact_] - Parent or guardian
  * @property {ReplyDecision} [decision] - Consent decision
  * @property {boolean} [alternative] - Consent for alternative vaccine
  * @property {boolean} [confirmed] - Decision confirmed

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -19,7 +19,7 @@ import {
  * @property {string} [urn] - URN
  * @property {boolean} [sen] - SEN school
  * @property {string} [site] - Site code
- * @property {import('../enums.js').SchoolPhase} [phase] - Phase
+ * @property {SchoolPhase} [phase] - Phase
  * @property {Array<number>} [yearGroups] - Year groups
  */
 export class School extends Location {
@@ -285,3 +285,7 @@ export class School extends Location {
     delete context.schools[id]
   }
 }
+
+/**
+ * @import { SchoolPhase } from '../enums.js'
+ */

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -1222,7 +1222,7 @@ export class Session {
    * Update register
    *
    * @param {string} patient_uuid
-   * @param {import('../enums.js').RegistrationOutcome} registration
+   * @param {RegistrationOutcome} registration
    */
   updateRegister(patient_uuid, registration) {
     this.register[patient_uuid] = registration
@@ -1238,3 +1238,7 @@ export class Session {
     delete context.sessions[String(id)]
   }
 }
+
+/**
+ * @import { RegistrationOutcome } from '../enums.js'
+ */

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -8,9 +8,9 @@ import { formatCode, formatLink } from '../utils/string.js'
  * @property {string} [firstName] - First/given name
  * @property {string} [lastName] - Last/family name
  * @property {string} [email] - Email address
- * @property {import('../enums.js').UserRole} [role] - User role
+ * @property {UserRole} [role] - User role
  * @property {boolean} [canPrescribe] - Can provide PSD instruction
- * @property {Array<import('../enums.js').VaccineMethod>} [vaccineMethods] - Vaccine methods
+ * @property {Array<VaccineMethod>} [vaccineMethods] - Vaccine methods
  * @property {object} [vaccinations] - Vaccination count
  */
 export class User {
@@ -111,3 +111,7 @@ export class User {
     }
   }
 }
+
+/**
+ * @import { UserRole, VaccineMethod } from '../enums.js'
+ */

--- a/app/models/vaccination.js
+++ b/app/models/vaccination.js
@@ -304,7 +304,7 @@ export class Vaccination {
   /**
    * Get patient
    *
-   * @returns {import('../models.js').Patient|undefined} Patient
+   * @returns {Patient|undefined} Patient
    */
   get patient() {
     if (this.patient_uuid) {
@@ -317,7 +317,7 @@ export class Vaccination {
   /**
    * Get session
    *
-   * @returns {import('../models.js').Session|undefined} Session
+   * @returns {Session|undefined} Session
    */
   get session() {
     if (this.patientSession) {
@@ -683,3 +683,7 @@ export class Vaccination {
     return updatedVaccination
   }
 }
+
+/**
+ * @import { Session } from '../models.js'
+ */

--- a/app/models/vaccine.js
+++ b/app/models/vaccine.js
@@ -20,12 +20,12 @@ import {
  * @property {string} manufacturer - Manufacturer
  * @property {object} [leaflet] - Leaflet
  * @property {number} dose - Dosage
- * @property {import('../enums.js').VaccineCriteria} criteria - Criteria
- * @property {import('../enums.js').VaccineMethod} method - Method
- * @property {import('../enums.js').VaccinationProtocol} [delegationProtocol] - Delegation protocol
- * @property {Array<import('../enums.js').VaccineSideEffect>} sideEffects - Side effects
+ * @property {VaccineCriteria} criteria - Criteria
+ * @property {VaccineMethod} method - Method
+ * @property {VaccinationProtocol} [delegationProtocol] - Delegation protocol
+ * @property {Array<VaccineSideEffect>} sideEffects - Side effects
  * @property {object} healthQuestions - Health questions
- * @property {Array<import('../enums.js').PreScreenQuestion>} preScreenQuestions - Pre-screening questions
+ * @property {Array<PreScreenQuestion>} preScreenQuestions - Pre-screening questions
  */
 export class Vaccine {
   constructor(options, context) {
@@ -159,3 +159,7 @@ export class Vaccine {
     delete context.vaccines[String(snomed)]
   }
 }
+
+/**
+ * @import { PreScreenQuestion, VaccinationProtocol, VaccineCriteria, VaccineSideEffect, VaccineMethod } from '../enums.js'
+ */

--- a/app/utils/clinic-appointment.js
+++ b/app/utils/clinic-appointment.js
@@ -168,7 +168,7 @@ export const getAllAppointmentPaths = (
  * Get the path for a single health question
  *
  * @param {string} key
- * @param {import('../models.js').ClinicAppointment} appointment
+ * @param {ClinicAppointment} appointment
  * @param {string} pathPrefix
  * @returns {string} The full path to the given health question
  */

--- a/app/utils/consent.js
+++ b/app/utils/consent.js
@@ -17,7 +17,7 @@ const getHealthQuestionPath = (key, pathPrefix) => {
  * Get health question paths for given vaccines
  *
  * @param {string} pathPrefix - Path prefix
- * @param {import('../models.js').Consent} consent - Consent
+ * @param {Consent} consent - Consent
  * @returns {object|undefined} Health question paths
  */
 export const getHealthQuestionPaths = (pathPrefix, consent) => {
@@ -71,3 +71,7 @@ export const getHealthQuestionPaths = (pathPrefix, consent) => {
 
   return paths
 }
+
+/**
+ * @import { Consent } from '../models.js'
+ */

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -13,7 +13,7 @@ import {
 /**
  * Get instruction outcome for nasal spray
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
+ * @param {PatientSession} patientSession - Patient session
  * @returns {InstructionOutcome|boolean} Instruction outcome
  */
 export const getInstructionOutcome = (patientSession) => {
@@ -33,7 +33,7 @@ export const getInstructionOutcome = (patientSession) => {
 /**
  * Get registration outcome
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
+ * @param {PatientSession} patientSession - Patient session
  * @returns {RegistrationOutcome} Registration outcome
  */
 export const getRegistrationOutcome = (patientSession) => {
@@ -56,7 +56,7 @@ export const getRegistrationOutcome = (patientSession) => {
  * Get ready to record outcome
  * Check if registration is needed prior to recording vaccination
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
+ * @param {PatientSession} patientSession - Patient session
  * @returns {boolean} Ready to record outcome
  */
 export const getRecordOutcome = (patientSession) => {
@@ -76,7 +76,7 @@ export const getRecordOutcome = (patientSession) => {
 /**
  * Get vaccination (session) outcome
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
+ * @param {PatientSession} patientSession - Patient session
  * @returns {VaccinationOutcome|undefined} Vaccination (session) outcome
  */
 export const getSessionOutcome = (patientSession) => {
@@ -100,7 +100,7 @@ export const getSessionOutcome = (patientSession) => {
 /**
  * Get patient status
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
+ * @param {PatientSession} patientSession - Patient session
  * @returns {PatientStatus} Overall patient status
  */
 export const getReportOutcome = (patientSession) => {
@@ -185,3 +185,7 @@ export const getReportOutcome = (patientSession) => {
 
   return PatientStatus.Ineligible
 }
+
+/**
+ * @import { PatientSession } from '../models.js'
+ */

--- a/app/utils/reply.js
+++ b/app/utils/reply.js
@@ -51,7 +51,7 @@ export function getRepliesWithHealthAnswers(replies) {
 /**
  * Get combined answers to health questions
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
+ * @param {PatientSession} patientSession - Patient session
  * @returns {object|undefined} Combined answers to health questions
  */
 export function getConsentHealthAnswers(patientSession) {
@@ -116,8 +116,8 @@ export function getConsentHealthAnswers(patientSession) {
 /**
  * Get consent outcome
  *
- * @param {import('../models.js').Reply} reply - Reply
- * @param {import('../models.js').Session} session - Session
+ * @param {Reply} reply - Reply
+ * @param {Session} session - Session
  * @returns {ConsentOutcome} Consent outcome
  */
 export const getConfirmedConsentOutcome = (reply, session) => {
@@ -162,7 +162,7 @@ export const getConfirmedConsentOutcome = (reply, session) => {
 /**
  * Get consent outcome
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
+ * @param {PatientSession} patientSession - Patient session
  * @returns {ConsentOutcome} Consent outcome
  */
 export const getConsentOutcome = (patientSession) => {
@@ -275,7 +275,7 @@ export const getConsentOutcome = (patientSession) => {
 /**
  * Get combined refusal reasons
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
+ * @param {PatientSession} patientSession - Patient session
  * @returns {Array<ReplyRefusal>} Refusal reasons
  */
 export const getConsentRefusalReasons = (patientSession) => {
@@ -303,7 +303,7 @@ export const getConsentRefusalReasons = (patientSession) => {
 /**
  * Get faked answers for health questions needed for a vaccine
  *
- * @param {import('../models.js').Vaccine} vaccine - Vaccine
+ * @param {Vaccine} vaccine - Vaccine
  * @param {string} healthCondition - Health condition
  * @returns {object|undefined} Health answers
  */
@@ -414,3 +414,7 @@ export const countAnswersNeedingTriage = (healthAnswers) => {
     .flatMap(([, answer]) => (Array.isArray(answer) ? answer : [answer]))
     .filter((answer) => answer.answer === 'Yes').length
 }
+
+/**
+ * @import { PatientSession, Reply, Session, Vaccine } from '../models.js'
+ */

--- a/app/utils/session.js
+++ b/app/utils/session.js
@@ -15,7 +15,7 @@ import { today } from './date.js'
 /**
  * Get consent window (is it open, opening or closed)
  *
- * @param {import('../models.js').Session} session - Session
+ * @param {Session} session - Session
  * @returns {string} Consent window key and value
  */
 export const getConsentWindow = (session) => {
@@ -44,7 +44,7 @@ export const getConsentWindow = (session) => {
 /**
  * Get consent URL
  *
- * @param {import('../models.js').Session[]} sessions - Sessions
+ * @param {Array<Session>} sessions - Sessions
  * @param {string} [presetName] - Session preset name
  * @param {boolean} [isSchool] - Get school session
  * @returns {object|undefined} Consent window key and value
@@ -69,7 +69,7 @@ export const getSessionConsentUrl = (
 /**
  * Filter array where key has a value
  *
- * @param {import('../models.js').Session} session - Session
+ * @param {Session} session - Session
  * @param {Array<object>} filters - Filters
  * @returns {number} Number
  */
@@ -154,3 +154,7 @@ export function removeSlots(allSlots, slotsToRemove) {
     return false
   })
 }
+
+/**
+ * @import { Session } from '../models.js'
+ */

--- a/app/utils/status.js
+++ b/app/utils/status.js
@@ -93,7 +93,7 @@ export function getInstructionOutcomeStatus(instruct) {
  * Get patient status properties
  *
  * @param {PatientStatus} report - Patient status
- * @param {import('../enums.js').PatientDueStatus} [vaccinationDue] - Patient due status
+ * @param {PatientDueStatus} [vaccinationDue] - Patient due status
  * @returns {object} Status properties
  */
 export function getPatientStatus(report, vaccinationDue) {
@@ -315,3 +315,7 @@ export function getVaccinationOutcomeStatus(outcome) {
     text: outcome
   }
 }
+
+/**
+ * @import { PatientDueStatus } from '../enums.js'
+ */

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -338,7 +338,7 @@ export function formatNhsNumber(string, invalid) {
 /**
  * Format contact name with optional display of contact details
  *
- * @param {import('../models.js').Contact} contact - Contact
+ * @param {Contact} contact - Contact
  * @param {boolean} [includeContactDetails] - Include contact details
  * @returns {string|undefined} Formatted contact HTML
  */
@@ -399,7 +399,7 @@ export function formatIdentifier(identifiedBy) {
 /**
  * Format parental relationship, falling back to name else unknown
  *
- * @param {import('../models.js').Contact} contact - Contact
+ * @param {Contact} contact - Contact
  * @returns {string|undefined} Formatted parental relationship HTML
  */
 export function formatParentalRelationship(contact) {
@@ -574,3 +574,7 @@ export function formatTime(date, hour12 = true) {
     })
     .toLowerCase()
 }
+
+/**
+ * @import { Contact } from '../models.js'
+ */

--- a/app/utils/triage.js
+++ b/app/utils/triage.js
@@ -11,8 +11,8 @@ import { getRepliesWithHealthAnswers } from './reply.js'
 /**
  * Get screen outcomes for vaccination method(s) consented to
  *
- * @param {import('../models.js').Programme} programme - Programme
- * @param {Array<import('../models.js').Reply>} replies - Replies
+ * @param {Programme} programme - Programme
+ * @param {Array<Reply>} replies - Replies
  * @returns {Array<ScreenOutcome>} Screen outcomes
  */
 export const getScreenOutcomesForConsentMethod = (programme, replies) => {
@@ -50,9 +50,9 @@ export const getScreenOutcomesForConsentMethod = (programme, replies) => {
 /**
  * Get vaccination criteria consented to use if safe to vaccinate
  *
- * @param {import('../models.js').Programme} programme - Programme
- * @param {Array<import('../models.js').Reply>} replies - Replies
- * @returns {import('../enums.js').ScreenVaccineCriteria|boolean} Criteria
+ * @param {Programme} programme - Programme
+ * @param {Array<Reply>} replies - Replies
+ * @returns {ScreenVaccineCriteria|boolean} Criteria
  */
 export const getScreenVaccineCriteria = (programme, replies) => {
   const hasConsentForInjection = replies?.every(
@@ -84,7 +84,7 @@ export const getScreenVaccineCriteria = (programme, replies) => {
 /**
  * Get screen outcome (what was the triage decision)
  *
- * @param {import('../models.js').PatientSession} patientSession - Patient session
+ * @param {PatientSession} patientSession - Patient session
  * @returns {ScreenOutcome|boolean} Screen outcome
  */
 export const getScreenOutcome = (patientSession) => {
@@ -149,3 +149,7 @@ export const getScreenOutcome = (patientSession) => {
 
   return false
 }
+
+/**
+ * @import { PatientSession, Programme, Reply } from '../models.js'
+ */


### PR DESCRIPTION
Make it easier to read JSDoc comments by importing types at the bottom of files using the `@import` syntax.