### PR TITLE
Add team defaults for registration at clinics and appointment lengths

### DIFF
--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -144,7 +144,6 @@ export const sessionController = {
     const session = Session.create(
       {
         // TODO: This needs contextual team data to work
-        registration: data.team.sessionRegistration,
         createdBy_uid: account.uid
       },
       data.wizard
@@ -928,8 +927,24 @@ export const sessionController = {
     const { data } = request.session
     const { paths } = response.locals
 
-    // Update values in the session model
     let session = Session.findOne(session_id, data.wizard)
+    if (view === 'type') {
+      // Inject the relevant registration default, if not already set, or if changing session type
+      if (
+        session.registration === undefined ||
+        session?.type !== request.body.session.type
+      ) {
+        let { team } = response.locals
+        team = Team.findOne(team?.id || '001', data)
+
+        request.body.session.registration =
+          request.body.session.type === SessionType.School
+            ? team.schoolSessionRegistration
+            : team.clinicSessionRegistration
+      }
+    }
+
+    // Update values in the session model
     if (request.body.session) {
       session = Session.update(session_id, request.body.session, data.wizard)
     }

--- a/app/controllers/team.js
+++ b/app/controllers/team.js
@@ -67,25 +67,6 @@ export const teamController = {
   /**
    * @type {RequestHandler<Record<string, string>>}
    */
-  readSchool(request, response, next) {
-    const { school_id } = request.params
-
-    const school = School.findOne(school_id, request.session.data)
-    response.locals.school = school
-
-    return next()
-  },
-
-  /**
-   * @type {RequestHandler<Record<string, string>>}
-   */
-  showSchool(request, response) {
-    return response.render(`team/school`)
-  },
-
-  /**
-   * @type {RequestHandler<Record<string, string>>}
-   */
   showForm(request, response) {
     const view = request.params.view || 'contact'
 

--- a/app/controllers/team.js
+++ b/app/controllers/team.js
@@ -1,4 +1,4 @@
-import { School, Team } from '../models.js'
+import { Team } from '../models.js'
 
 export const teamController = {
   /**
@@ -52,7 +52,8 @@ export const teamController = {
 
     const referrers = {
       contact: `${team.uri}/contact`,
-      sessions: `${team.uri}/sessions`,
+      'school-sessions': `${team.uri}/sessions`,
+      'clinic-sessions': `${team.uri}/sessions`,
       password: `${team.uri}/sessions`
     }
 

--- a/app/enums.js
+++ b/app/enums.js
@@ -707,7 +707,10 @@ export const SessionType = {
 export const TeamDefaults = {
   SessionOpenWeeks: 3,
   SessionReminderWeeks: 1,
-  SessionRegistration: true
+  SchoolSessionRegistration: true,
+  ClinicSessionRegistration: true,
+  NasalSprayDuration: 5,
+  InjectionDuration: 10
 }
 
 /**

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -3057,9 +3057,49 @@ export const en = {
     },
     sessions: {
       title: 'Sessions',
-      defaults: 'Session defaults',
-      password: 'Shared password',
-      text: 'You can change these values when scheduling new sessions.'
+      school: {
+        title: 'School sessions',
+        text: 'You can change these values when scheduling new school sessions.',
+        defaults: 'School session defaults'
+      },
+      clinic: {
+        title: 'Clinic sessions',
+        text: 'You can change these values when scheduling new clinics.',
+        defaults: 'Clinic session defaults'
+      },
+      password: 'Shared password'
+    },
+    sessionOpenWeeks: {
+      title: 'When should parents get a request to give consent?',
+      label: 'Consent request',
+      hint: 'Enter the number of weeks before the first session takes place'
+    },
+    sessionReminderWeeks: {
+      title: 'When should parents get a reminder to give consent?',
+      label: 'Consent reminders',
+      hint: 'Enter the number of weeks before a session takes place'
+    },
+    schoolSessionRegistration: {
+      title:
+        'Register children’s attendance before recording vaccinations in school?',
+      label: 'Register attendance'
+    },
+    clinicSessionRegistration: {
+      title:
+        'Register children’s attendance before recording vaccinations at a clinic?',
+      label: 'Register attendance'
+    },
+    nasalSprayDuration: {
+      title:
+        'How much time should be given for a nasal spray at clinic sessions?',
+      label: 'Nasal spray appointment length',
+      hint: 'Enter the number of minutes to give each nasal spray'
+    },
+    injectionDuration: {
+      title:
+        'How much time should be given for an injection at clinic sessions?',
+      label: 'Injection appointment length',
+      hint: 'Enter the number of minutes to give each injection'
     },
     reminders: {
       title: 'Consent reminders'
@@ -3079,21 +3119,6 @@ export const en = {
     privacyPolicyUrl: {
       label: 'Privacy policy',
       hint: 'Linked to from consent forms and consent request emails'
-    },
-    sessionOpenWeeks: {
-      title: 'When should parents get a request to give consent?',
-      label: 'Consent request',
-      hint: 'Enter the number of weeks before the first session takes place'
-    },
-    sessionReminderWeeks: {
-      title: 'When should parents get a reminder to give consent?',
-      label: 'Consent reminders',
-      hint: 'Enter the number of weeks before a session takes place'
-    },
-    sessionRegistration: {
-      title:
-        'Do you want to register children’s attendance before recording vaccinations?',
-      label: 'Register attendance'
     },
     password: {
       label: 'Shared password',

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -106,7 +106,6 @@ export class Session {
 
     if (this.type === SessionType.Clinic) {
       this.clinic_id = options?.clinic_id
-      this.registration = false
       this.vaccinationPeriods = options?.vaccinationPeriods
         ? options.vaccinationPeriods.map(
             (period) => new ClinicVaccinationPeriod(period)
@@ -131,10 +130,11 @@ export class Session {
       this.mmrConsent = this.presetNames?.includes(SessionPresetName.MMR)
         ? options?.mmrConsent
         : undefined
-      this.registration = stringToBoolean(options?.registration)
-      this.register = options?.register || {}
       this.psdProtocol = stringToBoolean(options?.psdProtocol) || false
     }
+
+    this.registration = stringToBoolean(options?.registration)
+    this.register = options?.register || {}
 
     if (
       this.type === SessionType.School &&

--- a/app/models/team.js
+++ b/app/models/team.js
@@ -17,7 +17,10 @@ import { stringToBoolean } from '../utils/string.js'
  * @property {string} [privacyPolicyUrl] - Privacy policy URL
  * @property {number} [sessionOpenWeeks] - Weeks before request consent
  * @property {number} [sessionReminderWeeks] - Weeks before send first reminder
- * @property {boolean} [sessionRegistration] - Should sessions have registration
+ * @property {boolean} [schoolSessionRegistration] - Should school sessions have registration
+ * @property {number} [clinicNasalSprayDuration] - Minutes to allocate each nasal spray
+ * @property {number} [clinicInjectionDuration] - Minutes to allocate each injection
+ * @property {boolean} [clinicSessionRegistration] - Should clinic sessions have registration
  * @property {string} [password] - Shared password
  * @property {Array<string>} [clinic_ids] - Clinic IDs
  * @property {Array<string>} [school_ids] - School URNs
@@ -44,9 +47,17 @@ export class Team {
       Number(options?.sessionOpenWeeks) || TeamDefaults.SessionOpenWeeks
     this.sessionReminderWeeks =
       Number(options?.sessionReminderWeeks) || TeamDefaults.SessionReminderWeeks
-    this.sessionRegistration =
-      stringToBoolean(options.sessionRegistration) ||
-      TeamDefaults.SessionRegistration
+    this.schoolSessionRegistration =
+      stringToBoolean(options.schoolSessionRegistration) ??
+      TeamDefaults.SchoolSessionRegistration
+    this.clinicNasalSprayDuration =
+      Number(options?.clinicNasalSprayDuration) ||
+      TeamDefaults.NasalSprayDuration
+    this.clinicInjectionDuration =
+      Number(options?.clinicInjectionDuration) || TeamDefaults.InjectionDuration
+    this.clinicSessionRegistration =
+      stringToBoolean(options.clinicSessionRegistration) ??
+      TeamDefaults.ClinicSessionRegistration
     this.password = options?.password
     this.clinic_ids = options?.clinic_ids || []
     this.school_ids = options?.school_ids || []
@@ -98,9 +109,20 @@ export class Team {
       'week'
     )
 
+    const nasalSprayDuration = prototypeFilters.plural(
+      this.clinicNasalSprayDuration,
+      'minute'
+    )
+    const injectionDuration = prototypeFilters.plural(
+      this.clinicInjectionDuration,
+      'minute'
+    )
+
     return {
       sessionOpenWeeks: `Send ${sessionOpenWeeks} before first session`,
-      sessionReminderWeeks: `Send ${sessionReminderWeeks} before each session`
+      sessionReminderWeeks: `Send ${sessionReminderWeeks} before each session`,
+      nasalSprayDuration,
+      injectionDuration
     }
   }
 
@@ -157,6 +179,17 @@ export class Team {
    * @static
    */
   static update(id, updates, context) {
+    // Sanitise values from boolean radios
+    if (updates?.schoolSessionRegistration) {
+      updates.schoolSessionRegistration =
+        stringToBoolean(updates.schoolSessionRegistration) || false
+    }
+    if (updates?.clinicSessionRegistration) {
+      updates.clinicSessionRegistration =
+        stringToBoolean(updates.clinicSessionRegistration) || false
+    }
+
+    // Update the team instance
     const updatedTeam = Object.assign(Team.findOne(id, context), updates)
     updatedTeam.updatedAt = today()
 

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -12,9 +12,6 @@ router.all('/:team_id/edit/:view', team.readForm)
 router.get('/:team_id/edit/:view', team.showForm)
 router.post('/:team_id/edit/:view', team.updateForm)
 
-router.all('/:team_id/schools/:school_id', team.readSchool)
-router.get('/:team_id/schools/:school_id', team.showSchool)
-
 router.get('/:team_id{/:view}', team.show)
 
 export const teamRoutes = router

--- a/app/views/session/form/check-answers.njk
+++ b/app/views/session/form/check-answers.njk
@@ -80,6 +80,9 @@
         appointmentLength: {
           href: session.uri + "/new/appointment-length"
         },
+        registration: {
+          href: session.uri + "/new/registration"
+        },
         totalAppointments: {}
       })
     }) }}

--- a/app/views/team/form/clinic-sessions.njk
+++ b/app/views/team/form/clinic-sessions.njk
@@ -1,6 +1,6 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("team.sessions.title") %}
+{% set title = __("team.sessions.clinic.title") %}
 
 {% block form %}
   {{ appHeading({
@@ -9,7 +9,7 @@
   }) }}
 
   {{ insetText({
-    text: __("team.sessions.text")
+    text: __("team.sessions.clinic.text")
   }) }}
 
   {{ input({
@@ -18,12 +18,12 @@
     },
     label: {
       classes: "nhsuk-label--m",
-      text: __("team.sessionOpenWeeks.title")
+      text: __("team.nasalSprayDuration.title")
     },
-    hint: { text: __("team.sessionOpenWeeks.hint") },
-    suffix: "weeks",
+    hint: { text: __("team.nasalSprayDuration.hint") },
+    suffix: "minutes",
     width: 2,
-    decorate: "team.sessionOpenWeeks"
+    decorate: "team.clinicNasalSprayDuration"
   }) }}
 
   {{ input({
@@ -32,23 +32,23 @@
     },
     label: {
       classes: "nhsuk-label--m",
-      text: __("team.sessionReminderWeeks.title")
+      text: __("team.injectionDuration.title")
     },
-    hint: { text: __("team.sessionReminderWeeks.hint") },
-    suffix: "weeks",
+    hint: { text: __("team.injectionDuration.hint") },
+    suffix: "minutes",
     width: 2,
-    decorate: "team.sessionReminderWeeks"
+    decorate: "team.clinicInjectionDuration"
   }) }}
 
   {{ radios({
     fieldset: {
       legend: {
         classes: "nhsuk-fieldset__legend--m",
-        text: __("team.sessionRegistration.title")
+        text: __("team.clinicSessionRegistration.title")
       }
     },
     inline: true,
     items: getBooleanItems(),
-    decorate: "team.sessionRegistration"
+    decorate: "team.clinicSessionRegistration"
   }) }}
 {% endblock %}

