### PR TITLE
Clinic registration: show registration status in Appointments and move form to Appointment tab

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -256,7 +256,9 @@ export const patientSessionController = {
         data
       )
 
-      patientSession.patient.recordVaccination(vaccination)
+      patientSession.patient.recordVaccination(
+        Vaccination.findOne(vaccination.uuid, data)
+      )
     }
 
     request.flash(

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -109,7 +109,7 @@ export const patientSessionController = {
         patientSession.instruct &&
         patientSession.session.isActive,
       hasSupplier: userIsHCA && userHasSupplier,
-      canRegister: session.register && session.isActive,
+      canRegister: session.registration && session.isActive,
       canRecord:
         account.vaccineMethods?.includes(patientSession.vaccine?.method) &&
         record &&

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -196,10 +196,13 @@ export const patientSessionController = {
    */
   readForm(request, response, next) {
     const { referrer } = request.session
-    const { patientSession } = response.locals
+    const { patientSession, session } = response.locals
 
     // Show back link to referring page, else patient session page
-    response.locals.back = referrer || patientSession.uri
+    response.locals.back =
+      referrer || session.type === SessionType.Clinic
+        ? `${patientSession.uri}/appointment`
+        : patientSession.uri
 
     return next()
   },

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -658,7 +658,7 @@ export const sessionController = {
             .map((appointment, index) => ({
               header: headers[index + rowValues.length],
               appointment,
-              canExtend: extendableAppointmentTimes.some(
+              spaceToExtend: extendableAppointmentTimes.some(
                 (extendableTime) =>
                   extendableTime.getTime() === appointment.startAt.getTime()
               )
@@ -670,7 +670,7 @@ export const sessionController = {
             .map((index) => ({
               header: headers[index + rowValues.length],
               appointment: null,
-              canExtend: false
+              spaceToExtend: false
             }))
         )
 

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -226,6 +226,7 @@ export const vaccinationController = {
         if (data?.token?.vaccinations?.[vaccination.vaccine_snomed]) {
           data.token.vaccinations[vaccination.vaccine_snomed] += 1
         } else {
+          data.token = data.token ?? User.findAll(data).at(-1)
           data.token.vaccinations = {
             [vaccination.vaccine_snomed]: 1
           }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2035,7 +2035,9 @@ export const en = {
         [RegistrationOutcome.Present]:
           '{{patientSession.patient.fullName}} is attending today’s session.',
         [RegistrationOutcome.Absent]:
-          '{{patientSession.patient.fullName}} has been recorded as absent from today’s session.'
+          '{{patientSession.patient.fullName}} has been recorded as absent from today’s session.',
+        [RegistrationOutcome.Pending]:
+          '{{patientSession.patient.fullName}} has not been registered yet.'
       }
     },
     catchUps: {

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -9,6 +9,7 @@ import {
   Impairment,
   ParentalRelationship,
   ProgrammeType,
+  RegistrationOutcome,
   ReplyDecision,
   SessionStatus,
   VaccineCriteria,
@@ -350,6 +351,16 @@ export class ClinicAppointment {
   }
 
   /**
+   * Get the registration status for this appointment's child i.e. have they turned up?
+   *
+   * @returns {RegistrationOutcome|undefined} the registration status if a matched child, or undefined if not yet matched
+   */
+  get register() {
+    // Return undefined if not yet matched as registration is tied to a patient record
+    return this.patientSessions.at(0)?.register
+  }
+
+  /**
    * Get any impairments reported for this appointment's child/patient
    *
    * @returns {Array<Impairment>} the child or patient's impairments
@@ -459,6 +470,8 @@ export class ClinicAppointment {
     )
     const summary = `${teamFacingStartTime} ${this.fullName} (${programmeNames})`
 
+    const register = this.patientSessions.at(0)?.formatted?.register
+
     return {
       nameAndAge: [
         this.fullName,
@@ -508,7 +521,8 @@ export class ClinicAppointment {
             )
           }
         : {}),
-      summary
+      summary,
+      register
     }
   }
 
@@ -536,12 +550,15 @@ export class ClinicAppointment {
    */
   get link() {
     return {
-      unmatched: formatLinkWithSecondaryText(
-        this.uri.unmatched,
-        this.child.fullName,
-        `via ${this.contact.fullNameAndRelationship}`
-      ),
-      patientSession: formatLink(this.uri.matched, this.patient?.fullName),
+      unmatched: {
+        withParent: formatLinkWithSecondaryText(
+          this.uri.unmatched,
+          this.child.fullName,
+          `by ${this.contact.fullNameAndRelationship}`
+        ),
+        withoutParent: formatLink(this.uri.unmatched, this.child.fullName)
+      },
+      matched: formatLink(this.uri.matched, this.patient?.fullName),
       extend: formatLink(this.uri.extend, 'Extend'),
       summary: this.patient_uuid
         ? formatLink(this.uri.matched, this.formatted.summary)

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -709,7 +709,7 @@ export class PatientSession {
    * @returns {boolean} Consent has been given
    */
   get consentGiven() {
-    if (this.consent) {
+    if (this.consent && !this.clinicAppointment) {
       return [
         ConsentOutcome.Given,
         ConsentOutcome.GivenForAlternativeInjection,

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -359,7 +359,7 @@ export function formatContact(contact, includeContactDetails = true) {
 
   // Add email address, if provided
   if (includeContactDetails && contact.email) {
-    string += `<br>${contact.email}`
+    string += `<br><span class="nhsuk-u-secondary-text-colour">${contact.email}</span>`
   }
 
   return string

--- a/app/views/appointments/list.njk
+++ b/app/views/appointments/list.njk
@@ -31,7 +31,7 @@
     {% set appointmentRows = appointmentRows | push([
       {
         header: __("appointments.summary.label"),
-        html: appointment.link.unmatched | replace("/unmatched-appointments", appointmentsPath)
+        html: appointment.link.unmatched.withParent | replace("/unmatched-appointments", appointmentsPath)
       },
       {
         header: __("appointments.location.label"),

--- a/app/views/patient-session/appointment.njk
+++ b/app/views/patient-session/appointment.njk
@@ -24,6 +24,11 @@
   {# Details of the appointment as it stands #}
   {% include "patient-session/_appointment.njk" %}
 
+  {# Registration #}
+  {% if options.canRegister %}
+    {% include "patient-session/_register.njk" %}
+  {% endif %}
+  
   {# Details of additional programmes that could be offered #}
   {% include "patient-session/_catch-up.njk" %}
 {% endblock %}

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -72,7 +72,7 @@
         {% include "patient-session/_instruct.njk" %}
       {% endif %}
 
-      {% if options.canRegister %}
+      {% if options.canRegister and session.type === SessionType.School %}
         {% include "patient-session/_register.njk" %}
       {% endif %}
 

--- a/app/views/session/appointments.njk
+++ b/app/views/session/appointments.njk
@@ -5,16 +5,34 @@
 {% set caption = session.formatted.date %}
 
 {% block content %}
-  {% macro buildSlotHtml(appointment, time, canExtend) %}
+  {% macro buildSlotHtml(appointment, time, spaceToExtend) %}
     {% if appointment !== null %}
+      {# Link from child’s name #}
       {% if appointment.patient_uuid %}
-        {{ appointment.link.patientSession | safe }}
+        {{ appointment.link.matched | safe }}
       {% else %}
-        {{ appointment.link.unmatched | safe }}
+        {{ appointment.link.unmatched.withoutParent | safe }}
         <span class="nhsuk-u-secondary-text-colour nhsuk-u-font-size-16"> (unmatched)</span>
       {% endif %}
+
+      {# Registration status #}
+      {% if session.isActive and session.registration %}
+        <br>
+        {% if appointment.register %}
+          {{ appointment.formatted.register | safe }}
+        {% else %}
+          {{ tag({
+            text: RegistrationOutcome.Pending,
+            classes: "nhsuk-tag--grey"
+          }) }}
+        {% endif %}
+      {% endif %}
+
+      {# Selected vaccinations #}
       <br>
       {{ appointment.formatted.programmeTags | safe }}
+
+      {# Adjustments and impairements #}
       {% if appointment.requiresAdjustments %}
         <br>
         {{ appointment.formatted.adjustmentsCount | safe }}
@@ -23,7 +41,9 @@
         <br>
         {{ appointment.formatted.impairmentsCount | safe }}
       {% endif %}
-      {% if canExtend and not session.isCancelled %}
+
+      {# Option to extend the appointment #}
+      {% if spaceToExtend and session.isPlanned %}
         <br>
         {{ appointment.link.extend | safe }}
       {% endif %}
@@ -47,7 +67,7 @@
           if rowValue.timeSlot else
           {
             header: rowValue.header,
-            html: buildSlotHtml(rowValue.appointment, row.time, rowValue.canExtend)
+            html: buildSlotHtml(rowValue.appointment, row.time, rowValue.spaceToExtend)
           }
         ) %}
       {% endfor %}


### PR DESCRIPTION
Two main changes here:

In an active session, show registration status in the session's Appointments tab
<img width="1132" height="861" alt="image" src="https://github.com/user-attachments/assets/4d2793a7-3286-4dd4-9598-d53ee7d1c64d" />

Move the patient session's registration form to the Appointment tab (clinic sessions only, as school sessions have no such tab)
<img width="1132" height="1184" alt="image" src="https://github.com/user-attachments/assets/c959aff7-e58e-4549-bf7f-a846fcd0b450" />
