### PR TITLE
Update field level auditing examples

### DIFF
--- a/app/assets/stylesheets/components/_summary-list.scss
+++ b/app/assets/stylesheets/components/_summary-list.scss
@@ -41,8 +41,6 @@
 
 .nhsuk-summary-list {
   .nhsuk-icon {
-    position: relative;
-    top: 3px;
     width: nhsuk-px-to-rem(19);
     height: nhsuk-px-to-rem(19);
   }

--- a/app/controllers/activity.js
+++ b/app/controllers/activity.js
@@ -59,6 +59,12 @@ export const activityController = {
     const vaccinationGiven = Vaccination.findAll(data).find(
       (vaccination) => vaccination.given
     )
+    const vaccinationUpdated = Vaccination.findAll(data).find(
+      (vaccination) =>
+        vaccination.given &&
+        vaccination.uuid !== vaccinationGiven.uuid &&
+        vaccination.batch_id !== vaccinationGiven.batch_id
+    )
     const vaccinationNotGiven = Vaccination.findAll(data).find(
       (vaccination) => !vaccination.given
     )
@@ -348,6 +354,22 @@ export const activityController = {
             createdBy_uid,
             programme_ids: [vaccinationGiven?.programme_id],
             vaccination_uuid: vaccinationGiven?.uuid
+          }),
+          auditEvent({
+            name: activity.vaccination.updated,
+            updatedFields: [
+              {
+                key: 'vaccination.batch_id.label',
+                before: vaccinationGiven?.formatted.batch_id,
+                after: vaccinationUpdated?.formatted.batch_id
+              },
+              {
+                key: 'vaccination.note.label',
+                before: '(Empty)',
+                after: 'Child reported feeling light headed'
+              }
+            ],
+            createdBy_uid
           })
         ]
       }

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -370,6 +370,7 @@ export const patientController = {
    * @type {RequestHandler}
    */
   update(request, response) {
+    const { account } = request.app.locals
     const { patient_uuid } = request.params
     const { data, referrer } = request.session
     const { __ } = response.locals
@@ -377,7 +378,10 @@ export const patientController = {
     // Update session data
     const patient = Patient.update(
       patient_uuid,
-      data.wizard.patients[String(patient_uuid)],
+      {
+        ...data.wizard.patients[String(patient_uuid)],
+        ...{ createdBy_uid: account.uid }
+      },
       data,
       true
     )

--- a/app/datasets/activity.js
+++ b/app/datasets/activity.js
@@ -108,6 +108,7 @@ export default {
       vaccination.given
         ? `Vaccinated with ${vaccination.vaccine?.brand}`
         : `${PatientStatus.Deferred}: ${lowerCaseFirst(vaccination.outcome)}`,
-    uploaded: 'Vaccination record uploaded'
+    uploaded: 'Vaccination record uploaded',
+    updated: 'Vaccination record updated manually'
   }
 }

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -605,6 +605,7 @@ export class Patient extends Child {
         name: activity.patient.updated(),
         type: AuditEventType.Record,
         createdAt: today(),
+        createdBy_uid: updates.createdBy_uid,
         updatedFields
       })
     }


### PR DESCRIPTION
Fix display of field-level activity log entries, and add example of a vaccination record with manually updated fields:

<img width="710" height="270" alt="Example of vaccination record updated manually activity log entry" src="https://github.com/user-attachments/assets/092f51bc-bffd-472b-8a61-9a0d238ec0b2" />
