### PR TITLE
Lazy evaluation of models’ formatted getters

### DIFF
--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -230,23 +230,43 @@ export class AuditEvent {
    * @returns {object} Formatted values
    */
   get formatted() {
-    return {
-      createdAt: formatDate(this.createdAt, { dateStyle: 'long' }),
-      createdBy: this.createdBy_uid && this.createdBy.fullName,
-      datetime: formatDate(this.createdAt, {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        hour12: true
-      }),
-      note: this.note && formatMarkdown(this.note),
-      outcome: this.outcome && formatTag(getScreenOutcomeStatus(this.outcome)),
-      outcomeAt:
-        this.outcomeAt && formatDate(this.outcomeAt, { dateStyle: 'long' }),
-      programmes: this.programmes.flatMap(({ nameTag }) => nameTag).join(' ')
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'createdAt':
+              return formatDate(this.createdAt, { dateStyle: 'long' })
+            case 'createdBy':
+              return this.createdBy_uid && this.createdBy.fullName
+            case 'datetime':
+              return formatDate(this.createdAt, {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+              })
+            case 'note':
+              return this.note && formatMarkdown(this.note)
+            case 'outcome':
+              return (
+                this.outcome && formatTag(getScreenOutcomeStatus(this.outcome))
+              )
+            case 'outcomeAt':
+              return (
+                this.outcomeAt &&
+                formatDate(this.outcomeAt, { dateStyle: 'long' })
+              )
+            case 'programmes':
+              return this.programmes.flatMap(({ nameTag }) => nameTag).join(' ')
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/batch.js
+++ b/app/models/batch.js
@@ -102,12 +102,25 @@ export class Batch {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const createdAt = formatDate(this.createdAt, { dateStyle: 'long' })
-    const updatedAt = formatDate(this.updatedAt, { dateStyle: 'long' })
-    const expiry = formatDate(this.expiry, { dateStyle: 'long' })
-    const id = formatCode(this.id)
-
-    return { createdAt, updatedAt, expiry, id }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'createdAt':
+              return formatDate(this.createdAt, { dateStyle: 'long' })
+            case 'updatedAt':
+              return formatDate(this.updatedAt, { dateStyle: 'long' })
+            case 'expiry':
+              return formatDate(this.expiry, { dateStyle: 'long' })
+            case 'id':
+              return formatCode(this.id)
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -308,39 +308,60 @@ export class Child {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const yearGroup = formatYearGroup(this.yearGroup)
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          // Multiple properties use the formatted year group, but keep it lazy
+          const getFormattedYearGroup = () => formatYearGroup(this.yearGroup)
 
-    return {
-      dob: formatDate(this.dob, { dateStyle: 'long' }),
-      dod: formatDate(this.dod, { dateStyle: 'long' }),
-      address:
-        this?.address &&
-        Object.values(this.address)
-          .filter((string) => string)
-          .join('<br>'),
-      ...(!this.agedOutOfProgrammes && {
-        yearGroup,
-        yearGroupWithRegistration:
-          this.registrationGroup && yearGroup
-            ? `${yearGroup} (${this.registrationGroup})`
-            : yearGroup,
-        schoolName: this?.school && this.school.name
-      }),
-      adjustments:
-        this.adjustments &&
-        formatList(
-          this.adjustments.filter(
-            (adjustment) => adjustment !== Adjustment.None
-          )
-        ),
-      impairments:
-        this.impairments &&
-        formatList(
-          this.impairments.filter(
-            (impairment) => impairment !== Impairment.None
-          )
-        )
-    }
+          switch (prop) {
+            case 'dob':
+              return formatDate(this.dob, { dateStyle: 'long' })
+            case 'dod':
+              return formatDate(this.dod, { dateStyle: 'long' })
+            case 'address':
+              return (
+                this?.address &&
+                Object.values(this.address).filter(Boolean).join('<br>')
+              )
+            case 'yearGroup':
+              if (this.agedOutOfProgrammes) return undefined
+              return getFormattedYearGroup()
+            case 'yearGroupWithRegistration': {
+              if (this.agedOutOfProgrammes) return undefined
+              const yearGroup = getFormattedYearGroup()
+              return this.registrationGroup && yearGroup
+                ? `${yearGroup} (${this.registrationGroup})`
+                : yearGroup
+            }
+            case 'schoolName':
+              if (this.agedOutOfProgrammes) return undefined
+              return this?.school && this.school.name
+            case 'adjustments':
+              return (
+                this.adjustments &&
+                formatList(
+                  this.adjustments.filter(
+                    (adjustment) => adjustment !== Adjustment.None
+                  )
+                )
+              )
+            case 'impairments':
+              return (
+                this.impairments &&
+                formatList(
+                  this.impairments.filter(
+                    (impairment) => impairment !== Impairment.None
+                  )
+                )
+              )
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/clinic-booking.js
+++ b/app/models/clinic-booking.js
@@ -110,9 +110,19 @@ export class ClinicBooking {
    * @returns {object} Formatted values
    */
   get formatted() {
-    return {
-      bookingReference: formatCode(this.bookingReference, true)
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'bookingReference':
+              return formatCode(this.bookingReference, true)
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/clinic-vaccination-period.js
+++ b/app/models/clinic-vaccination-period.js
@@ -118,16 +118,23 @@ export class ClinicVaccinationPeriod {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const startAndEndTimes = `${this.startAt_.hour}:${this.startAt_.minute} to ${this.endAt_.hour}:${this.endAt_.minute}`
-    const vaccinators =
-      this.vaccinatorCount === 1
-        ? '1 vaccinator'
-        : `${this.vaccinatorCount} vaccinators`
-
-    return {
-      startAndEndTimes,
-      vaccinators
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'startAndEndTimes':
+              return `${this.startAt_.hour}:${this.startAt_.minute} to ${this.endAt_.hour}:${this.endAt_.minute}`
+            case 'vaccinators':
+              return this.vaccinatorCount === 1
+                ? '1 vaccinator'
+                : `${this.vaccinatorCount} vaccinators`
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -89,12 +89,23 @@ export class Contact {
    * @returns {object} Formatted values
    */
   get formatted() {
-    return {
-      contactPreference:
-        this.contactPreferenceDetails || this.contactPreference,
-      fullName: this.fullName || 'Name unknown',
-      relationship: formatOther(this.relationshipOther, this.relationship)
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'contactPreference':
+              return this.contactPreferenceDetails || this.contactPreference
+            case 'fullName':
+              return this.fullName || 'Name unknown'
+            case 'relationship':
+              return formatOther(this.relationshipOther, this.relationship)
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/download.js
+++ b/app/models/download.js
@@ -426,38 +426,57 @@ export class Download {
    * @returns {object} Formatted values
    */
   get formatted() {
-    return {
-      createdAt: formatDate(this.createdAt, {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        hour12: true
-      }),
-      createdBy: this.createdBy?.fullName,
-      startAt: this.startAt && formatDate(this.startAt, { dateStyle: 'long' }),
-      endAt: this.endAt && formatDate(this.endAt, { dateStyle: 'long' }),
-      startEndAt:
-        this.startAt &&
-        this.endAt &&
-        new Intl.DateTimeFormat('en', {
-          dateStyle: 'long'
-        }).formatRange(this.startAt, this.endAt),
-      status:
-        this.status === DownloadStatus.Processing
-          ? formatProgress(this.progress)
-          : formatTag(getDownloadStatus(this.status)),
-      programme: this.programme?.nameTag,
-      teams:
-        this.teams?.length > 0
-          ? formatList(this.teams.map(({ name }) => name))
-          : this.teams.length,
-      vaccinations: `${this.vaccinations?.length} records`,
-      ...(this.type === DownloadType.Session && {
-        recordOffline: this.recordOffline === true ? 'Yes' : 'No'
-      })
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'createdAt':
+              return formatDate(this.createdAt, {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+              })
+            case 'createdBy':
+              return this.createdBy?.fullName
+            case 'startAt':
+              return (
+                this.startAt && formatDate(this.startAt, { dateStyle: 'long' })
+              )
+            case 'endAt':
+              return this.endAt && formatDate(this.endAt, { dateStyle: 'long' })
+            case 'startEndAt':
+              return (
+                this.startAt &&
+                this.endAt &&
+                new Intl.DateTimeFormat('en', {
+                  dateStyle: 'long'
+                }).formatRange(this.startAt, this.endAt)
+              )
+            case 'status':
+              return this.status === DownloadStatus.Processing
+                ? formatProgress(this.progress)
+                : formatTag(getDownloadStatus(this.status))
+            case 'programme':
+              return this.programme?.nameTag
+            case 'teams':
+              return this.teams?.length > 0
+                ? formatList(this.teams.map(({ name }) => name))
+                : this.teams.length
+            case 'vaccinations':
+              return `${this.vaccinations?.length} records`
+            case 'recordOffline':
+              if (this.type !== DownloadType.Session) return undefined
+              return this.recordOffline === true ? 'Yes' : 'No'
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/location.js
+++ b/app/models/location.js
@@ -125,26 +125,35 @@ export class Location {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const address =
-      this.address &&
-      Object.values(this.address)
-        .filter((string) => string)
-        .join(', ')
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          const getAddress = () =>
+            this.address &&
+            Object.values(this.address).filter(Boolean).join(', ')
 
-    return {
-      address,
-      location: Object.values(this.location)
-        .filter((string) => string)
-        .join(', '),
-      nameAndAddress: this.address
-        ? `<span>${this.name}</br>
-            <span class="nhsuk-u-secondary-text-colour">${address}</span>
+          switch (prop) {
+            case 'address':
+              return getAddress()
+            case 'location':
+              return Object.values(this.location).filter(Boolean).join(', ')
+            case 'nameAndAddress':
+              return this.address
+                ? `<span>${this.name}</br>
+            <span class="nhsuk-u-secondary-text-colour">${getAddress()}</span>
           </span>`
-        : this.name,
-      programmes: this.programmes
-        .flatMap((programme) => programme?.nameTag)
-        .join(' ')
-    }
+                : this.name
+            case 'programmes':
+              return this.programmes
+                .flatMap((programme) => programme?.nameTag)
+                .join(' ')
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/move.js
+++ b/app/models/move.js
@@ -69,14 +69,27 @@ export class Move {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const team = Team.findOne(this.team_id, this.context)
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          const getTeam = () => Team.findOne(this.team_id, this.context)
 
-    return {
-      createdAt: formatDate(this.createdAt, { dateStyle: 'long' }),
-      team_id: this.team_id ? team.name : 'Unknown team',
-      from_urn: schools[this.from_urn]?.name || 'Unknown school',
-      to_urn: schools[this.to_urn]?.name || 'Unknown school'
-    }
+          switch (prop) {
+            case 'createdAt':
+              return formatDate(this.createdAt, { dateStyle: 'long' })
+            case 'team_id':
+              return this.team_id ? getTeam()?.name : 'Unknown team'
+            case 'from_urn':
+              return schools[this.from_urn]?.name || 'Unknown school'
+            case 'to_urn':
+              return schools[this.to_urn]?.name || 'Unknown school'
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/notice.js
+++ b/app/models/notice.js
@@ -50,9 +50,19 @@ export class Notice {
    * @returns {object} Formatted values
    */
   get formatted() {
-    return {
-      createdAt: formatDate(this.createdAt, { dateStyle: 'long' })
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'createdAt':
+              return formatDate(this.createdAt, { dateStyle: 'long' })
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -596,18 +596,36 @@ export class PatientProgramme {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const status = formatTag(getPatientStatus(this.status, this.vaccinationDue))
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          const getStatusTag = () =>
+            formatTag(getPatientStatus(this.status, this.vaccinationDue))
 
-    return {
-      doseDue: ordinal(this.doseDue),
-      status,
-      statusWithNotes: formatWithSecondaryText(status, this.statusNotes, false),
-      programmeStatus: formatProgrammeStatus(
-        this.programme,
-        getPatientStatus(this.status, this.vaccinationDue),
-        this.statusNotes
-      )
-    }
+          switch (prop) {
+            case 'doseDue':
+              return ordinal(this.doseDue)
+            case 'status':
+              return getStatusTag()
+            case 'statusWithNotes':
+              return formatWithSecondaryText(
+                getStatusTag(),
+                this.statusNotes,
+                false
+              )
+            case 'programmeStatus':
+              return formatProgrammeStatus(
+                this.programme,
+                getPatientStatus(this.status, this.vaccinationDue),
+                this.statusNotes
+              )
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -947,33 +947,55 @@ export class PatientSession {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const outstandingVaccinations = this.outstandingVaccinations?.map(
-      (vaccination) => vaccination.programme?.name
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'programme':
+              return this.programme?.nameTag
+            case 'consent':
+              return this.consent && formatTag(this.status.consent)
+            case 'screen':
+              return this.screen && formatTag(this.status.screen)
+            case 'instruct':
+              return (
+                this.session?.psdProtocol && formatTag(this.status.instruct)
+              )
+            case 'register':
+              return formatTag(this.status.register)
+            case 'outcome':
+              return this.outcome && formatTag(this.status.outcome)
+            case 'report':
+              return this.patientProgramme?.formatted.programmeStatus
+            case 'outstandingVaccinations': {
+              const outstanding = this.outstandingVaccinations?.map(
+                (vaccination) => vaccination.programme?.name
+              )
+              return filters.formatList(outstanding)
+            }
+            case 'vaccineCriteria':
+              return formatVaccineCriteria(this.vaccineCriteria)
+            case 'yearGroup': {
+              let formattedYearGroup = formatYearGroup(this.yearGroup)
+              formattedYearGroup += this.patient?.registrationGroup
+                ? `, ${this.patient?.registrationGroup}`
+                : ''
+              formattedYearGroup += ` (${AcademicYear[this.session.academicYear]} academic year)`
+              return formattedYearGroup
+            }
+            case 'creationTime':
+              return formatDate(this.createdAt, {
+                hour: 'numeric',
+                minute: 'numeric',
+                hour12: true
+              })
+            default:
+              return undefined
+          }
+        }
+      }
     )
-
-    let formattedYearGroup = formatYearGroup(this.yearGroup)
-    formattedYearGroup += this.patient?.registrationGroup
-      ? `, ${this.patient?.registrationGroup}`
-      : ''
-    formattedYearGroup += ` (${AcademicYear[this.session.academicYear]} academic year)`
-
-    return {
-      programme: this.programme?.nameTag,
-      consent: this.consent && formatTag(this.status.consent),
-      screen: this.screen && formatTag(this.status.screen),
-      instruct: this.session?.psdProtocol && formatTag(this.status.instruct),
-      register: formatTag(this.status.register),
-      outcome: this.outcome && formatTag(this.status.outcome),
-      report: this.patientProgramme?.formatted.programmeStatus,
-      outstandingVaccinations: filters.formatList(outstandingVaccinations),
-      vaccineCriteria: formatVaccineCriteria(this.vaccineCriteria),
-      yearGroup: formattedYearGroup,
-      creationTime: formatDate(this.createdAt, {
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: true
-      })
-    }
   }
 
   /**

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -497,26 +497,43 @@ export class Patient extends Child {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const formattedNhsn = formatNhsNumber(this.nhsn, this.invalid)
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          const getFormattedNhsn = () =>
+            formatNhsNumber(this.nhsn, this.invalid)
 
-    return {
-      ...super.formatted,
-      fullNameAndNhsn: formatWithSecondaryText(this.fullName, formattedNhsn),
-      nhsn: formattedNhsn,
-      newUrn:
-        this.pendingChanges?.school_id &&
-        schools[this.pendingChanges.school_id].name,
-      archiveReason: formatOther(this.archiveReasonOther, this.archiveReason),
-      lastReminderDate: this.lastReminderDate
-        ? `Last reminder sent on ${this.lastReminderDate}`
-        : 'No reminders sent',
-      clinicProgramme_ids: this.clinicProgramme_ids
-        .map((id) => this.programmes[id].programme.nameTag)
-        .join(' '),
-      contacts: formatList(
-        this.contacts.map((contact) => contact.fullNameAndRelationship)
-      )
-    }
+          switch (prop) {
+            case 'fullNameAndNhsn':
+              return formatWithSecondaryText(this.fullName, getFormattedNhsn())
+            case 'nhsn':
+              return getFormattedNhsn()
+            case 'newUrn':
+              return (
+                this.pendingChanges?.school_id &&
+                schools[this.pendingChanges.school_id].name
+              )
+            case 'archiveReason':
+              return formatOther(this.archiveReasonOther, this.archiveReason)
+            case 'lastReminderDate':
+              return this.lastReminderDate
+                ? `Last reminder sent on ${this.lastReminderDate}`
+                : 'No reminders sent'
+            case 'clinicProgramme_ids':
+              return this.clinicProgramme_ids
+                .map((id) => this.programmes[id].programme.nameTag)
+                .join(' ')
+            case 'contacts':
+              return formatList(
+                this.contacts.map((contact) => contact.fullNameAndRelationship)
+              )
+            default:
+              return super.formatted?.[prop]
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/pds-record.js
+++ b/app/models/pds-record.js
@@ -98,17 +98,30 @@ export class PDSRecord extends Child {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const formattedNhsn = formatNhsNumber(this.nhsn, this.invalid)
-    const formattedContacts = this.contacts.map((contact) =>
-      formatContact(contact)
-    )
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          const getFormattedNhsn = () =>
+            formatNhsNumber(this.nhsn, this.invalid)
 
-    return {
-      ...super.formatted,
-      fullNameAndNhsn: formatWithSecondaryText(this.fullName, formattedNhsn),
-      nhsn: formattedNhsn,
-      contacts: formatList(formattedContacts)
-    }
+          switch (prop) {
+            case 'fullNameAndNhsn':
+              return formatWithSecondaryText(this.fullName, getFormattedNhsn())
+            case 'nhsn':
+              return getFormattedNhsn()
+            case 'contacts': {
+              const formattedContacts = this.contacts.map((contact) =>
+                formatContact(contact)
+              )
+              return formatList(formattedContacts)
+            }
+            default:
+              return super.formatted?.[prop]
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -217,29 +217,40 @@ export class Programme {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const vaccineList = Array.isArray(this.vaccine_snomeds)
-      ? this.vaccine_snomeds.map(
-          (snomed) => new Vaccine(vaccines[snomed]).brand
-        )
-      : []
-
-    const yearGroups = this.yearGroups.map((yearGroup) =>
-      formatYearGroup(yearGroup)
-    )
-
-    return {
-      consentPdf:
-        this.consentPdf &&
-        formatLink(
-          this.consentPdf,
-          `Download the ${this.name} consent form (PDF)`,
-          {
-            download: 'true'
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'consentPdf':
+              return (
+                this.consentPdf &&
+                formatLink(
+                  this.consentPdf,
+                  `Download the ${this.name} consent form (PDF)`,
+                  { download: 'true' }
+                )
+              )
+            case 'yearGroups': {
+              const formattedYearGroups = this.yearGroups.map((yearGroup) =>
+                formatYearGroup(yearGroup)
+              )
+              return prototypeFilters.formatList(formattedYearGroups)
+            }
+            case 'vaccines': {
+              const vaccineList = Array.isArray(this.vaccine_snomeds)
+                ? this.vaccine_snomeds.map(
+                    (snomed) => new Vaccine(vaccines[snomed]).brand
+                  )
+                : []
+              return vaccineList.join('<br>')
+            }
+            default:
+              return undefined
           }
-        ),
-      yearGroups: prototypeFilters.formatList(yearGroups),
-      vaccines: vaccineList.join('<br>')
-    }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -459,47 +459,71 @@ export class Reply {
    * @returns {object} Formatted values
    */
   get formatted() {
-    let decisionStatus = formatTag(getReplyDecisionStatus(this.decision))
-    if (!this.delivered) {
-      decisionStatus = formatTag(
-        getConsentOutcomeStatus(ConsentOutcome.NotDelivered)
-      )
-    } else if (this.invalid) {
-      decisionStatus = formatWithSecondaryText(
-        formatTag({
-          colour: 'grey',
-          html: `<s>${this.decision}</s>`
-        }),
-        'Invalid',
-        false
-      )
-    } else if (this.confirmed) {
-      decisionStatus = formatWithSecondaryText(
-        decisionStatus,
-        'Confirmed',
-        false
-      )
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          const getDecisionStatus = () => {
+            let decisionStatus = formatTag(
+              getReplyDecisionStatus(this.decision)
+            )
+            if (!this.delivered) {
+              decisionStatus = formatTag(
+                getConsentOutcomeStatus(ConsentOutcome.NotDelivered)
+              )
+            } else if (this.invalid) {
+              decisionStatus = formatWithSecondaryText(
+                formatTag({
+                  colour: 'grey',
+                  html: `<s>${this.decision}</s>`
+                }),
+                'Invalid',
+                false
+              )
+            } else if (this.confirmed) {
+              decisionStatus = formatWithSecondaryText(
+                decisionStatus,
+                'Confirmed',
+                false
+              )
+            }
+            return decisionStatus
+          }
 
-    return {
-      createdAt: formatDate(this.createdAt, {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        hour12: true
-      }),
-      createdBy: this.createdBy?.fullName || '',
-      decisionStatus,
-      contact: formatContact(this.contact, true),
-      tel: this.contact && this.contact.tel,
-      email: this.contact && this.contact.email,
-      programme: this.programme?.nameTag,
-      refusalReason: formatOther(this.refusalReasonOther, this.refusalReason),
-      refusalReasonDetails: formatMarkdown(this.refusalReasonDetails),
-      note: formatMarkdown(this.note)
-    }
+          switch (prop) {
+            case 'createdAt':
+              return formatDate(this.createdAt, {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+              })
+            case 'createdBy':
+              return this.createdBy?.fullName || ''
+            case 'decisionStatus':
+              return getDecisionStatus()
+            case 'contact':
+              return formatContact(this.contact, true)
+            case 'tel':
+              return this.contact && this.contact.tel
+            case 'email':
+              return this.contact && this.contact.email
+            case 'programme':
+              return this.programme?.nameTag
+            case 'refusalReason':
+              return formatOther(this.refusalReasonOther, this.refusalReason)
+            case 'refusalReasonDetails':
+              return formatMarkdown(this.refusalReasonDetails)
+            case 'note':
+              return formatMarkdown(this.note)
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -263,21 +263,43 @@ export class School extends Location {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const id = formatCode(this.id)
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          const getId = () => formatCode(this.id)
 
-    return {
-      ...super.formatted,
-      urn: formatCode(this.urn),
-      id,
-      openAt: this.openAt && formatDate(this.openAt, { dateStyle: 'long' }),
-      closeAt: this.closeAt && formatDate(this.closeAt, { dateStyle: 'long' }),
-      nameAndUrn: `${this.name} (${id})`,
-      nextSessionDate: formatDate(this.nextSessionDate, { dateStyle: 'full' }),
-      patients: filters.plural(this.patients.length, 'child'),
-      site: formatCode(this.site),
-      status: this.status && formatTag(getSchoolStatus(this.status)),
-      yearGroups: formatYearGroups(this.yearGroups)
-    }
+          switch (prop) {
+            case 'urn':
+              return formatCode(this.urn)
+            case 'id':
+              return getId()
+            case 'openAt':
+              return (
+                this.openAt && formatDate(this.openAt, { dateStyle: 'long' })
+              )
+            case 'closeAt':
+              return (
+                this.closeAt && formatDate(this.closeAt, { dateStyle: 'long' })
+              )
+            case 'nameAndUrn':
+              return `${this.name} (${getId()})`
+            case 'nextSessionDate':
+              return formatDate(this.nextSessionDate, { dateStyle: 'full' })
+            case 'patients':
+              return filters.plural(this.patients.length, 'child')
+            case 'site':
+              return formatCode(this.site)
+            case 'status':
+              return this.status && formatTag(getSchoolStatus(this.status))
+            case 'yearGroups':
+              return formatYearGroups(this.yearGroups)
+            default:
+              return super.formatted?.[prop]
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -1049,126 +1049,163 @@ export class Session {
    * @returns {object} Formatted values
    */
   get formatted() {
-    let consentWindow
-    let consentWindowSentence
-    const consentDateStyle = { day: 'numeric', month: 'long' }
-    switch (this.consentWindow) {
-      case ConsentWindow.Opening:
-        consentWindow = `Opens ${formatDate(this.openAt, consentDateStyle)}`
-        consentWindowSentence = `Consent window opens on ${formatDate(this.openAt, consentDateStyle)}.`
-        break
-      case ConsentWindow.Closed:
-        consentWindow = `Closed ${formatDate(this.closeAt, consentDateStyle)}`
-        consentWindowSentence = `Consent window closed on ${formatDate(this.closeAt, consentDateStyle)}.`
-        break
-      case ConsentWindow.Open:
-        consentWindow = `Open from ${formatDate(this.openAt, consentDateStyle)} until ${formatDate(this.closeAt, consentDateStyle)}`
-        consentWindowSentence = `Consent window is open from ${formatDate(this.openAt, consentDateStyle)} until ${formatDate(this.closeAt, consentDateStyle)}.`
-        break
-      default:
-        consentWindow = ''
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          // Shared configuration
+          const consentDateStyle = { day: 'numeric', month: 'long' }
 
-    const nextReminderDate = formatDate(this.nextReminderDate, {
-      dateStyle: 'full'
-    })
+          // Lazily format consent window values
+          const getConsentWindowData = () => {
+            let consentWindow = ''
+            let consentWindowSentence = ''
 
-    const reminderWeeks = filters.plural(this.reminderWeeks, 'week')
-
-    let startAndEndTimes, vaccinatorCounts, totalAppointments
-    if (this.type === SessionType.Clinic) {
-      startAndEndTimes = ''
-      vaccinatorCounts = ''
-      totalAppointments = 0
-
-      let lastVaccinatorCount = -1
-      let hasVariableVaccinatorCounts = false
-      this.vaccinationPeriods.forEach((vaccinationPeriod, periodIndex) => {
-        const thisPeriod = vaccinationPeriod.formatted.startAndEndTimes
-        const thisVaccinatorCount = vaccinationPeriod.vaccinatorCount || 0
-
-        startAndEndTimes += thisPeriod
-        vaccinatorCounts += `${thisVaccinatorCount} from ${thisPeriod}`
-        if (periodIndex < this.vaccinationPeriods.length - 1) {
-          startAndEndTimes += '<br>'
-          vaccinatorCounts += '<br>'
-        }
-
-        hasVariableVaccinatorCounts =
-          hasVariableVaccinatorCounts ||
-          (lastVaccinatorCount !== -1 &&
-            lastVaccinatorCount !== thisVaccinatorCount)
-        lastVaccinatorCount = thisVaccinatorCount
-
-        totalAppointments += vaccinationPeriod.appointmentCount(
-          this.appointmentLength
-        )
-      })
-      if (!hasVariableVaccinatorCounts) {
-        vaccinatorCounts = lastVaccinatorCount.toString()
-      }
-    }
-
-    return {
-      address:
-        this.address &&
-        Object.values(this.address)
-          .filter((string) => string)
-          .join('<br>'),
-      dateShort: formatDate(this.date, {
-        dateStyle: 'long'
-      }),
-      date: formatDate(this.date, {
-        dateStyle: 'full'
-      }),
-      nextDate: formatDate(this.date, {
-        weekday: 'long',
-        month: 'long',
-        day: 'numeric'
-      }),
-      openAt: formatDate(this.openAt, {
-        dateStyle: 'full'
-      }),
-      reminderDate: formatDate(this.reminderDate, {
-        dateStyle: 'full'
-      }),
-      nextReminderDate,
-      reminderWeeks: nextReminderDate
-        ? formatWithSecondaryText(
-            `Send ${reminderWeeks} before each session`,
-            `First: ${nextReminderDate}`
-          )
-        : `Send ${reminderWeeks} before each session`,
-      closeAt: formatDate(this.closeAt, { dateStyle: 'full' }),
-      patients: filters.plural(this.patients.length, 'child'),
-      consents:
-        this.consents.length > 0
-          ? filters.plural(this.consents.length, 'child')
-          : undefined,
-      programmes: this.programmes.flatMap(({ nameTag }) => nameTag).join(' '),
-      consentUrl:
-        this.consentUrl &&
-        formatLink(
-          this.consentUrl,
-          'View the online consent form (opens in new tab)',
-          {
-            target: '_blank'
+            switch (this.consentWindow) {
+              case ConsentWindow.Opening:
+                consentWindow = `Opens ${formatDate(this.openAt, consentDateStyle)}`
+                consentWindowSentence = `Consent window opens on ${formatDate(this.openAt, consentDateStyle)}.`
+                break
+              case ConsentWindow.Closed:
+                consentWindow = `Closed ${formatDate(this.closeAt, consentDateStyle)}`
+                consentWindowSentence = `Consent window closed on ${formatDate(this.closeAt, consentDateStyle)}.`
+                break
+              case ConsentWindow.Open:
+                consentWindow = `Open from ${formatDate(this.openAt, consentDateStyle)} until ${formatDate(this.closeAt, consentDateStyle)}`
+                consentWindowSentence = `Consent window is open from ${formatDate(this.openAt, consentDateStyle)} until ${formatDate(this.closeAt, consentDateStyle)}.`
+                break
+            }
+            return { consentWindow, consentWindowSentence }
           }
-        ),
-      consentWindow,
-      consentWindowSentence,
-      location: Object.values(this.location)
-        .filter((string) => string)
-        .join(', '),
-      clinic: this.clinic && this.clinic.name,
-      school: this.school && this.school.name,
-      school_id: this.school && this.school.formatted.id,
-      yearGroups: this.yearGroups && formatYearGroups(this.yearGroups),
-      vaccinationPeriods: startAndEndTimes,
-      vaccinators: vaccinatorCounts,
-      totalAppointments,
-      appointmentLength: `${this.appointmentLength} minutes`
-    }
+
+          // Lazily harvest various things from the vaccination periods
+          const getVaccinationPeriodData = () => {
+            let startAndEndTimes = ''
+            let vaccinatorCounts = ''
+            let totalAppointments = 0
+
+            if (this.type === SessionType.Clinic) {
+              let lastVaccinatorCount = -1
+              let hasVariableVaccinatorCounts = false
+
+              this.vaccinationPeriods.forEach(
+                (vaccinationPeriod, periodIndex) => {
+                  const thisPeriod =
+                    vaccinationPeriod.formatted.startAndEndTimes
+                  const thisVaccinatorCount =
+                    vaccinationPeriod.vaccinatorCount || 0
+
+                  startAndEndTimes += thisPeriod
+                  vaccinatorCounts += `${thisVaccinatorCount} from ${thisPeriod}`
+                  if (periodIndex < this.vaccinationPeriods.length - 1) {
+                    startAndEndTimes += '<br>'
+                    vaccinatorCounts += '<br>'
+                  }
+
+                  hasVariableVaccinatorCounts =
+                    hasVariableVaccinatorCounts ||
+                    (lastVaccinatorCount !== -1 &&
+                      lastVaccinatorCount !== thisVaccinatorCount)
+                  lastVaccinatorCount = thisVaccinatorCount
+
+                  totalAppointments += vaccinationPeriod.appointmentCount(
+                    this.appointmentLength
+                  )
+                }
+              )
+
+              if (!hasVariableVaccinatorCounts) {
+                vaccinatorCounts = lastVaccinatorCount.toString()
+              }
+            }
+
+            return { startAndEndTimes, vaccinatorCounts, totalAppointments }
+          }
+
+          switch (prop) {
+            case 'address':
+              return (
+                this.address &&
+                Object.values(this.address).filter(Boolean).join('<br>')
+              )
+            case 'dateShort':
+              return formatDate(this.date, { dateStyle: 'long' })
+            case 'date':
+              return formatDate(this.date, { dateStyle: 'full' })
+            case 'nextDate':
+              return formatDate(this.date, {
+                weekday: 'long',
+                month: 'long',
+                day: 'numeric'
+              })
+            case 'openAt':
+              return formatDate(this.openAt, { dateStyle: 'full' })
+            case 'reminderDate':
+              return formatDate(this.reminderDate, { dateStyle: 'full' })
+            case 'nextReminderDate':
+              return formatDate(this.nextReminderDate, { dateStyle: 'full' })
+            case 'reminderWeeks': {
+              const nextReminder = formatDate(this.nextReminderDate, {
+                dateStyle: 'full'
+              })
+              const reminderWeeksText = filters.plural(
+                this.reminderWeeks,
+                'week'
+              )
+              return nextReminder
+                ? formatWithSecondaryText(
+                    `Send ${reminderWeeksText} before each session`,
+                    `First: ${nextReminder}`
+                  )
+                : `Send ${reminderWeeksText} before each session`
+            }
+            case 'closeAt':
+              return formatDate(this.closeAt, { dateStyle: 'full' })
+            case 'patients':
+              return filters.plural(this.patients.length, 'child')
+            case 'consents':
+              return this.consents.length > 0
+                ? filters.plural(this.consents.length, 'child')
+                : undefined
+            case 'programmes':
+              return this.programmes.flatMap(({ nameTag }) => nameTag).join(' ')
+            case 'consentUrl':
+              return (
+                this.consentUrl &&
+                formatLink(
+                  this.consentUrl,
+                  'View the online consent form (opens in new tab)',
+                  { target: '_blank' }
+                )
+              )
+            case 'consentWindow':
+              return getConsentWindowData().consentWindow
+            case 'consentWindowSentence':
+              return getConsentWindowData().consentWindowSentence
+            case 'location':
+              return Object.values(this.location).filter(Boolean).join(', ')
+            case 'clinic':
+              return this.clinic && this.clinic.name
+            case 'school':
+              return this.school && this.school.name
+            case 'school_id':
+              return this.school && this.school.formatted.id
+            case 'yearGroups':
+              return this.yearGroups && formatYearGroups(this.yearGroups)
+            case 'vaccinationPeriods':
+              return getVaccinationPeriodData().startAndEndTimes
+            case 'vaccinators':
+              return getVaccinationPeriodData().vaccinatorCounts
+            case 'totalAppointments':
+              return getVaccinationPeriodData().totalAppointments
+            case 'appointmentLength':
+              return `${this.appointmentLength} minutes`
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/team.js
+++ b/app/models/team.js
@@ -98,30 +98,41 @@ export class Team {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const sessionOpenWeeks = prototypeFilters.plural(
-      this.sessionOpenWeeks,
-      'week'
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'sessionOpenWeeks': {
+              const weeks = prototypeFilters.plural(
+                this.sessionOpenWeeks,
+                'week'
+              )
+              return `Send ${weeks} before first session`
+            }
+            case 'sessionReminderWeeks': {
+              const weeks = prototypeFilters.plural(
+                this.sessionReminderWeeks,
+                'week'
+              )
+              return `Send ${weeks} before each session`
+            }
+            case 'nasalSprayDuration':
+              return prototypeFilters.plural(
+                this.clinicNasalSprayDuration,
+                'minute'
+              )
+            case 'injectionDuration':
+              return prototypeFilters.plural(
+                this.clinicInjectionDuration,
+                'minute'
+              )
+            default:
+              return undefined
+          }
+        }
+      }
     )
-    const sessionReminderWeeks = prototypeFilters.plural(
-      this.sessionReminderWeeks,
-      'week'
-    )
-
-    const nasalSprayDuration = prototypeFilters.plural(
-      this.clinicNasalSprayDuration,
-      'minute'
-    )
-    const injectionDuration = prototypeFilters.plural(
-      this.clinicInjectionDuration,
-      'minute'
-    )
-
-    return {
-      sessionOpenWeeks: `Send ${sessionOpenWeeks} before first session`,
-      sessionReminderWeeks: `Send ${sessionReminderWeeks} before each session`,
-      nasalSprayDuration,
-      injectionDuration
-    }
   }
 
   /**

--- a/app/models/upload.js
+++ b/app/models/upload.js
@@ -214,46 +214,69 @@ export class Upload {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const yearGroups = this.yearGroups?.map((item) => formatYearGroup(item))
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          // Lazy formatting of timestamps
+          const getCreatedAt = () =>
+            formatDate(this.createdAt, {
+              day: 'numeric',
+              month: 'long',
+              year: 'numeric',
+              hour: 'numeric',
+              minute: '2-digit',
+              hour12: true
+            })
 
-    const createdAt = formatDate(this.createdAt, {
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true
-    })
-    const updatedAt = formatDate(this.updatedAt, {
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true
-    })
+          const getUpdatedAt = () =>
+            formatDate(this.updatedAt, {
+              day: 'numeric',
+              month: 'long',
+              year: 'numeric',
+              hour: 'numeric',
+              minute: '2-digit',
+              hour12: true
+            })
 
-    return {
-      createdAt,
-      createdBy: this.createdBy?.fullName,
-      created: `${createdAt} by ${this.createdBy?.fullName}`,
-      updatedAt,
-      updatedBy: this.updatedBy?.fullName,
-      updated: this.updatedAt && `${updatedAt} by ${this.updatedBy?.fullName}`,
-      ...(this.type === UploadType.School && {
-        school: this.school?.name,
-        yearGroups: prototypeFilters.formatList(yearGroups)
-      }),
-      ...(this.type === UploadType.School && {
-        school: this.school?.name,
-        yearGroups: prototypeFilters.formatList(yearGroups)
-      }),
-      patients: this.patients.length,
-      status:
-        this.status === UploadStatus.Processing
-          ? formatProgress(this.progress)
-          : formatTag(getUploadStatus(this.status))
-    }
+          switch (prop) {
+            case 'createdAt':
+              return getCreatedAt()
+            case 'createdBy':
+              return this.createdBy?.fullName
+            case 'created':
+              return `${getCreatedAt()} by ${this.createdBy?.fullName}`
+            case 'updatedAt':
+              return getUpdatedAt()
+            case 'updatedBy':
+              return this.updatedBy?.fullName
+            case 'updated':
+              return (
+                this.updatedAt &&
+                `${getUpdatedAt()} by ${this.updatedBy?.fullName}`
+              )
+            case 'school':
+              if (this.type !== UploadType.School) return undefined
+              return this.school?.name
+            case 'yearGroups': {
+              if (this.type !== UploadType.School) return undefined
+              const yearGroups = this.yearGroups?.map((item) =>
+                formatYearGroup(item)
+              )
+              return prototypeFilters.formatList(yearGroups)
+            }
+            case 'patients':
+              return this.patients.length
+            case 'status':
+              return this.status === UploadStatus.Processing
+                ? formatProgress(this.progress)
+                : formatTag(getUploadStatus(this.status))
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -56,9 +56,19 @@ export class User {
    * @returns {object} Formatted values
    */
   get formatted() {
-    return {
-      uid: formatCode(this.uid)
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'uid':
+              return formatCode(this.uid)
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/vaccination.js
+++ b/app/models/vaccination.js
@@ -489,88 +489,121 @@ export class Vaccination {
    * @returns {object} Formatted values
    */
   get formatted() {
-    const programme = this.variant
-      ? formatTag({
-          text: this.programmeOrVariantName,
-          colour: 'transparent'
-        })
-      : this.programme?.nameTag
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          const getProgrammeTag = () => {
+            return this.variant
+              ? formatTag({
+                  text: this.programmeOrVariantName,
+                  colour: 'transparent'
+                })
+              : this.programme?.nameTag
+          }
 
-    return {
-      createdAt: formatDate(this.createdAt, {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        hour12: true
-      }),
-      createdAt_date: formatDate(this.createdAt, {
-        dateStyle: 'long'
-      }),
-      createdAt_time: formatDate(this.createdAt, {
-        hour: 'numeric',
-        minute: '2-digit',
-        hour12: true
-      }),
-      createdAt_dateShort: formatDate(this.createdAt, {
-        day: 'numeric',
-        month: 'short',
-        year: 'numeric'
-      }),
-      createdBy: this.createdBy?.fullName || 'Unknown',
-      suppliedBy: this.suppliedBy?.fullName || '',
-      updatedAt: formatDate(this.updatedAt, {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        hour12: true
-      }),
-      reportedAt:
-        this.reportedAt &&
-        formatDate(this.reportedAt, {
-          day: 'numeric',
-          month: 'long',
-          year: 'numeric',
-          hour: 'numeric',
-          minute: '2-digit',
-          hour12: true
-        }),
-      reportedBy: (this.reportedBy && this.reportedBy?.fullName) || '',
-      syncStatus: formatWithSecondaryText(
-        formatTag(getVaccinationSyncStatus(this.syncStatus)),
-        this.syncStatusNotes,
-        true
-      ),
-      batch: this.batch?.summary,
-      batch_id: formatCode(this.batch_id),
-      dose: formatMillilitres(this.dose),
-      sequence: this.sequence && formatSequence(this.sequence),
-      vaccine_snomed: this.vaccine_snomed ? this.vaccine?.brand : 'Unknown',
-      note: formatMarkdown(this.note),
-      outcome: formatTag(getVaccinationOutcomeStatus(this.outcome)),
-      programme: this.programmeOther || programme,
-      programmeWithSequence:
-        this.programmeOther ||
-        formatWithSecondaryText(
-          programme,
-          formatSequence(this.sequence),
-          false
-        ),
-      location:
-        (this?.location &&
-          Object.values(this.location)
-            .filter((string) => string)
-            .join(', ')) ||
-        'Unknown',
-      country: this.countryOther || this.country || 'England',
-      school: this.school && this.school.name,
-      identifiedBy: this.selfId
-        ? 'The child'
-        : formatIdentifier(this.identifiedBy)
-    }
+          switch (prop) {
+            case 'createdAt':
+              return formatDate(this.createdAt, {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+              })
+            case 'createdAt_date':
+              return formatDate(this.createdAt, { dateStyle: 'long' })
+            case 'createdAt_time':
+              return formatDate(this.createdAt, {
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+              })
+            case 'createdAt_dateShort':
+              return formatDate(this.createdAt, {
+                day: 'numeric',
+                month: 'short',
+                year: 'numeric'
+              })
+            case 'createdBy':
+              return this.createdBy?.fullName || 'Unknown'
+            case 'suppliedBy':
+              return this.suppliedBy?.fullName || ''
+            case 'updatedAt':
+              return formatDate(this.updatedAt, {
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit',
+                hour12: true
+              })
+            case 'reportedAt':
+              return (
+                this.reportedAt &&
+                formatDate(this.reportedAt, {
+                  day: 'numeric',
+                  month: 'long',
+                  year: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                  hour12: true
+                })
+              )
+            case 'reportedBy':
+              return this.reportedBy?.fullName || ''
+            case 'syncStatus':
+              return formatWithSecondaryText(
+                formatTag(getVaccinationSyncStatus(this.syncStatus)),
+                this.syncStatusNotes,
+                true
+              )
+            case 'batch':
+              return this.batch?.summary
+            case 'batch_id':
+              return formatCode(this.batch_id)
+            case 'dose':
+              return formatMillilitres(this.dose)
+            case 'sequence':
+              return this.sequence && formatSequence(this.sequence)
+            case 'vaccine_snomed':
+              return this.vaccine_snomed ? this.vaccine?.brand : 'Unknown'
+            case 'note':
+              return formatMarkdown(this.note)
+            case 'outcome':
+              return formatTag(getVaccinationOutcomeStatus(this.outcome))
+            case 'programme':
+              return this.programmeOther || getProgrammeTag()
+            case 'programmeWithSequence':
+              return (
+                this.programmeOther ||
+                formatWithSecondaryText(
+                  getProgrammeTag(),
+                  formatSequence(this.sequence),
+                  false
+                )
+              )
+            case 'location':
+              return (
+                (this?.location &&
+                  Object.values(this.location).filter(Boolean).join(', ')) ||
+                'Unknown'
+              )
+            case 'country':
+              return this.countryOther || this.country || 'England'
+            case 'school':
+              return this.school && this.school.name
+            case 'identifiedBy':
+              return this.selfId
+                ? 'The child'
+                : formatIdentifier(this.identifiedBy)
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**

--- a/app/models/vaccine.js
+++ b/app/models/vaccine.js
@@ -97,13 +97,27 @@ export class Vaccine {
    * @returns {object} Formatted values
    */
   get formatted() {
-    return {
-      snomed: formatCode(this.snomed),
-      healthQuestions: formatHealthQuestions(this.healthQuestions),
-      preScreenQuestions: formatList(this.preScreenQuestions),
-      sideEffects: formatList(this.sideEffects),
-      dose: formatMillilitres(this.dose)
-    }
+    return new Proxy(
+      {},
+      {
+        get: (_target, prop) => {
+          switch (prop) {
+            case 'snomed':
+              return formatCode(this.snomed)
+            case 'healthQuestions':
+              return formatHealthQuestions(this.healthQuestions)
+            case 'preScreenQuestions':
+              return formatList(this.preScreenQuestions)
+            case 'sideEffects':
+              return formatList(this.sideEffects)
+            case 'dose':
+              return formatMillilitres(this.dose)
+            default:
+              return undefined
+          }
+        }
+      }
+    )
   }
 
   /**


### PR DESCRIPTION
This is a performance optimisation that means we're not doing a whole load of value formatting for values that end up not being used by the caller. And it's completely transparent to the caller; the getters appear to behave exactly as before.