--- a/app/views/team/form/school-sessions.njk
+++ b/app/views/team/form/school-sessions.njk
@@ -1,0 +1,54 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("team.sessions.school.title") %}
+
+{% block form %}
+  {{ appHeading({
+    caption: team.name,
+    title: title
+  }) }}
+
+  {{ insetText({
+    text: __("team.sessions.school.text")
+  }) }}
+
+  {{ input({
+    formGroup: {
+      classes: "nhsuk-u-margin-bottom-7"
+    },
+    label: {
+      classes: "nhsuk-label--m",
+      text: __("team.sessionOpenWeeks.title")
+    },
+    hint: { text: __("team.sessionOpenWeeks.hint") },
+    suffix: "weeks",
+    width: 2,
+    decorate: "team.sessionOpenWeeks"
+  }) }}
+
+  {{ input({
+    formGroup: {
+      classes: "nhsuk-u-margin-bottom-7"
+    },
+    label: {
+      classes: "nhsuk-label--m",
+      text: __("team.sessionReminderWeeks.title")
+    },
+    hint: { text: __("team.sessionReminderWeeks.hint") },
+    suffix: "weeks",
+    width: 2,
+    decorate: "team.sessionReminderWeeks"
+  }) }}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        classes: "nhsuk-fieldset__legend--m",
+        text: __("team.schoolSessionRegistration.title")
+      }
+    },
+    inline: true,
+    items: getBooleanItems(),
+    decorate: "team.schoolSessionRegistration"
+  }) }}
+{% endblock %}

