### PR TITLE
Cancel session: fix issues, add Cancelled status, and hide some commands

### DIFF
--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -1178,9 +1178,10 @@ export const sessionController = {
         back = `${session.uri}/cancel/appointments`
         break
       case 'confirm':
-        back = session.hasAppointments
-          ? `${session.uri}/cancel/rebooking`
-          : session.uri
+        back =
+          session.type === SessionType.Clinic && session.hasAppointments
+            ? `${session.uri}/cancel/rebooking`
+            : session.uri
         break
     }
 
@@ -1195,16 +1196,16 @@ export const sessionController = {
     const { data } = request.session
     const { __, session } = response.locals
 
-    let next
+    let nextUrl
     switch (view) {
       case 'appointments':
-        next = `${session.uri}/cancel/rebooking`
+        nextUrl = `${session.uri}/cancel/rebooking`
         break
       case 'rebooking':
-        next = `${session.uri}/cancel/confirm`
+        nextUrl = `${session.uri}/cancel/confirm`
         break
       case 'confirm':
-        next = '/sessions'
+        nextUrl = session.uri
         break
     }
 
@@ -1215,11 +1216,11 @@ export const sessionController = {
     } else if (view === 'confirm') {
       request.flash('message', __('session.cancel.success', { session }))
 
-      // TODO: mirror the live service by setting a Cancelled status instead
-      Session.delete(session.id, data)
+      session.cancelled = true
+      Session.update(session.id, session, data)
     }
 
-    return response.redirect(next)
+    return response.redirect(nextUrl)
   }
 }
 

--- a/app/enums.js
+++ b/app/enums.js
@@ -721,7 +721,8 @@ export const SessionStatus = {
   Unplanned: 'Not scheduled',
   Planned: 'Scheduled',
   Completed: 'Completed',
-  Closed: 'Closed'
+  Closed: 'Closed',
+  Cancelled: 'Cancelled'
 }
 
 /**

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -262,9 +262,12 @@ export class PatientProgramme {
       ?.filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
       ?.at(-1)
     return (
-      ![SessionStatus.Completed, SessionStatus.Closed].includes(
-        latestSchoolSession?.status
-      ) && latestSchoolSession?.academicYear === getCurrentAcademicYear()
+      ![
+        SessionStatus.Completed,
+        SessionStatus.Closed,
+        SessionStatus.Cancelled
+      ].includes(latestSchoolSession?.status) &&
+      latestSchoolSession?.academicYear === getCurrentAcademicYear()
     )
   }
 

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -333,6 +333,15 @@ export class Session {
   }
 
   /**
+   * Is the session cancelled?
+   *
+   * @returns {boolean} True if cancelled, or false otherwise
+   */
+  get isCancelled() {
+    return this.status === SessionStatus.Cancelled
+  }
+
+  /**
    * Does session occur in the current academic year?
    *
    * @returns {boolean} Session occurs in current academic year

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -80,6 +80,7 @@ import {
  * @property {Date} [openAt] - Date consent window opens
  * @property {object} [openAt_] - Date consent window opens (from `dateInput`)
  * @property {boolean} [closed] - Session closed
+ * @property {boolean} [cancelled] - Session was cancelled
  * @property {number} [reminderWeeks] - Weeks before session to send reminders
  * @property {object} [register] - Patient register
  * @property {boolean} [nationalProtocol] - Enable national protocol
@@ -104,6 +105,7 @@ export class Session {
     this.date_ = options?.date_
     this.academicYear = options?.academicYear || getCurrentAcademicYear()
     this.presetNames = options?.presetNames
+    this.cancelled = options?.cancelled || false
 
     if (this.type === SessionType.Clinic) {
       this.clinic_id = options?.clinic_id
@@ -346,12 +348,14 @@ export class Session {
    */
   get status() {
     switch (true) {
-      case isSameDay(this.date, setMidday(today())):
-        return SessionStatus.Active
       case this.closed:
         return SessionStatus.Closed
+      case this.cancelled:
+        return SessionStatus.Cancelled
       case !this.date:
         return SessionStatus.Unplanned
+      case isSameDay(this.date, setMidday(today())):
+        return SessionStatus.Active
       case isAfter(setMidday(today()), this.date):
         return SessionStatus.Completed
       default:

--- a/app/views/patient-session/_appointment.njk
+++ b/app/views/patient-session/_appointment.njk
@@ -12,7 +12,7 @@
         href: patientSession.clinicAppointment.uri.cancel
       }
     ]
-  } if patientSession.clinicAppointment
+  } if not session.isCancelled and patientSession.clinicAppointment
 }) %}
 
   {% if patientSession.clinicAppointment %}

--- a/app/views/patient-session/_catch-up.njk
+++ b/app/views/patient-session/_catch-up.njk
@@ -22,7 +22,8 @@
         {
           header: __("actions.label"),
           html: link(patientSession.clinicAppointment.uri.addProgramme + patientProgramme.programme.id, "Add to appointment")
-        } ]) %}
+        } if not session.isCancelled
+      ]) %}
     {% endif %}
   {% endfor %}
 
@@ -38,7 +39,7 @@
           { text: __("patientProgramme.name.label") },
           { text: __("patientProgramme.status.label") },
           { text: __("patientProgramme.statusNotes.label") },
-          { text: __("actions.label") }
+          { text: __("actions.label") } if not session.isCancelled
         ],
         rows: patientProgrammeRows
       }) }}

--- a/app/views/session/show.njk
+++ b/app/views/session/show.njk
@@ -45,7 +45,7 @@
       {
         text: __("session.schedule.title") if session.isUnplanned else __("session.edit.title"),
         href: session.uri + "/edit"
-      },
+      } if not session.isCancelled,
       {
         text: __("session.action.cancel"),
         href: session.uri + "/cancel"


### PR DESCRIPTION
Changed cancellation of sessions to move the new session to a new Cancelled status, replacing the naive deletion of sessions (which wasn't working anyway).

Also now hiding some commands if a session is cancelled e.g. the ability to edit the session or edit/cancel appointments therein. Still need to actually cancel the appointments.