### PR TITLE
Add journey for adding a child to a drop-in clinic

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -32,7 +32,7 @@ export const patientSessionController = {
 
     const patientSession = PatientSession.findAll(request.session.data).find(
       (patientSession) =>
-        patientSession.session.id === session_id &&
+        patientSession.session_id === session_id &&
         patientSession.programme_id === programme_id &&
         patientSession.patient.nhsn === nhsn
     )

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -5,7 +5,6 @@ import {
   PatientClinicStatus,
   PatientStatus,
   ProgrammeType,
-  SessionPresetName,
   SessionStatus,
   SessionType,
   VaccinationOutcome
@@ -18,7 +17,6 @@ import {
   PatientSession,
   Session
 } from '../models.js'
-import { today } from '../utils/date.js'
 import { getResults, getPagination } from '../utils/pagination.js'
 import {
   ConjunctionType,
@@ -279,7 +277,7 @@ export const patientController = {
       // Warn about inviting to any programmes that don't have clinics scheduled
       const programmesWithoutClinics =
         response.locals.clinicReadyProgrammes.filter(
-          (patientProgramme) => patientProgramme.scheduledClinicCount === 0
+          (patientProgramme) => patientProgramme.scheduledClinicsCount === 0
         )
       const formatter = new Intl.ListFormat('en', {
         style: 'long',
@@ -441,9 +439,19 @@ export const patientController = {
       return response.redirect(patient.uri)
     }
 
-    response.locals.patientProgramme = new PatientProgramme(
+    const patientProgramme = new PatientProgramme(
       patient.programmes[String(programme_id)],
       data
+    )
+
+    response.locals.patientProgramme = patientProgramme
+
+    response.locals.activeClinicsItems = patientProgramme.activeClinics.map(
+      (session) => ({
+        text: session.location.name,
+        hint: { text: session.clinic.formatted.address },
+        value: session.id
+      })
     )
 
     return next()
@@ -453,7 +461,9 @@ export const patientController = {
    * @type {RequestHandler<Record<string, string>>}
    */
   showProgramme(request, response) {
-    return response.render(`patient/programme`)
+    const view = request.params.view || 'programme'
+
+    return response.render(`patient/${view}`)
   },
 
   /**
@@ -461,7 +471,7 @@ export const patientController = {
    */
   inviteOneToClinic(request, response) {
     const { patient_uuid } = request.params
-    const { data } = request.session
+    const { data, referrer } = request.session
     const { __ } = response.locals
 
     // Strip any _unchecked value from the selected programme IDs
@@ -492,7 +502,7 @@ export const patientController = {
       })
     )
 
-    return response.redirect(patient.uri)
+    return response.redirect(referrer || patient.uri)
   },
 
   /**
@@ -545,7 +555,7 @@ export const patientController = {
             PatientClinicStatus.Ready
         ).length
       if (clinicReadyChildrenCount > 0) {
-        const scheduledClinicCount = scheduledSessions.filter((session) =>
+        const scheduledClinicsCount = scheduledSessions.filter((session) =>
           session.programme_ids.includes(programme.id)
         ).length
 
@@ -553,7 +563,7 @@ export const patientController = {
           name: programme.name,
           id: programme.id,
           childrenCount: clinicReadyChildrenCount,
-          clinicCount: scheduledClinicCount
+          clinicCount: scheduledClinicsCount
         })
       }
     }
@@ -680,78 +690,46 @@ export const patientController = {
   /**
    * @type {RequestHandler<Record<string, string>>}
    */
-  record(request, response) {
+  addToSession(request, response) {
     const { account } = request.app.locals
+    const { session_id } = request.body
     const { programme_id } = request.params
     const { data } = request.session
-    const { patient } = response.locals
+    const { __, patient, patientProgramme } = response.locals
 
-    let presetNames, appointmentLength
-    switch (programme_id) {
-      case 'flu':
-        presetNames = SessionPresetName.Flu
-        appointmentLength = 5
-        break
-      case 'hpv':
-        presetNames = SessionPresetName.HPV
-        appointmentLength = 10
-        break
-      case 'menacwy':
-      case 'td-ipv':
-        presetNames = SessionPresetName.Doubles
-        appointmentLength = 10
-        break
-      case 'mmr':
-        presetNames = SessionPresetName.MMR
-        appointmentLength = 10
-        break
-      default:
+    if (patientProgramme.scheduledClinicsCount === 0) {
+      return response.redirect(`/sessions/new`)
     }
 
-    const session = Session.create(
-      {
-        createdBy_uid: account.uid,
-        date: today(),
-        type: SessionType.Clinic,
-        presetNames,
-        clinic_id: 'M84008',
-        appointmentLength
-      },
-      data
-    )
+    // Get session
+    const session = Session.findOne(session_id, data)
 
-    let startAt = new Date(session.date)
-    startAt.setUTCHours(9, 0, 0, 0)
-    let endAt = new Date(session.date)
-    endAt.setUTCHours(12, 0, 0, 0)
-    session.addVaccinationPeriod({
-      startAt,
-      endAt,
-      vaccinatorCount: 5
-    })
-
-    Session.update(session.id, session, data)
-
-    const createdPatientSession = PatientSession.create(
+    // Create and add patient session
+    const patientSession = PatientSession.create(
       {
         createdBy_uid: account.uid,
         patient_uuid: patient.uuid,
         programme_id,
-        session_id: session.id
+        session_id
       },
       data
     )
 
-    patient.addToSession(createdPatientSession)
+    // Add to session
+    patient.addToSession(patientSession)
 
-    Patient.update(patient.uuid, { clinicProgramme_ids: [programme_id] }, data)
+    // Update session data
+    Patient.update(patient.uuid, patient, data)
 
-    const patientSession = PatientSession.findOne(
-      createdPatientSession.uuid,
-      data
+    request.flash(
+      'success',
+      __(`patientProgramme.addToSession.success`, { patient, session })
     )
 
-    return response.redirect(patientSession.uri)
+    // TODO: Should be able to use patientSession.uri here, but it doesn’t work
+    return response.redirect(
+      `/sessions/${session_id}/patients/${patient?.nhsn}/${programme_id}`
+    )
   },
 
   /**

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1825,6 +1825,10 @@ export const en = {
   },
   patientProgramme: {
     label: 'Vaccination programme',
+    addToSession: {
+      success:
+        '{{patient.fullName}}’s added to today’s clinic at {{session.location.name}}'
+    },
     name: {
       label: 'Programme'
     },
@@ -1846,6 +1850,20 @@ export const en = {
     },
     ttcv: {
       label: 'Previous vaccinations for tetanus, diptheria and polio'
+    },
+    activeClinics: {
+      label: 'Add to current clinic session',
+      title:
+        '{count, plural, =0 {There are no {programme} clinics running today} one {Are you sure you want to add this child to the following {programme} clinic?} other {Which {programme} clinic do you want to add the child to?}}',
+      hint: '{{count}} clinics are available today'
+    },
+    newClinicSession: {
+      label: 'Create a new clinic session',
+      description:
+        'You can create a new clinic session and then add children to it.'
+    },
+    inviteToClinic: {
+      label: 'Invite to upcoming clinic session'
     }
   },
   patientSession: {

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -269,16 +269,45 @@ export class PatientProgramme {
   }
 
   /**
-   * Get the number of clinics scheduled for this programme
+   * Get active clinics for this programme
    *
-   * @returns {number} Number of scheduled clinics targeting this programme
+   * @returns {Array<Session>} Active clinics targeting this programme
    */
-  get scheduledClinicCount() {
-    const scheduledClinics = Session.findAll(this.context)
+  get activeClinics() {
+    return Session.findAll(this.context)
+      ?.filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
+      ?.filter(({ type }) => type === SessionType.Clinic)
+      ?.filter(({ status }) => status === SessionStatus.Active)
+  }
+
+  /**
+   * Get number of active clinics for this programme
+   *
+   * @returns {number} Number of active clinics targeting this programme
+   */
+  get activeClinicsCount() {
+    return this.activeClinics?.length || 0
+  }
+
+  /**
+   * Get scheduled clinics for this programme
+   *
+   * @returns {Array<Session>} Scheduled clinics targeting this programme
+   */
+  get scheduledClinics() {
+    return Session.findAll(this.context)
       ?.filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
       ?.filter(({ type }) => type === SessionType.Clinic)
       ?.filter(({ status }) => status === SessionStatus.Planned)
-    return scheduledClinics?.length || 0
+  }
+
+  /**
+   * Get number of scheduled clinics for this programme
+   *
+   * @returns {number} Number of scheduled clinics targeting this programme
+   */
+  get scheduledClinicsCount() {
+    return this.scheduledClinics?.length || 0
   }
 
   /**

--- a/app/routes/patient.js
+++ b/app/routes/patient.js
@@ -24,10 +24,19 @@ router.post('/:patient_uuid/new/note', patient.note)
 router.post('/:patient_uuid/archive', patient.archive)
 router.post('/:patient_uuid/invite-to-clinic', patient.inviteOneToClinic)
 
-router.all('/:patient_uuid/programmes{/:programme_id}', patient.readProgramme)
-router.get('/:patient_uuid/programmes{/:programme_id}', patient.showProgramme)
+router.all(
+  '/:patient_uuid/programmes/:programme_id{/:view}',
+  patient.readProgramme
+)
+router.get(
+  '/:patient_uuid/programmes/:programme_id{/:view}',
+  patient.showProgramme
+)
 
-router.post('/:patient_uuid/programmes/:programme_id/record', patient.record)
+router.post(
+  '/:patient_uuid/programmes/:programme_id/clinics',
+  patient.addToSession
+)
 
 router.get(
   '/:patient_uuid/programmes/:programme_id/new/vaccination',

--- a/app/views/patient/clinics.njk
+++ b/app/views/patient/clinics.njk
@@ -1,0 +1,63 @@
+{% extends "_layouts/form.njk" %}
+
+{% set paths = { back: patientProgramme.uri } %}
+{% set title = __mf("patientProgramme.activeClinics.title", {
+  programme: patientProgramme.programme.nameSentenceCase,
+  count: patientProgramme.activeClinicsCount
+}) %}
+
+{% if patientProgramme.activeClinicsCount == 0 %}
+  {% set confirmButtonText = __("patientProgramme.newClinicSession.label") %}
+{% elif patientProgramme.activeClinicsCount == 1 %}
+  {% set confirmButtonText = "Add to clinic" %}
+{% endif %}
+
+{% block form %}
+  {% if patientProgramme.activeClinicsCount == 0 %}
+    {{ appHeading({
+      caption: patient.fullName,
+      title: title
+    }) }}
+
+    {{ __("patientProgramme.newClinicSession.description") | nhsukMarkdown }}
+  {% elif patientProgramme.activeClinicsCount == 1 %}
+    {{ appHeading({
+      caption: patient.fullName,
+      title: title
+    }) }}
+
+    {% call insetText({
+      classes: "nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-4"
+    }) %}
+      <p>
+        <span class="nhsuk-heading-m nhsuk-u-margin-bottom-0">{{ patientProgramme.activeClinics[0].clinic.name }}</span>
+        {{ patientProgramme.activeClinics[0].clinic.formatted.address }}
+      </p>
+    {% endcall %}
+
+    {{ input({
+      type: "hidden",
+      value: patientProgramme.activeClinics[0].id,
+      decorate: "session_id"
+    }) }}
+  {% else %}
+    {% call fieldset({
+      legend: {
+        html: appHeading({
+          caption: patient.fullName,
+          title: title
+        })
+      }
+    }) %}
+      <p class="nhsuk-hint">{{ __("patientProgramme.activeClinics.hint", {
+        programme: patientProgramme.programme.nameSentenceCase,
+        count: patientProgramme.activeClinicsCount
+      }) }}</p>
+
+      {{ radios({
+        items: activeClinicsItems,
+        decorate: "session_id"
+      }) }}
+    {% endcall %}
+  {% endif %}
+{% endblock %}

--- a/app/views/patient/invite-to-clinic.njk
+++ b/app/views/patient/invite-to-clinic.njk
@@ -21,7 +21,7 @@
     hint: { text: __mf("patient.inviteToClinic.clinicCount.hint",
       {
         programmeName: patientProgramme.programme.name | replace("Flu", "flu"),
-        count: patientProgramme.scheduledClinicCount
+        count: patientProgramme.scheduledClinicsCount
       })
     }
   }) %}
@@ -50,7 +50,7 @@
       items: checkboxItems,
       decorate: "clinicProgramme_ids"
     }) }}
-  
+
     {{ warningCallout({
       heading: __("patient.inviteToClinic.scheduledClinicWarning.title"),
       text: __mf("patient.inviteToClinic.scheduledClinicWarning.description",
@@ -69,7 +69,7 @@
       {{ __mf("patient.inviteToClinic.clinicCount.someParagraph",
       {
         programmeName: clinicReadyProgrammes[0].programme.name | replace("Flu", "flu"),
-        count: clinicReadyProgrammes[0].scheduledClinicCount
+        count: clinicReadyProgrammes[0].scheduledClinicsCount
       }) | nhsukMarkdown }}
     {% else %}
       {# Tell the user there are NO clinics available for this child's one clinic-ready programme #}

--- a/app/views/patient/programme.njk
+++ b/app/views/patient/programme.njk
@@ -70,21 +70,10 @@
       }) }}
     {% endif %}
 
-    {{ appButtonGroup({
-      buttons: [{
-        text: __("patientSession.record.title", {
-          programme: patientProgramme.programme
-        }) | safe,
-        variant: "secondary",
-        attributes: {
-          formaction: patientProgramme.uri + "/record?referrer=" + referrer
-        }
-      }, {
-        text: __("vaccination.new.alreadyVaccinated.title"),
-        href: patientProgramme.uri + "/new/vaccination",
-        variant: "secondary"
-      }]
-    }) if patientProgramme.status != PatientStatus.Vaccinated and patientProgramme.eligible }}
+    {{ actionLink({
+      text: __("vaccination.new.alreadyVaccinated.title"),
+      href: patientProgramme.uri + "/new/vaccination"
+    }) }}
   {% endcall %}
 
   {% if patientProgramme.ttcvVaccinations %}
@@ -126,53 +115,69 @@
         rows: ttcvRows
       }) }}
 
-      {{ button({
+      {{ actionLink({
         text: __("vaccination.new.alreadyVaccinated.ttcv"),
-        href: patientProgramme.uri + "/new/ttcv",
-        variant: "secondary"
+        href: patientProgramme.uri + "/new/ttcv"
       }) }}
     {% endcall %}
   {% endif %}
 
   {% if patientProgramme.patientSessions.length %}
-    {% set patientSessionRows = [] %}
-    {% for patientSession in patientProgramme.patientSessions %}
-      {% set patientSessionRows = patientSessionRows | push([
-        {
-          header: __("session.location.label"),
-          html: link(patientSession.uri, patientSession.session.location.name)
-        },
-        {
-          header: __("session.date.label"),
-          html: patientSession.session.formatted.date if patientSession.session.date else patientSession.session.status
-        },
-        {
-          header: __("patientSession.outcome.label"),
-          html: patientSession.formatted.outcome or "No outcome"
-        }
-      ]) %}
-    {% endfor %}
-
-    {{ table({
-      id: "patient-sessions",
-      sort: "name",
-      responsive: true,
-      card: {
-        heading: __("patientProgramme.patientSessions.label"),
-        headingLevel: 3
-      },
-      head: [
-        {
-          text: __("session.location.label"),
-          attributes: {
-            style: "width: 33%"
+    {% call card({
+      heading: __("patientProgramme.patientSessions.label"),
+      headingLevel: 3
+    }) %}
+      {% set patientSessionRows = [] %}
+      {% for patientSession in patientProgramme.patientSessions %}
+        {% set patientSessionRows = patientSessionRows | push([
+          {
+            header: __("session.location.label"),
+            html: link(patientSession.uri, patientSession.session.location.name)
+          },
+          {
+            header: __("session.date.label"),
+            html: patientSession.session.formatted.date if patientSession.session.date else patientSession.session.status
+          },
+          {
+            header: __("patientSession.outcome.label"),
+            html: patientSession.formatted.outcome or "No outcome"
           }
-        },
-        { text: __("session.date.label") },
-        { text: __("patientSession.outcome.label") }
-      ],
-      rows: patientSessionRows
-    }) }}
+        ]) %}
+      {% endfor %}
+
+      {{ table({
+        id: "patient-sessions",
+        sort: "name",
+        responsive: true,
+        head: [
+          {
+            text: __("session.location.label"),
+            attributes: {
+              style: "width: 33%"
+            }
+          },
+          { text: __("session.date.label") },
+          { text: __("patientSession.outcome.label") }
+        ],
+        rows: patientSessionRows
+      }) }}
+
+      {{ appButtonGroup({
+        buttons: [{
+          text: __("patientProgramme.inviteToClinic.label") | safe,
+          variant: "secondary",
+          decorate: "programme_ids",
+          value: patientProgramme.programme.id,
+          attributes: {
+            formaction: patient.uri + "/invite-to-clinic?referrer=" + patientProgramme.uri
+          }
+        }, {
+          text: __("patientProgramme.activeClinics.label") | safe,
+          variant: "secondary",
+          href: patientProgramme.uri + "/clinics"
+        }]
+      }) if patientProgramme.status != PatientStatus.Vaccinated and patientProgramme.eligible }}
+    {% endcall %}
   {% endif %}
 
   {{ card({


### PR DESCRIPTION
## Background

In April we implemented an interim fix to allow teams to record vaccinations in clinics directly from the child record page.

To do this, teams could:
1. Search for the child in the children list, using the new ‘invited to clinic’ filter to narrow results if needed
2. Go to the programme tab and click ‘Record a vaccination in clinic’

The first time this button is clicked, a new Community clinic session is created, and the child added to it. From there the user can record verbal consent, perform any triage if needed and record a vaccination.

If a subsequent child is vaccinated in a clinic on the same day, they would be added to this Community clinic session.

With the new clinics design in place, Community clinic sessions will disappear, and existing clinics may have already been set up.

Until the ability to add a child to an existing clinic, or book a child into a clinic has been implemented, we can update the ‘Record a vaccination in clinic’ functionality to both work with the new implementation and handle drop-ins to clinics.

This PR replaces the previous ‘quick win’ that enabled teams to create ad-hoc patient clinic sessions to record a vaccination today.

The new journey only allows the user to choose from clinic session(s) running today. If there are no sessions in progress, they are promoted to create a new clinic session using the new session wizard.

## Patient programme with prompt to add child to a clinic

<img width="2400" height="3384" alt="patient-programme" src="https://github.com/user-attachments/assets/d7ba5c7e-d6db-4dff-8012-568651b9b5fc" />

## Many clinics running for chosen programme today

<p><img width="2400" height="1908" alt="many-clinics-today" src="https://github.com/user-attachments/assets/f682b4b6-fc1a-4a59-b573-7c7f51a3e71a" /></p>

Upon selecting a clinic location, the user is redirected to patient session page for that clinic

## One clinic running for chosen programme today

User is asked to confirm the clinic location before continuing.

<p><img width="2400" height="1822" alt="one-clinic today" src="https://github.com/user-attachments/assets/ca40d446-95c2-4715-aac5-8d8cfee23a02" /></p>

Upon confirming the clinic location, the user is redirected to patient session page for that clinic.

## No clinics running for chosen programme today

<p><img width="2400" height="1640" alt="no-clinics-today" src="https://github.com/user-attachments/assets/a179cc2e-16e2-44e9-a437-ac78720cc5a2" /></p>

## Recording a vaccination

Once a child has been added to a clinic, the user will then need to record a verbal consent response, within which the chosen vaccine method (if applicable) can be selected, and answers to health questions recorded.

Once consent has been added, the user can then record a vaccination.