--- a/app/views/team/sessions.njk
+++ b/app/views/team/sessions.njk
@@ -20,19 +20,38 @@
     <div class="nhsuk-grid-column-three-quarters">
       {{ summaryList({
         card: {
-          heading: __("team.sessions.defaults"),
+          heading: __("team.sessions.school.defaults"),
           headingSize: "m"
         },
         lastRowBorder: false,
         rows: summaryRows(team, {
           sessionOpenWeeks: {
-            href: team.uri + "/edit/sessions"
+            href: team.uri + "/edit/school-sessions"
           },
           sessionReminderWeeks: {
-            href: team.uri + "/edit/sessions"
+            href: team.uri + "/edit/school-sessions"
           },
-          sessionRegistration: {
-            href: team.uri + "/edit/sessions"
+          schoolSessionRegistration: {
+            href: team.uri + "/edit/school-sessions"
+          }
+        })
+      }) }}
+
+      {{ summaryList({
+        card: {
+          heading: __("team.sessions.clinic.defaults"),
+          headingSize: "m"
+        },
+        lastRowBorder: false,
+        rows: summaryRows(team, {
+          nasalSprayDuration: {
+            href: team.uri + "/edit/clinic-sessions"
+          },
+          injectionDuration: {
+            href: team.uri + "/edit/clinic-sessions"
+          },
+          clinicSessionRegistration: {
+            href: team.uri + "/edit/clinic-sessions"
           }
         })
       }) }}


### PR DESCRIPTION
For the registration, we want to test how teams would use this, incl. re setting the same default for clinics vs. school sessions.

For the appointment length defaults, this is just the first step in a design investigation. The values in the team settings aren't yet being used, as there are non-trivial implications for slot start times we can offer parents (and probably more besides).