### PR TITLE
Always have a logged in user when viewing authenticated pages

### DIFF
--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -1,11 +1,14 @@
-import { UserRole } from '../enums.js'
-
 export const accountController = {
   /**
    * @type {RequestHandler}
    */
   changeRole(request, response) {
-    request.session.data.token.role = request.body.role
+    const { account } = request.app.locals
+
+    request.session.data.token = {
+      ...account,
+      ...{ role: request.body.role }
+    }
 
     return response.redirect(
       /** @type {string} */ (request.query.referrer || '/home')
@@ -16,13 +19,6 @@ export const accountController = {
    * @type {RequestHandler}
    */
   cis2(request, response) {
-    const { data } = request.session
-
-    const user = Object.values(data.users).at(-1)
-    user.role = UserRole.Nurse
-
-    request.session.data.token = user
-
     return response.redirect('/account/change-role')
   },
 
@@ -30,13 +26,12 @@ export const accountController = {
    * @type {RequestHandler}
    */
   login(request, response) {
-    const { data } = request.session
-    const { role } = request.query
+    const { account } = request.app.locals
 
-    const user = Object.values(data.users).at(-1)
-    user.role = role || UserRole.Nurse
-
-    request.session.data.token = user
+    request.session.data.token = {
+      ...account,
+      ...{ role: request.query.role }
+    }
 
     return response.redirect('/home')
   },
@@ -45,7 +40,8 @@ export const accountController = {
    * @type {RequestHandler}
    */
   logout(request, response) {
-    delete request.session.data.token
+    // Delete role selected when signing in via CIS2
+    delete request.session.data.role
 
     return response.redirect('/start')
   }

--- a/app/middleware/authentication.js
+++ b/app/middleware/authentication.js
@@ -4,7 +4,8 @@ import { User } from '../models.js'
 export const authentication = (request, response, next) => {
   const { data } = request.session
 
-  const user = data.token ? new User(data.token) : {}
+  // Get user from logged in user, or default to last user in session data
+  const user = data.token ? new User(data.token) : User.findAll(data).at(-1)
 
   // Vaccine method(s)
   if ([UserRole.Nurse, UserRole.NursePrescriber].includes(user.role)) {


### PR DESCRIPTION
When viewing signed in pages, session data can sometimes get deleted, meaning the signed in user token is deleted too. This can be a problem as certain features only show when a signed in user is present.

This change means that viewing any page that requires authentication will ensure there is a signed in user present, while respecting any role selected when signing in or changing the current user role. The user’s role may still get reset, however.