### PR TITLE
Dry out models

### DIFF
--- a/app/controllers/clinic.js
+++ b/app/controllers/clinic.js
@@ -45,13 +45,15 @@ export const clinicController = {
     const { data } = request.session
     const { __ } = response.locals
 
-    const clinic = Clinic.create(
+    let clinic = Clinic.create(
       {
         ...request.body.clinic,
         team_id
       },
       data
     )
+
+    clinic = Clinic.findOne(clinic.id, data)
 
     request.flash('success', __(`clinic.new.success`, { clinic }))
 

--- a/app/controllers/consent.js
+++ b/app/controllers/consent.js
@@ -43,6 +43,8 @@ export const consentController = {
   readAll(request, response, next) {
     const { session_id } = request.params
     const consents = Consent.findAll(request.session.data)
+      .filter((consent) => !consent.invalid)
+      .filter((consent) => !consent.patient_uuid)
 
     // Sort
     let results = _.sortBy(consents, 'createdAt')

--- a/app/controllers/move.js
+++ b/app/controllers/move.js
@@ -18,7 +18,9 @@ export const moveController = {
    * @type {RequestHandler<Record<string, string>>}
    */
   readAll(request, response, next) {
-    const moves = Move.findAll(request.session.data)
+    const moves = Move.findAll(request.session.data).filter(
+      (move) => !move.ignored
+    )
 
     // Sort
     let results = _.sortBy(moves, 'createdAt')

--- a/app/controllers/notice.js
+++ b/app/controllers/notice.js
@@ -1,4 +1,5 @@
 import { Notice } from '../models.js'
+import { getDateValueDifference } from '../utils/date.js'
 import { saveAndRedirect } from '../utils/redirect.js'
 
 export const noticeController = {
@@ -14,9 +15,9 @@ export const noticeController = {
   },
 
   readAll(request, response, next) {
-    response.locals.notices = Notice.findAll(request.session.data).filter(
-      ({ archivedAt }) => !archivedAt
-    )
+    response.locals.notices = Notice.findAll(request.session.data)
+      .filter(({ archivedAt }) => !archivedAt)
+      .sort((a, b) => getDateValueDifference(a.createdAt, b.createdAt))
 
     next()
   },

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -413,9 +413,7 @@ export const patientSessionController = {
       createdBy_uid: account.uid,
       session_id:
         type === AuditEventType.SessionNote && patientSession.session_id,
-      programme_ids:
-        type === AuditEventType.ProgrammeNote &&
-        programme_ids?.filter((programme_id) => programme_id !== '_unchecked')
+      programme_ids: type === AuditEventType.ProgrammeNote && programme_ids
     })
 
     // Clean up session data

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -356,16 +356,23 @@ export const patientController = {
     const { data, referrer } = request.session
     const { __, account } = response.locals
 
+    const patient = Patient.findOne(patient_uuid, data)
+
     // Update session data
-    const patient = Patient.update(
+    let updatedPatient = Patient.update(
       patient_uuid,
       {
-        ...data.wizard.patients[String(patient_uuid)],
-        ...{ createdBy_uid: account.uid }
+        ...data.wizard.patients[patient_uuid],
+        ...{ updatedBy_uid: account.uid }
       },
-      data,
-      true
+      data
     )
+
+    // Restore context to updated patient
+    updatedPatient = Patient.findOne(updatedPatient.uuid, data)
+
+    // Update activity log
+    updatedPatient.addAuditRecord(patient)
 
     // Clean up session data
     delete data.patient
@@ -373,7 +380,7 @@ export const patientController = {
 
     request.flash('success', __('patient.edit.success'))
 
-    return saveAndRedirect(request, response, referrer || patient.uri)
+    return saveAndRedirect(request, response, referrer || updatedPatient.uri)
   },
 
   /**

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -490,13 +490,7 @@ export const patientController = {
     const { data, referrer } = request.session
     const { __ } = response.locals
 
-    // Strip any _unchecked value from the selected programme IDs
-    let { clinicProgramme_ids } = request.body
-    if (typeof clinicProgramme_ids === 'string') {
-      clinicProgramme_ids = [clinicProgramme_ids]
-    } else {
-      clinicProgramme_ids = stringToArray(clinicProgramme_ids)
-    }
+    const clinicProgramme_ids = stringToArray(request.body.clinicProgramme_ids)
 
     // Send comms to contacts and record in audit trail
     const patient = Patient.findOne(patient_uuid, data)
@@ -608,18 +602,11 @@ export const patientController = {
    * @type {RequestHandler<Record<string, string>>}
    */
   inviteManyToClinic(request, response) {
-    let { clinicProgramme_ids } = request.body
     const { data } = request.session
     const { __mf } = response.locals
 
-    let clinicPatient_ids = stringToArray(data.clinicPatient_ids)
-
-    // Tidy up any _unchecked values
-    if (typeof clinicProgramme_ids === 'string') {
-      clinicProgramme_ids = [clinicProgramme_ids]
-    } else {
-      clinicProgramme_ids = stringToArray(clinicProgramme_ids)
-    }
+    const clinicPatient_ids = stringToArray(data.clinicPatient_ids)
+    const clinicProgramme_ids = stringToArray(request.body.clinicProgramme_ids)
 
     // Invite each of the children to clinic for the subset of the selected programmes
     // that make sense for that child

--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -6,7 +6,7 @@ import { Patient, School } from '../models.js'
 import { generateNewSiteCode } from '../utils/location.js'
 import { getResults, getPagination } from '../utils/pagination.js'
 import { saveAndRedirect } from '../utils/redirect.js'
-import { formatYearGroup } from '../utils/string.js'
+import { formatYearGroup, stringToArray } from '../utils/string.js'
 import { getFilterParams } from '../utils/url.js'
 
 export const schoolController = {
@@ -531,9 +531,8 @@ export const schoolController = {
     const patient_uuids = school.patients.map((patient) => patient.uuid)
 
     // Invite contacts to book into a clinic
-    const clinicProgramme_ids = request.body.clinicProgramme_ids.filter(
-      (item) => item !== '_unchecked'
-    )
+    const clinicProgramme_ids = stringToArray(request.body.clinicProgramme_ids)
+
     for (const patient_uuid of patient_uuids) {
       const patient = Patient.findOne(patient_uuid, data)
       patient.inviteToClinic(clinicProgramme_ids)

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -20,7 +20,7 @@ import {
 } from '../models.js'
 import { today } from '../utils/date.js'
 import { saveAndRedirect } from '../utils/redirect.js'
-import { formatSequence } from '../utils/string.js'
+import { formatSequence, stringToArray } from '../utils/string.js'
 
 export const vaccinationController = {
   /**
@@ -448,10 +448,7 @@ export const vaccinationController = {
 
     // Set default batch, if checked
     if (request.body?.defaultBatchId) {
-      let { defaultBatchId } = request.body
-      defaultBatchId = Array.isArray(defaultBatchId)
-        ? defaultBatchId.filter((item) => item !== '_unchecked')
-        : defaultBatchId
+      const defaultBatchId = stringToArray(request.body.defaultBatchId)[0]
 
       if (defaultBatchId) {
         DefaultBatch.addToSession(

--- a/app/data.js
+++ b/app/data.js
@@ -57,7 +57,10 @@ const data = {
 const unmatchedAppointmentCount = ClinicBooking.findAll(data)
   ?.flatMap(({ appointments }) => appointments)
   .filter(({ patient_uuid }) => !patient_uuid).length
-const unmatchedConsentCount = Consent.findAll(data).length || 0
+const unmatchedConsentCount =
+  Consent.findAll(data)
+    .filter((consent) => !consent.invalid)
+    .filter((consent) => !consent.patient_uuid).length || 0
 const moveCount = Move.findAll(data).length || 0
 const noticeCount =
   Notice.findAll(data).filter(({ archivedAt }) => !archivedAt).length || 0

--- a/app/datasets/teams.js
+++ b/app/datasets/teams.js
@@ -1,5 +1,3 @@
-import clinics from './clinics.js'
-
 export default [
   {
     id: '001',
@@ -7,10 +5,7 @@ export default [
     name: 'Coventry and Warwickshire Partnership NHS Trust',
     email: 'enquiries@covwarkpt.nhs.uk',
     tel: '024 7636 2100',
-    privacyPolicyUrl: 'https://www.covwarkpt.nhs.uk/download.cfm?ver=8286',
-    clinic_ids: Object.values(clinics)
-      .filter((clinic) => clinic.team_id == '001')
-      .map((clinic) => clinic.id)
+    privacyPolicyUrl: 'https://www.covwarkpt.nhs.uk/download.cfm?ver=8286'
   },
   {
     id: '002',

--- a/app/datasets/teams.js
+++ b/app/datasets/teams.js
@@ -1,5 +1,4 @@
 import clinics from './clinics.js'
-import schools from './schools.js'
 
 export default [
   {
@@ -11,8 +10,7 @@ export default [
     privacyPolicyUrl: 'https://www.covwarkpt.nhs.uk/download.cfm?ver=8286',
     clinic_ids: Object.values(clinics)
       .filter((clinic) => clinic.team_id == '001')
-      .map((clinic) => clinic.id),
-    school_ids: Object.keys(schools)
+      .map((clinic) => clinic.id)
   },
   {
     id: '002',

--- a/app/globals.js
+++ b/app/globals.js
@@ -589,12 +589,12 @@ export default () => {
       // Allow value to be explicitly set
       let value = rows[key]?.value || formattedValue
 
-      if (typeof value !== 'undefined' && value !== 0 && value?.length !== 0) {
-        // Handle _unchecked checkbox value
-        if (value === '_unchecked') {
-          value = 'None selected'
-        }
+      if (Array.isArray(value) && value?.length === 0) {
+        // Handle empty arrays
+        value = 'None selected'
+      }
 
+      if (typeof value !== 'undefined' && value !== 0 && value?.length !== 0) {
         // Handle falsy values
         if (value === false) {
           value = 'No'

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -6,7 +6,6 @@ import {
   Programme,
   Session,
   Team,
-  User,
   Vaccination
 } from '../models.js'
 import {
@@ -23,10 +22,10 @@ import {
   stringToArray
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} AuditEventOptions
- * @property {Date} [createdAt] - Created date
- * @property {string} [createdBy_uid] - User who created event
+ * @typedef {BaseModelOptions & object} AuditEventOptions
  * @property {string} [name] - Name
  * @property {string} [note] - Note
  * @property {AuditEventType} [type] - Audit event type
@@ -46,15 +45,17 @@ import {
 /**
  * @class Audit event
  */
-export class AuditEvent {
+export class AuditEvent extends BaseModel {
+  static ns = 'event'
+
   /**
    * @param {AuditEventOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.createdBy_uid = options?.createdBy_uid
     this.name = options?.name
     this.note = options?.note
     this.type = options?.type
@@ -69,21 +70,6 @@ export class AuditEvent {
     this.session_id = options?.session_id
     this.team_id = options?.team_id || '001'
     this.vaccination_uuid = options?.vaccination_uuid
-  }
-
-  /**
-   * Get user who created event
-   *
-   * @returns {User|undefined} User
-   */
-  get createdBy() {
-    try {
-      if (this.createdBy_uid) {
-        return User.findOne(this.createdBy_uid, this.context)
-      }
-    } catch (error) {
-      console.error('Upload.createdBy', error.message)
-    }
   }
 
   /**
@@ -269,17 +255,9 @@ export class AuditEvent {
       }
     )
   }
-
-  /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'event'
-  }
 }
 
 /**
  * @import { AuditEventType } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -35,11 +35,7 @@ import { BaseModel } from './base.js'
  * @property {string} [outcome] - Outcome for activity type
  * @property {Date} [outcomeAt] - Date outcome invalidates
  * @property {object} [outcomeAt_] - Date outcome invalidates (from `dateInput`)
- * @property {string} [patient_uuid] - Patient UUID
  * @property {Array<string>} [programme_ids] - Programme IDs
- * @property {string} [session_id] - Session ID
- * @property {string} [team_id] - Team ID
- * @property {string} [vaccination_uuid] - Vaccination UUID
  */
 
 /**
@@ -55,6 +51,30 @@ export class AuditEvent extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.patient_uuid
+
+    /** @type {Patient|undefined} */
+    this.patient
+
+    /** @type {string|undefined} */
+    this.session_id
+
+    /** @type {Session|undefined} */
+    this.session
+
+    /** @type {string|undefined} */
+    this.team_id
+
+    /** @type {Team|undefined} */
+    this.team
+
+    /** @type {string|undefined} */
+    this.vaccination_uuid
+
+    /** @type {Vaccination|undefined} */
+    this.vaccination
+
     this.context = context
     this.name = options?.name
     this.note = options?.note
@@ -65,11 +85,7 @@ export class AuditEvent extends BaseModel {
     this.outcome = options?.outcome
     this.outcomeAt = options?.outcomeAt && new Date(options.outcomeAt)
     this.outcomeAt_ = options?.outcomeAt_
-    this.patient_uuid = options?.patient_uuid
     this.programme_ids = stringToArray(options?.programme_ids)
-    this.session_id = options?.session_id
-    this.team_id = options?.team_id || '001'
-    this.vaccination_uuid = options?.vaccination_uuid
   }
 
   /**
@@ -115,21 +131,6 @@ export class AuditEvent extends BaseModel {
   }
 
   /**
-   * Get patient
-   *
-   * @returns {Patient|undefined} Patient
-   */
-  get patient() {
-    try {
-      if (this.patient_uuid) {
-        return Patient.findOne(this.patient_uuid, this.context)
-      }
-    } catch (error) {
-      console.error('AuditEvent.patient', error.message)
-    }
-  }
-
-  /**
    * Get programmes event relates to
    *
    * @returns {Array<Programme>} Programmes
@@ -142,47 +143,6 @@ export class AuditEvent extends BaseModel {
     }
 
     return []
-  }
-
-  /**
-   * Get session
-   *
-   * @returns {Session|undefined} Session
-   */
-  get session() {
-    try {
-      return Session.findOne(this.session_id, this.context)
-    } catch (error) {
-      console.error('AuditEvent.session', error.message)
-    }
-  }
-
-  /**
-   * Get team
-   *
-   * @returns {Team|undefined} Team
-   */
-  get team() {
-    try {
-      return Team.findOne(this.team_id, this.context)
-    } catch (error) {
-      console.error('AuditEvent.team', error.message)
-    }
-  }
-
-  /**
-   * Get vaccination
-   *
-   * @returns {Vaccination|undefined} Vaccination
-   */
-  get vaccination() {
-    try {
-      if (this.vaccination_uuid) {
-        return Vaccination.findOne(this.vaccination_uuid, this.context)
-      }
-    } catch (error) {
-      console.error('AuditEvent.vaccination', error.message)
-    }
   }
 
   get summary() {
@@ -256,6 +216,11 @@ export class AuditEvent extends BaseModel {
     )
   }
 }
+
+AuditEvent.relate('patient_uuid', () => Patient, 'patient')
+AuditEvent.relate('session_id', () => Session, 'session')
+AuditEvent.relate('team_id', () => Team, 'team')
+AuditEvent.relate('vaccination_uuid', () => Vaccination, 'vaccination')
 
 /**
  * @import { AuditEventType } from '../enums.js'

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -19,7 +19,8 @@ import { getScreenOutcomeStatus } from '../utils/status.js'
 import {
   formatTag,
   formatMarkdown,
-  formatWithSecondaryText
+  formatWithSecondaryText,
+  stringToArray
 } from '../utils/string.js'
 
 /**
@@ -64,7 +65,7 @@ export class AuditEvent {
     this.outcomeAt = options?.outcomeAt && new Date(options.outcomeAt)
     this.outcomeAt_ = options?.outcomeAt_
     this.patient_uuid = options?.patient_uuid
-    this.programme_ids = options?.programme_ids
+    this.programme_ids = stringToArray(options?.programme_ids)
     this.session_id = options?.session_id
     this.team_id = options?.team_id || '001'
     this.vaccination_uuid = options?.vaccination_uuid

--- a/app/models/base.d.ts
+++ b/app/models/base.d.ts
@@ -1,0 +1,61 @@
+export interface BaseModelOptions {
+  createdAt?: Date
+  createdBy_uid?: string
+  updatedAt?: Date
+  updatedBy_uid?: string
+}
+
+export class BaseModel {
+  static contextKey: string
+  static identifierKey: string
+  static ns: string
+
+  context: object | undefined
+  createdAt: Date | undefined
+  createdBy_uid: string | undefined
+  updatedAt: Date | undefined
+  updatedBy_uid: string | undefined
+
+  constructor(options: object, context?: object)
+
+  get ns(): string
+  get createdBy(): User
+  get createdBy_(): object | string
+  get updatedBy(): User
+
+  set createdAt_(object: object): void
+
+  /**
+   * Remove `context` so it's hidden from JSON.stringify, or we'll get
+   * circular reference issues during saving
+   *
+   * @returns Object ready to be serialized to JSON
+   */
+  toJSON(): Omit<this, 'context'>
+
+  static findAll<T extends typeof BaseModel>(
+    this: T,
+    context: object
+  ): InstanceType<T>[]
+
+  static findOne<T extends typeof BaseModel>(
+    this: T,
+    id: string,
+    context: object
+  ): InstanceType<T> | undefined
+
+  static create<T extends typeof BaseModel>(
+    this: T,
+    options: object,
+    context: object
+  ): InstanceType<T> | undefined
+
+  static update<T extends typeof BaseModel>(
+    this: T,
+    id: string,
+    updates: object,
+    context: object
+  ): InstanceType<T> | undefined
+
+  static delete<T extends typeof BaseModel>(id: string, context: object): void
+}

--- a/app/models/base.d.ts
+++ b/app/models/base.d.ts
@@ -7,6 +7,7 @@ export interface BaseModelOptions {
 
 export class BaseModel {
   static contextKey: string
+  static foreignKeys: Record<string, () => typeof BaseModel>
   static identifierKey: string
   static ns: string
 
@@ -25,13 +26,9 @@ export class BaseModel {
 
   set createdAt_(object: object): void
 
-  /**
-   * Remove `context` so it's hidden from JSON.stringify, or we'll get
-   * circular reference issues during saving
-   *
-   * @returns Object ready to be serialized to JSON
-   */
   toJSON(): Omit<this, 'context'>
+
+  static relate(key: string, getModel: () => typeof BaseModel, as: string): void
 
   static findAll<T extends typeof BaseModel>(
     this: T,

--- a/app/models/base.js
+++ b/app/models/base.js
@@ -12,6 +12,7 @@ import {
  */
 export class BaseModel {
   static contextKey = ''
+  static foreignKeys = {}
   static identifierKey = ''
   static ns = ''
 
@@ -20,17 +21,30 @@ export class BaseModel {
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    /** @type {string|undefined} */
+    this.createdBy_uid
+
+    /** @type {User|undefined} */
+    this.createdBy
+
+    /** @type {string|undefined} */
+    this.updatedBy_uid
+
+    /** @type {User|undefined} */
+    this.updatedBy
+
     this.context = context
     this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
     this.createdAt_ = options?.createdAt_
-    this.createdBy_uid = options?.createdBy_uid
     this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
     this.updatedAt_ = options?.updatedAt_
-    this.updatedBy_uid = options?.updatedBy_uid
-  }
 
-  get createdBy() {
-    return User.findOne(this.createdBy_uid, this.context)
+    // Assign foreign key properties from options
+    for (const key of Object.keys(
+      /** @type {typeof BaseModel} */ (this.constructor).foreignKeys
+    )) {
+      this[key] = options?.[key]
+    }
   }
 
   get createdAt_() {
@@ -43,12 +57,23 @@ export class BaseModel {
     }
   }
 
-  get updatedBy() {
-    return User.findOne(this.updatedBy_uid, this.context)
-  }
-
   get ns() {
     return /** @type {typeof BaseModel} */ (this.constructor).ns
+  }
+
+  static relate(key, getModel, as) {
+    this.foreignKeys = { ...this.foreignKeys, [key]: getModel }
+
+    Object.defineProperty(this.prototype, as, {
+      get() {
+        return getModel().findOne(this[key], this.context)
+      },
+      set(updates) {
+        getModel().update(this[key], updates, this.context)
+      },
+      configurable: true,
+      enumerable: false
+    })
   }
 
   toJSON() {
@@ -109,3 +134,6 @@ export class BaseModel {
     delete context?.[this.contextKey]?.[identifier]
   }
 }
+
+BaseModel.relate('createdBy_uid', () => User, 'createdBy')
+BaseModel.relate('updatedBy_uid', () => User, 'updatedBy')

--- a/app/models/base.js
+++ b/app/models/base.js
@@ -1,0 +1,111 @@
+import _ from 'lodash'
+
+import { User } from '../models.js'
+import {
+  convertIsoDateToObject,
+  convertObjectToIsoDate,
+  today
+} from '../utils/date.js'
+
+/**
+ * @class BaseModel
+ */
+export class BaseModel {
+  static contextKey = ''
+  static identifierKey = ''
+  static ns = ''
+
+  /**
+   * @param {object} options - Options
+   * @param {object} [context] - Context
+   */
+  constructor(options, context) {
+    this.context = context
+    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
+    this.createdAt_ = options?.createdAt_
+    this.createdBy_uid = options?.createdBy_uid
+    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
+    this.updatedAt_ = options?.updatedAt_
+    this.updatedBy_uid = options?.updatedBy_uid
+  }
+
+  get createdBy() {
+    return User.findOne(this.createdBy_uid, this.context)
+  }
+
+  get createdAt_() {
+    return convertIsoDateToObject(this.createdAt)
+  }
+
+  set createdAt_(object) {
+    if (object) {
+      this.createdAt = convertObjectToIsoDate(object)
+    }
+  }
+
+  get updatedBy() {
+    return User.findOne(this.updatedBy_uid, this.context)
+  }
+
+  get ns() {
+    return /** @type {typeof BaseModel} */ (this.constructor).ns
+  }
+
+  toJSON() {
+    const { context, ...rest } = this
+    return rest
+  }
+
+  static findAll(context) {
+    if (!context?.[this.contextKey]) return []
+    return Object.values(context[this.contextKey]).map(
+      (item) => new this(item, context)
+    )
+  }
+
+  static findOne(identifier, context) {
+    if (context?.[this.contextKey]?.[identifier]) {
+      return new this(context[this.contextKey][identifier], context)
+    }
+  }
+
+  static create(options, context) {
+    const createdItem = new this(options)
+
+    // Update context
+    context[this.contextKey] = context[this.contextKey] || {}
+    context[this.contextKey][`${createdItem[this.identifierKey]}`] = createdItem
+
+    return createdItem
+  }
+
+  static update(identifier, updates, context) {
+    if (!context?.[this.contextKey]) return
+
+    // Update item
+    const updatedItem = _.mergeWith(
+      this.findOne(identifier, context),
+      updates,
+      (oldValue, newValue) => {
+        // Arrays shouldn’t be merged but replaced entirely
+        if (Array.isArray(oldValue)) return newValue
+      }
+    )
+    updatedItem.updatedAt = today()
+
+    // Remove item context
+    delete updatedItem.context
+
+    // Delete original item (with previous identifier)
+    this.delete(identifier, context)
+
+    // Update context
+    context[this.contextKey][identifier] = updatedItem
+
+    return new this(updatedItem, context)
+  }
+
+  static delete(identifier, context) {
+    delete context?.[this.contextKey]?.[identifier]
+  }
+}

--- a/app/models/batch.js
+++ b/app/models/batch.js
@@ -10,11 +10,11 @@ import {
 } from '../utils/date.js'
 import { formatCode } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} BatchOptions
+ * @typedef {BaseModelOptions & object} BatchOptions
  * @property {string} [id] - Batch ID
- * @property {Date} [createdAt] - Created date
- * @property {Date} [updatedAt] - Updated date
  * @property {Date} [archivedAt] - Archived date
  * @property {Date} [expiry] - Expiry date
  * @property {object} [expiry_] - Expiry date (from `dateInput`)
@@ -23,17 +23,22 @@ import { formatCode } from '../utils/string.js'
 
 /**
  * @class Batch
+ * @augments BaseModel
  */
-export class Batch {
+export class Batch extends BaseModel {
+  static contextKey = 'batches'
+  static identifierKey = 'id'
+  static ns = 'batch'
+
   /**
    * @param {BatchOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.id = options?.id || faker.helpers.replaceSymbols('??####')
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
     this.archivedAt = options?.archivedAt && new Date(options.archivedAt)
     this.expiry = options?.expiry ? new Date(options.expiry) : undefined
     this.expiry_ = options?.expiry_
@@ -124,91 +129,12 @@ export class Batch {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'batch'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/vaccines/${this.vaccine_snomed}/batches/${this.id}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Batch>|undefined} Batches
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.batches).map(
-      (batch) => new Batch(batch, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} id - Batch ID
-   * @param {object} context - Context
-   * @returns {Batch|undefined} Batch
-   * @static
-   */
-  static findOne(id, context) {
-    if (context?.batches?.[id]) {
-      return new Batch(context.batches[id], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {Batch} batch - Batch
-   * @param {object} context - Context
-   * @returns {Batch} Created batch
-   * @static
-   */
-  static create(batch, context) {
-    const createdBatch = new Batch(batch)
-
-    // Update context
-    context.batches = context.batches || {}
-    context.batches[createdBatch.id] = createdBatch
-
-    return createdBatch
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} id - Batch ID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Batch} Updated batch
-   * @static
-   */
-  static update(id, updates, context) {
-    const updatedBatch = Object.assign(Batch.findOne(id, context), updates)
-    updatedBatch.updatedAt = today()
-
-    // Remove batch context
-    delete updatedBatch.context
-
-    // Delete original batch (with previous ID)
-    delete context.batches[id]
-
-    // Update context
-    context.batches[updatedBatch.id] = updatedBatch
-
-    return updatedBatch
   }
 
   /**
@@ -232,3 +158,7 @@ export class Batch {
     return archivedBatch
   }
 }
+
+/**
+ * @import { BaseModelOptions } from './base.js'
+ */

--- a/app/models/batch.js
+++ b/app/models/batch.js
@@ -37,12 +37,17 @@ export class Batch extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.vaccine_snomed
+
+    /** @type {Vaccine|undefined} */
+    this.vaccine
+
     this.context = context
     this.id = options?.id || faker.helpers.replaceSymbols('??####')
     this.archivedAt = options?.archivedAt && new Date(options.archivedAt)
     this.expiry = options?.expiry ? new Date(options.expiry) : undefined
     this.expiry_ = options?.expiry_
-    this.vaccine_snomed = options?.vaccine_snomed
   }
 
   /**
@@ -83,22 +88,6 @@ export class Batch extends BaseModel {
     const prefix = isBefore(this.archivedAt, today()) ? 'Expired' : 'Expires'
 
     return `${this.formatted.id}<br>\n<span class="nhsuk-u-secondary-text-colour">${prefix} ${this.formatted.expiry}</span>`
-  }
-
-  /**
-   * Get vaccine this batch belongs to
-   *
-   * @returns {Vaccine|undefined} Vaccine
-   */
-  get vaccine() {
-    try {
-      const vaccine = this.context?.vaccines[this.vaccine_snomed]
-      if (vaccine) {
-        return new Vaccine(vaccine)
-      }
-    } catch (error) {
-      console.error('Batch.vaccine', error.message)
-    }
   }
 
   /**
@@ -158,6 +147,8 @@ export class Batch extends BaseModel {
     return archivedBatch
   }
 }
+
+Batch.relate('vaccine_snomed', () => Vaccine, 'vaccine')
 
 /**
  * @import { BaseModelOptions } from './base.js'

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -26,11 +26,11 @@ import {
   stringToArray
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} ChildOptions
+ * @typedef {BaseModelOptions & object} ChildOptions
  * @property {string} [uuid] - Child UUID
- * @property {Date} [updatedAt] - Updated date
- * @property {string} [updatedBy_uid] - User who updated record
  * @property {string} [firstName] - First name
  * @property {string} [lastName] - Last name
  * @property {string} [preferredFirstName] - Preferred first name
@@ -58,15 +58,17 @@ import {
 /**
  * @class Child
  */
-export class Child {
+export class Child extends BaseModel {
+  static ns = 'child'
+
   /**
    * @param {ChildOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
-    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
-    this.updatedBy_uid = options?.updatedBy_uid
     this.uuid = options?.uuid || faker.string.uuid()
     this.firstName = options?.firstName || ''
     this.lastName = options?.lastName || ''
@@ -367,17 +369,9 @@ export class Child {
       }
     )
   }
-
-  /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'child'
-  }
 }
 
 /**
  * @import { Gender, EthnicBackground } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -29,6 +29,8 @@ import {
 /**
  * @typedef {object} ChildOptions
  * @property {string} [uuid] - Child UUID
+ * @property {Date} [updatedAt] - Updated date
+ * @property {string} [updatedBy_uid] - User who updated record
  * @property {string} [firstName] - First name
  * @property {string} [lastName] - Last name
  * @property {string} [preferredFirstName] - Preferred first name
@@ -63,6 +65,8 @@ export class Child {
    */
   constructor(options, context) {
     this.context = context
+    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
+    this.updatedBy_uid = options?.updatedBy_uid
     this.uuid = options?.uuid || faker.string.uuid()
     this.firstName = options?.firstName || ''
     this.lastName = options?.lastName || ''

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -1,6 +1,5 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
-import schools from '../datasets/schools.js'
 import {
   Adjustment,
   EthnicBackgroundAsian,
@@ -52,7 +51,6 @@ import { BaseModel } from './base.js'
  * @property {string} [gpSurgery] - GP surgery
  * @property {number} [academicYearGroup] - Academic year group (override)
  * @property {string} [registrationGroup] - Registration group
- * @property {string} [school_id] - School
  */
 
 /**
@@ -67,6 +65,12 @@ export class Child extends BaseModel {
    */
   constructor(options, context) {
     super(options, context)
+
+    /** @type {string|undefined} */
+    this.school_id
+
+    /** @type {School|undefined} */
+    this.school
 
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
@@ -87,10 +91,6 @@ export class Child extends BaseModel {
     this.gpSurgery = options?.gpSurgery
     this.academicYearGroup = options?.academicYearGroup || this.yearGroup
     this.registrationGroup = options?.registrationGroup
-
-    if (!this.agedOutOfProgrammes) {
-      this.school_id = options?.school_id
-    }
 
     if (this.ethnicGroup === EthnicGroup.Other) {
       this.ethnicGroupOther = options?.ethnicGroupOther
@@ -287,17 +287,6 @@ export class Child extends BaseModel {
   }
 
   /**
-   * Get school
-   *
-   * @returns {School|undefined} School
-   */
-  get school() {
-    if (this.school_id) {
-      return new School(schools[this.school_id], this.context)
-    }
-  }
-
-  /**
    * Get school name
    *
    * @returns {string|undefined} School name
@@ -370,6 +359,8 @@ export class Child extends BaseModel {
     )
   }
 }
+
+Child.relate('school_id', () => School, 'school')
 
 /**
  * @import { Gender, EthnicBackground } from '../enums.js'

--- a/app/models/child.js
+++ b/app/models/child.js
@@ -78,10 +78,8 @@ export class Child {
     this.gender = options?.gender
     this.ethnicGroup = options?.ethnicGroup
     this.ethnicBackground = options?.ethnicBackground
-    this.adjustments =
-      (options?.adjustments && stringToArray(options.adjustments)) || []
-    this.impairments =
-      (options?.impairments && stringToArray(options.impairments)) || []
+    this.adjustments = stringToArray(options?.adjustments)
+    this.impairments = stringToArray(options?.impairments)
     this.immunocompromised = options?.immunocompromised
     this.address = options?.address
     this.gpSurgery = options?.gpSurgery

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -39,7 +39,8 @@ import {
   formatOther,
   formatSecondaryText,
   formatTime,
-  stringToArray
+  stringToArray,
+  stringToBoolean
 } from '../utils/string.js'
 
 /**
@@ -88,20 +89,18 @@ export class ClinicAppointment {
 
     this.parentalRelationship = options?.parentalRelationship
     this.parentalRelationshipOther = options?.parentalRelationshipOther
-    this.parentHasParentalResponsibility =
+    this.parentHasParentalResponsibility = stringToBoolean(
       options?.parentHasParentalResponsibility
+    )
 
     this.session_id = options?.session_id
     this.startAt = options?.startAt ? new Date(options.startAt) : undefined
     this.endAt = options?.endAt ? new Date(options.endAt) : undefined
 
-    this.selected_programme_ids =
-      (options?.selected_programme_ids &&
-        stringToArray(options.selected_programme_ids)) ||
-      []
+    this.selected_programme_ids = stringToArray(options?.selected_programme_ids)
     this.fluDecision = options?.fluDecision ?? ReplyDecision.NoResponse
-    this.fluAlternative = options?.fluAlternative
-    this.mmrAlternative = options?.mmrAlternative
+    this.fluAlternative = stringToBoolean(options?.fluAlternative)
+    this.mmrAlternative = stringToBoolean(options?.mmrAlternative)
     this.healthAnswers = options?.healthAnswers || {}
 
     this.status = options?.status ?? ClinicAppointmentStatus.Booked

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -74,6 +74,7 @@ import {
 /**
  * @class ClinicAppointment
  */
+// TODO: Extend BaseModel (findOne and findAll currently deviate from pattern)
 export class ClinicAppointment {
   /**
    * @param {ClinicAppointmentOptions} options - Options

--- a/app/models/clinic-booking.js
+++ b/app/models/clinic-booking.js
@@ -1,14 +1,13 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
-import _ from 'lodash'
 
 import { ClinicAppointment, Contact } from '../models.js'
-import { today } from '../utils/date.js'
 import { formatCode, stringToArray } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} ClinicBookingOptions
+ * @typedef {BaseModelOptions & object} ClinicBookingOptions
  * @property {string} [uuid] - Clinic booking UUID
- * @property {Date} [createdAt] - Created date
  * @property {string} [bookingReference] - Booking reference number
  * @property {Array<string>} [invited_programme_ids] - IDs of programmes for which child was invited
  * @property {Contact} [contact] - Contact details for the booking; see appointments for parental relationship details
@@ -18,15 +17,20 @@ import { formatCode, stringToArray } from '../utils/string.js'
 /**
  * @class ClinicBooking
  */
-export class ClinicBooking {
+export class ClinicBooking extends BaseModel {
+  static contextKey = 'clinicBookings'
+  static identifierKey = 'uuid'
+  static ns = 'clinicBooking'
+
   /**
    * @param {ClinicBookingOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
 
     this.bookingReference =
       options?.bookingReference || ClinicBooking.generateReference()
@@ -124,15 +128,6 @@ export class ClinicBooking {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'clinicBooking'
-  }
-
-  /**
    * Get URI
    *
    * @returns {object} An object containing different URLs for this booking
@@ -143,94 +138,8 @@ export class ClinicBooking {
       debug: `/clinic-bookings/${this.uuid}`
     }
   }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<ClinicBooking>|undefined} Clinic bookings
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context?.clinicBookings ?? {}).map(
-      (booking) => new ClinicBooking(booking, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - ClinicBooking UUID
-   * @param {object} context - Context
-   * @returns {ClinicBooking|undefined} Clinic booking
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.clinicBookings?.[uuid]) {
-      return new ClinicBooking(context.clinicBookings[uuid], context)
-    }
-  }
-
-  /**
-   * Create a new clinic booking, adding it to the context
-   *
-   * @param {object} booking
-   * @param {object} context
-   * @returns {ClinicBooking} A new clinic booking, added to the context, and possibly with a new UUID
-   */
-  static create(booking, context) {
-    const createdBooking = new ClinicBooking(booking)
-
-    // Update context
-    context.clinicBookings = context.clinicBookings || {}
-    context.clinicBookings[createdBooking.uuid] = createdBooking
-
-    return createdBooking
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} uuid - ClinicBooking UUID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {ClinicBooking} Updated booking
-   * @static
-   */
-  static update(uuid, updates, context) {
-    // Copy updates into the relevant booking
-    const existingBooking = ClinicBooking.findOne(uuid, context)
-    const updatedBooking = _.mergeWith(
-      existingBooking,
-      updates,
-      (oldValue, newValue) => {
-        // Arrays shouldn’t be merged but replaced entirely
-        if (Array.isArray(oldValue)) {
-          return newValue
-        }
-      }
-    )
-
-    // Remove booking context
-    delete updatedBooking.context
-
-    // Delete original booking (with previous UUID)
-    delete context.clinicBookings[uuid]
-
-    // Update context
-    context.clinicBookings[updatedBooking.uuid] = updatedBooking
-
-    return updatedBooking
-  }
-
-  /**
-   * Delete
-   *
-   * @param {string} uuid - Clinic booking UUID
-   * @param {object} context - Context
-   * @static
-   */
-  static delete(uuid, context) {
-    delete context.clinicBookings[uuid]
-  }
 }
+
+/**
+ * @import { BaseModelOptions } from './base.js'
+ */

--- a/app/models/clinic-booking.js
+++ b/app/models/clinic-booking.js
@@ -3,7 +3,7 @@ import _ from 'lodash'
 
 import { ClinicAppointment, Contact } from '../models.js'
 import { today } from '../utils/date.js'
-import { formatCode, stringToArray, stringToBoolean } from '../utils/string.js'
+import { formatCode, stringToArray } from '../utils/string.js'
 
 /**
  * @typedef {object} ClinicBookingOptions
@@ -30,9 +30,7 @@ export class ClinicBooking {
 
     this.bookingReference =
       options?.bookingReference || ClinicBooking.generateReference()
-    this.invited_programme_ids = options?.invited_programme_ids
-      ? [...options.invited_programme_ids]
-      : []
+    this.invited_programme_ids = stringToArray(options?.invited_programme_ids)
 
     this.contact =
       (options?.contact && new Contact(options.contact)) ?? new Contact({})
@@ -200,17 +198,13 @@ export class ClinicBooking {
    * @static
    */
   static update(uuid, updates, context) {
-    // Sanitise any _unchecked checkbox values
-    ClinicBooking.#sanitiseCheckboxUpdates(updates)
-
     // Copy updates into the relevant booking
     const existingBooking = ClinicBooking.findOne(uuid, context)
     const updatedBooking = _.mergeWith(
       existingBooking,
       updates,
       (oldValue, newValue) => {
-        // The appointments array shouldn’t be merged but replaced entirely, or updates following
-        // the removal of a non-last appointment will result in appointment duplication
+        // Arrays shouldn’t be merged but replaced entirely
         if (Array.isArray(oldValue)) {
           return newValue
         }
@@ -227,62 +221,6 @@ export class ClinicBooking {
     context.clinicBookings[updatedBooking.uuid] = updatedBooking
 
     return updatedBooking
-  }
-
-  /**
-   * Get rid of _unchecked values from checkboxes in the booking journey
-   *
-   * @param {object} updates - new values posted from the booking journey
-   */
-  static #sanitiseCheckboxUpdates(updates) {
-    // Receive updates by SMS option
-    if (updates?.contact?.sms) {
-      updates.contact.sms = stringToBoolean(updates.contact.sms) || false
-    }
-
-    if (updates?.appointments) {
-      for (const appointment of updates.appointments) {
-        // Vaccinations selected
-        if (appointment?.selected_programme_ids) {
-          appointment.selected_programme_ids = stringToArray(
-            appointment.selected_programme_ids
-          )
-        }
-
-        // Willing to accept flu injection as alternative?
-        if (appointment?.fluAlternative) {
-          appointment.fluAlternative =
-            stringToBoolean(appointment.fluAlternative) || false
-        }
-
-        // Gelatine free, or either type of MMR vaccine?
-        if (appointment?.mmrAlternative) {
-          appointment.mmrAlternative =
-            stringToBoolean(appointment.mmrAlternative) || false
-        }
-
-        // Impairments
-        if (appointment?.child?.impairments) {
-          appointment.child.impairments = stringToArray(
-            appointment.child.impairments
-          )
-        }
-
-        // Adjustments
-        if (appointment?.child?.adjustments) {
-          appointment.child.adjustments = stringToArray(
-            appointment.child.adjustments
-          )
-        }
-
-        // Contact has parental responsibility?
-        if (appointment?.parentHasParentalResponsibility) {
-          appointment.parentHasParentalResponsibility =
-            stringToBoolean(appointment.parentHasParentalResponsibility) ||
-            false
-        }
-      }
-    }
   }
 
   /**

--- a/app/models/clinic-vaccination-period.js
+++ b/app/models/clinic-vaccination-period.js
@@ -7,8 +7,10 @@ import {
   convertObjectToIsoDate
 } from '../utils/date.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} ClinicVaccinationPeriodOptions
+ * @typedef {BaseModelOptions & object} ClinicVaccinationPeriodOptions
  * @property {string} [uuid] - Vaccination period UUID
  * @property {Date} [startAt] - Start time of first appointment slot
  * @property {Date} [endAt] - End time of final appointment slot
@@ -18,11 +20,16 @@ import {
 /**
  * @class ClinicVaccinationPeriod
  */
-export class ClinicVaccinationPeriod {
+export class ClinicVaccinationPeriod extends BaseModel {
+  // TODO: add this to the locale file
+  static ns = 'clinicVaccinationPeriod'
+
   /**
    * @param {ClinicVaccinationPeriodOptions} options - Options
    */
   constructor(options) {
+    super(options)
+
     this.uuid = options?.uuid || faker.string.uuid()
     this.startAt = options?.startAt && new Date(options.startAt)
     this.endAt = options?.endAt && new Date(options.endAt)
@@ -138,16 +145,6 @@ export class ClinicVaccinationPeriod {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    // TODO: add this to the locale file
-    return 'clinicVaccinationPeriod'
-  }
-
-  /**
    * Get all appointment slot start times, replicated for the number of vaccinators
    *
    * @param {number} appointmentLengthInMinutes - the length of a single appointment slot, in minutes
@@ -174,3 +171,7 @@ export class ClinicVaccinationPeriod {
     return appointmentStartTimes
   }
 }
+
+/**
+ * @import { BaseModelOptions } from './base.js'
+ */

--- a/app/models/clinic.js
+++ b/app/models/clinic.js
@@ -61,9 +61,6 @@ export class Clinic extends Location {
   static create(clinic, context) {
     const createdClinic = new Clinic(clinic)
 
-    // Add to team
-    context.teams[createdClinic.team_id].clinic_ids.push(createdClinic.id)
-
     // Update context
     context.clinics = context.clinics || {}
     context.clinics[createdClinic.id] = createdClinic
@@ -103,13 +100,6 @@ export class Clinic extends Location {
    * @static
    */
   static delete(id, context) {
-    const clinic = Clinic.findOne(id, context)
-
-    // Remove from team
-    context.teams[clinic.team_id].clinic_ids = context.teams[
-      clinic.team_id
-    ].clinic_ids.filter((item) => item !== id)
-
     delete context.clinics[id]
   }
 }

--- a/app/models/clinic.js
+++ b/app/models/clinic.js
@@ -5,14 +5,9 @@ import { Location } from '../models.js'
  * @augments Location
  */
 export class Clinic extends Location {
-  /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'clinic'
-  }
+  static contextKey = 'clinics'
+  static identifierKey = 'id'
+  static ns = 'clinic'
 
   /**
    * Get URI
@@ -21,85 +16,5 @@ export class Clinic extends Location {
    */
   get uri() {
     return `/teams/${this.team_id}/clinics/${this.id}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Clinic>|undefined} All clinics on the context
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.clinics).map(
-      (clinic) => new Clinic(clinic, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} id - Clinic ID
-   * @param {object} context - Context
-   * @returns {Clinic|undefined} Clinic
-   * @static
-   */
-  static findOne(id, context) {
-    if (context?.clinics?.[id]) {
-      return new Clinic(context.clinics[id], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {Clinic} clinic - Clinic
-   * @param {object} context - Context
-   * @returns {Clinic} Created clinic
-   * @static
-   */
-  static create(clinic, context) {
-    const createdClinic = new Clinic(clinic)
-
-    // Update context
-    context.clinics = context.clinics || {}
-    context.clinics[createdClinic.id] = createdClinic
-
-    return createdClinic
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} id - Clinic ID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Clinic} Updated clinic
-   * @static
-   */
-  static update(id, updates, context) {
-    const updatedClinic = Object.assign(Clinic.findOne(id, context), updates)
-
-    // Remove clinic context
-    delete updatedClinic.context
-
-    // Delete original clinic (with previous ID)
-    delete context.clinics[id]
-
-    // Update context
-    context.clinics[updatedClinic.id] = updatedClinic
-
-    return updatedClinic
-  }
-
-  /**
-   * Delete
-   *
-   * @param {string} id - Clinic ID
-   * @param {object} context - Context
-   * @static
-   */
-  static delete(id, context) {
-    delete context.clinics[id]
   }
 }

--- a/app/models/consent.js
+++ b/app/models/consent.js
@@ -7,6 +7,8 @@ import { formatLinkWithSecondaryText } from '../utils/string.js'
  * @augments Reply
  */
 export class Consent extends Reply {
+  static ns = 'consent'
+
   /**
    * Answers in this consent response need triage
    *
@@ -32,49 +34,12 @@ export class Consent extends Reply {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'consent'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/consents/${this.uuid}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Consent>|undefined} Consents
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.replies)
-      .map((reply) => new Consent(reply, context))
-      .filter((consent) => !consent.invalid)
-      .filter((consent) => !consent.patient_uuid)
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - Reply UUID
-   * @param {object} context - Context
-   * @returns {Consent|undefined} Consent
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.replies?.[uuid]) {
-      return new Consent(context.replies[uuid], context)
-    }
   }
 
   /**

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -48,7 +48,7 @@ export class Contact {
     this.tel = options?.tel
     this.email = options?.email
     this.emailStatus = this?.email && options?.emailStatus
-    this.sms = stringToBoolean(options.sms) || false
+    this.sms = stringToBoolean(options.sms)
     this.smsStatus = this?.tel && options?.smsStatus
     this.contactPreference = stringToBoolean(options?.contactPreference)
 

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -4,8 +4,10 @@ import { ParentalRelationship } from '../enums.js'
 import { Patient } from '../models.js'
 import { formatOther, formatContact, stringToBoolean } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} ContactOptions
+ * @typedef {BaseModelOptions & object} ContactOptions
  * @property {string} [uuid] - Contact UUID
  * @property {string} [fullName] - Full name
  * @property {ParentalRelationship} [relationship] - Relationship to child
@@ -25,12 +27,18 @@ import { formatOther, formatContact, stringToBoolean } from '../utils/string.js'
 /**
  * @class Contact
  */
-export class Contact {
+export class Contact extends BaseModel {
+  static contextKey = 'contacts'
+  static identifierKey = 'uuid'
+  static ns = 'contact'
+
   /**
    * @param {ContactOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
     this.fullName = options?.fullName || ''
@@ -109,15 +117,6 @@ export class Contact {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'contact'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
@@ -125,102 +124,9 @@ export class Contact {
   get uri() {
     return `/contacts/${this.uuid}`
   }
-
-  /**
-   * Remove `context` so it’s hidden from JSON.stringify, or we’ll get
-   * circular reference issues during saving
-   *
-   * @returns {object} Contact ready to be serialized to JSON
-   */
-  toJSON() {
-    const { context, ...rest } = this
-    return rest
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Contact>|undefined} Contacts
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.contacts).map(
-      (contact) => new Contact(contact, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - Contact UUID
-   * @param {object} context - Context
-   * @returns {Contact|undefined} Contact
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.contacts?.[uuid]) {
-      return new Contact(context.contacts[uuid], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {object} contact - Contact
-   * @param {object} context - Context
-   * @returns {Contact} Created contact
-   * @static
-   */
-  static create(contact, context) {
-    const createdContact = new Contact(contact)
-
-    // Update context
-    context.contacts = context.contacts || {}
-    context.contacts[createdContact.uuid] = createdContact
-
-    return createdContact
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} uuid - Contact UUID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Contact} Updated contact
-   * @static
-   */
-  static update(uuid, updates, context) {
-    const updatedContact = Object.assign(
-      Contact.findOne(uuid, context),
-      updates
-    )
-
-    // Remove move context
-    delete updatedContact.context
-
-    // Delete original move (with previous UUID)
-    delete context.contacts[uuid]
-
-    // Update context
-    context.contacts[updatedContact.uuid] = updatedContact
-
-    return updatedContact
-  }
-
-  /**
-   * Delete
-   *
-   * @param {string} uuid - Contact UUID
-   * @param {object} context - Context
-   * @static
-   */
-  static delete(uuid, context) {
-    delete context.contacts[uuid]
-  }
 }
 
 /**
  * @import { NotifyEmailStatus, NotifySmsStatus } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -21,7 +21,6 @@ import { BaseModel } from './base.js'
  * @property {NotifySmsStatus} [smsStatus] - SMS status
  * @property {boolean} [contactPreference] - Preferred contact method
  * @property {string} [contactPreferenceDetails] - Contact method details
- * @property {string} [patient_uuid] - Patient UUID
  */
 
 /**
@@ -38,6 +37,12 @@ export class Contact extends BaseModel {
    */
   constructor(options, context) {
     super(options, context)
+
+    /** @type {string|undefined} */
+    this.patient_uuid
+
+    /** @type {Patient|undefined} */
+    this.patient
 
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
@@ -63,8 +68,6 @@ export class Contact extends BaseModel {
     if (this.contactPreference) {
       this.contactPreferenceDetails = options?.contactPreferenceDetails
     }
-
-    this.patient_uuid = options?.patient_uuid
   }
 
   /**
@@ -74,21 +77,6 @@ export class Contact extends BaseModel {
    */
   get fullNameAndRelationship() {
     return formatContact(this, false)
-  }
-
-  /**
-   * Get patient
-   *
-   * @returns {Patient|undefined} Patient
-   */
-  get patient() {
-    try {
-      if (this.patient_uuid) {
-        return Patient.findOne(this.patient_uuid, this.context)
-      }
-    } catch (error) {
-      console.error('Contact.patient', error.message)
-    }
   }
 
   /**
@@ -125,6 +113,8 @@ export class Contact extends BaseModel {
     return `/contacts/${this.uuid}`
   }
 }
+
+Contact.relate('patient_uuid', () => Patient, 'patient')
 
 /**
  * @import { NotifyEmailStatus, NotifySmsStatus } from '../enums.js'

--- a/app/models/default-batch.js
+++ b/app/models/default-batch.js
@@ -1,7 +1,7 @@
 import { Batch, Session } from '../models.js'
 
 /**
- * @typedef {object} DefaultBatchOptions
+ * @typedef {BatchOptions & object} DefaultBatchOptions
  * @property {string} [session_id] - Session ID
  */
 
@@ -10,8 +10,11 @@ import { Batch, Session } from '../models.js'
  * @augments Batch
  */
 export class DefaultBatch extends Batch {
+  static contextKey = 'defaultBatches'
+  static ns = 'defaultBatch'
+
   /**
-   * @param {DefaultBatchOptions & BatchOptions} options - Options
+   * @param {DefaultBatchOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
@@ -31,53 +34,6 @@ export class DefaultBatch extends Batch {
     } catch (error) {
       console.error('DefaultBatch.session', error.message)
     }
-  }
-
-  /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'defaultBatch'
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<DefaultBatch>|undefined} Default batches
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.defaultBatches).map(
-      (batch) => new DefaultBatch(batch, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} id - Default batch ID
-   * @param {object} context - Context
-   * @returns {DefaultBatch|undefined} Default batch
-   * @static
-   */
-  static findOne(id, context) {
-    if (context?.defaultBatches?.[id]) {
-      return new DefaultBatch(context.defaultBatches[id], context)
-    }
-  }
-
-  /**
-   * Delete
-   *
-   * @param {string} id - Default batch ID
-   * @param {object} context - Context
-   * @static
-   */
-  static delete(id, context) {
-    delete context.defaultBatches[id]
   }
 
   /**

--- a/app/models/default-batch.js
+++ b/app/models/default-batch.js
@@ -20,20 +20,11 @@ export class DefaultBatch extends Batch {
   constructor(options, context) {
     super(options, context)
 
-    this.session_id = options?.session_id
-  }
+    /** @type {string|undefined} */
+    this.session_id
 
-  /**
-   * Get session
-   *
-   * @returns {Session|undefined} Session
-   */
-  get session() {
-    try {
-      return Session.findOne(this.session_id, this.context)
-    } catch (error) {
-      console.error('DefaultBatch.session', error.message)
-    }
+    /** @type {Session|undefined} */
+    this.session
   }
 
   /**
@@ -56,6 +47,8 @@ export class DefaultBatch extends Batch {
     context.defaultBatches[id] = defaultBatch
   }
 }
+
+DefaultBatch.relate('session_id', () => Session, 'session')
 
 /**
  * @import { BatchOptions } from './batch.js'

--- a/app/models/download.js
+++ b/app/models/download.js
@@ -34,9 +34,6 @@ import { BaseModel } from './base.js'
  * @property {boolean} [recordOffline] - Include columns for recording offline
  * @property {Array<DownloadVariable>} [variables] - Download variables
  * @property {number} [academicYear] - Programme year
- * @property {string} [programme_id] - Programme ID
- * @property {string} [school_id] - School ID
- * @property {string} [session_id] - Session ID
  * @property {Array<string>} [team_ids] - Team IDs
  * @property {Array<string>} [vaccination_uuids] - Vaccination UUIDs
  */
@@ -56,6 +53,24 @@ export class Download extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.programme_id
+
+    /** @type {Programme|undefined} */
+    this.programme
+
+    /** @type {string|undefined} */
+    this.session_id
+
+    /** @type {Session|undefined} */
+    this.session
+
+    /** @type {string|undefined} */
+    this.school_id
+
+    /** @type {School|undefined} */
+    this.school
+
     this.context = context
     this.id = options?.id || faker.string.hexadecimal({ length: 8, prefix: '' })
     this.format = options?.format || DownloadFormat.CSV
@@ -71,7 +86,6 @@ export class Download extends BaseModel {
     }
 
     if ([DownloadType.Cohort, DownloadType.Report].includes(this.type)) {
-      this.programme_id = options?.programme_id
       this.vaccination_uuids = stringToArray(options?.vaccination_uuids)
     }
 
@@ -84,8 +98,6 @@ export class Download extends BaseModel {
 
     if (this.type === DownloadType.Session) {
       this.recordOffline = stringToBoolean(options?.recordOffline)
-      this.school_id = options?.school_id
-      this.session_id = options?.session_id
     }
   }
 
@@ -148,48 +160,6 @@ export class Download extends BaseModel {
         return `Session spreadsheet`
       default:
         return 'Download'
-    }
-  }
-
-  /**
-   * Get programme
-   *
-   * @returns {Programme|undefined} Programme
-   */
-  get programme() {
-    try {
-      const programme = this.context?.programmes[this.programme_id]
-      if (programme) {
-        return new Programme(programme)
-      }
-    } catch (error) {
-      console.error('Download.programme', error.message)
-    }
-  }
-
-  /**
-   * Get school
-   *
-   * @returns {School|undefined} School
-   */
-  get school() {
-    try {
-      return School.findOne(this.school_id, this.context)
-    } catch (error) {
-      console.error('Download.school', error.message)
-    }
-  }
-
-  /**
-   * Get session
-   *
-   * @returns {Session|undefined} Session
-   */
-  get session() {
-    try {
-      return Session.findOne(this.session_id, this.context)
-    } catch (error) {
-      console.error('Download.session', error.message)
     }
   }
 
@@ -475,6 +445,10 @@ export class Download extends BaseModel {
     return { buffer, fileName: `${name}.${extension}`, mimetype }
   }
 }
+
+Download.relate('programme_id', () => Programme, 'programme')
+Download.relate('school_id', () => School, 'school')
+Download.relate('session_id', () => Session, 'session')
 
 /**
  * @import { DownloadVariable } from '../enums.js'

--- a/app/models/download.js
+++ b/app/models/download.js
@@ -1,17 +1,9 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import { addSeconds } from 'date-fns'
 import xlsx from 'json-as-xlsx'
-import _ from 'lodash'
 
 import { DownloadFormat, DownloadStatus, DownloadType } from '../enums.js'
-import {
-  Programme,
-  School,
-  Session,
-  Team,
-  Vaccination,
-  User
-} from '../models.js'
+import { Programme, School, Session, Team, Vaccination } from '../models.js'
 import {
   convertIsoDateToObject,
   convertObjectToIsoDate,
@@ -28,12 +20,11 @@ import {
   stringToBoolean
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} DownloadOptions
+ * @typedef {BaseModelOptions & object} DownloadOptions
  * @property {string} [id] - Download ID
- * @property {Date} [createdAt] - Created date
- * @property {string} [createdBy_uid] - User who created download
- * @property {Date} [updatedAt] - Updated date
  * @property {Date} [startAt] - Date to start report
  * @property {object} [startAt_] - Date to start report from (from `dateInput`)
  * @property {Date} [endAt] - Date to end report
@@ -53,17 +44,20 @@ import {
 /**
  * @class Vaccination report download
  */
-export class Download {
+export class Download extends BaseModel {
+  static contextKey = 'downloads'
+  static identifierKey = 'id'
+  static ns = 'download'
+
   /**
    * @param {DownloadOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.id = options?.id || faker.string.hexadecimal({ length: 8, prefix: '' })
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.createdBy_uid = options?.createdBy_uid
-    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
     this.format = options?.format || DownloadFormat.CSV
     this.type = options?.type || DownloadType.Report
     this.team_ids = stringToArray(options?.team_ids)
@@ -92,21 +86,6 @@ export class Download {
       this.recordOffline = stringToBoolean(options?.recordOffline)
       this.school_id = options?.school_id
       this.session_id = options?.session_id
-    }
-  }
-
-  /**
-   * Get user who created upload
-   *
-   * @returns {User|undefined} User
-   */
-  get createdBy() {
-    try {
-      if (this.createdBy_uid) {
-        return User.findOne(this.createdBy_uid, this.context)
-      }
-    } catch (error) {
-      console.error('Upload.createdBy', error.message)
     }
   }
 
@@ -460,100 +439,12 @@ export class Download {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'download'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/downloads/${this.id}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Download>|undefined} Downloads
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.downloads).map(
-      (upload) => new Download(upload, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} id - Download ID
-   * @param {object} context - Context
-   * @returns {Download|undefined} Download
-   * @static
-   */
-  static findOne(id, context) {
-    if (context?.downloads?.[id]) {
-      return new Download(context.downloads[id], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {object} download - Download
-   * @param {object} context - Context
-   * @returns {Download} Created download
-   * @static
-   */
-  static create(download, context) {
-    const createdDownload = new Download(download)
-
-    // Update context
-    context.downloads = context.downloads || {}
-    context.downloads[createdDownload.id] = createdDownload
-
-    return createdDownload
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} id - Download ID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Download} Updated download
-   * @static
-   */
-  static update(id, updates, context) {
-    const updatedDownload = _.mergeWith(
-      Download.findOne(id, context),
-      updates,
-      (oldValue, newValue) => {
-        // Arrays shouldn’t be merged but replaced entirely
-        if (Array.isArray(oldValue)) {
-          return newValue
-        }
-      }
-    )
-    updatedDownload.updatedAt = today()
-
-    // Remove download context
-    delete updatedDownload.context
-
-    // Delete original download (with previous ID)
-    delete context.downloads[id]
-
-    // Update context
-    context.downloads[updatedDownload.id] = updatedDownload
-
-    return updatedDownload
   }
 
   /**
@@ -587,4 +478,5 @@ export class Download {
 
 /**
  * @import { DownloadVariable } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/download.js
+++ b/app/models/download.js
@@ -1,6 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import { addSeconds } from 'date-fns'
 import xlsx from 'json-as-xlsx'
+import _ from 'lodash'
 
 import { DownloadFormat, DownloadStatus, DownloadType } from '../enums.js'
 import {
@@ -23,6 +24,7 @@ import {
   formatList,
   formatProgress,
   formatTag,
+  stringToArray,
   stringToBoolean
 } from '../utils/string.js'
 
@@ -64,10 +66,10 @@ export class Download {
     this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
     this.format = options?.format || DownloadFormat.CSV
     this.type = options?.type || DownloadType.Report
-    this.team_ids = options?.team_ids
+    this.team_ids = stringToArray(options?.team_ids)
 
     if (this.type === DownloadType.Cohort) {
-      this.variables = options?.variables || []
+      this.variables = stringToArray(options?.variables)
     }
 
     if (this.type === DownloadType.Report) {
@@ -76,7 +78,7 @@ export class Download {
 
     if ([DownloadType.Cohort, DownloadType.Report].includes(this.type)) {
       this.programme_id = options?.programme_id
-      this.vaccination_uuids = options?.vaccination_uuids || []
+      this.vaccination_uuids = stringToArray(options?.vaccination_uuids)
     }
 
     if ([DownloadType.Report, DownloadType.Moves].includes(this.type)) {
@@ -145,28 +147,6 @@ export class Download {
   set endAt_(object) {
     if (object) {
       this.endAt = convertObjectToIsoDate(object)
-    }
-  }
-
-  /**
-   * Get variable for `checkboxes`s
-   *
-   * @returns {Array<string>} `checkboxes` array values
-   */
-  get variables_() {
-    return this.variables.map((variable) => String(variable))
-  }
-
-  /**
-   * Set variable from `checkboxes`s
-   *
-   * @param {Array<string>} array - checkboxes array values
-   */
-  set variables_(array) {
-    if (array) {
-      this.variables = array
-        .filter((item) => item !== '_unchecked')
-        .map((variable) => String(variable))
     }
   }
 
@@ -241,9 +221,9 @@ export class Download {
    */
   get teams() {
     if (this.context?.teams && this.team_ids) {
-      return this.team_ids
-        .filter((id) => id !== '_unchecked')
-        .map((id) => new Team(this.context?.teams[id], this.context))
+      return this.team_ids.map(
+        (id) => new Team(this.context?.teams[id], this.context)
+      )
     }
 
     return []
@@ -552,9 +532,15 @@ export class Download {
    * @static
    */
   static update(id, updates, context) {
-    const updatedDownload = Object.assign(
+    const updatedDownload = _.mergeWith(
       Download.findOne(id, context),
-      updates
+      updates,
+      (oldValue, newValue) => {
+        // Arrays shouldn’t be merged but replaced entirely
+        if (Array.isArray(oldValue)) {
+          return newValue
+        }
+      }
     )
     updatedDownload.updatedAt = today()
 

--- a/app/models/gillick.js
+++ b/app/models/gillick.js
@@ -1,12 +1,10 @@
 import { GillickCompetent } from '../enums.js'
-import { today } from '../utils/date.js'
 import { stringToBoolean } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} GillickOptions
- * @property {Date} [createdAt] - Created date
- * @property {string} [createdBy_uid] - User who created session
- * @property {Date} [updatedAt] - Updated date
+ * @typedef {BaseModelOptions & object} GillickOptions
  * @property {boolean} [q1] - Question 1
  * @property {boolean} [q2] - Question 2
  * @property {boolean} [q3] - Question 3
@@ -18,14 +16,15 @@ import { stringToBoolean } from '../utils/string.js'
 /**
  * @class Gillick assessment
  */
-export class Gillick {
+export class Gillick extends BaseModel {
+  static ns = 'gillick'
+
   /**
    * @param {GillickOptions} options - Options
    */
   constructor(options) {
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.createdBy_uid = options?.createdBy_uid
-    this.updatedAt = options?.createdAt && new Date(options.updatedAt)
+    super(options)
+
     this.q1 = stringToBoolean(options?.q1)
     this.q2 = stringToBoolean(options?.q2)
     this.q3 = stringToBoolean(options?.q3)
@@ -47,13 +46,8 @@ export class Gillick {
       return GillickCompetent.True
     }
   }
-
-  /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'gillick'
-  }
 }
+
+/**
+ * @import { BaseModelOptions } from './base.js'
+ */

--- a/app/models/instruction.js
+++ b/app/models/instruction.js
@@ -1,13 +1,13 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
+import { PatientSession, Programme } from '../models.js'
+
 import { BaseModel } from './base.js'
 
 /**
  * @typedef {BaseModelOptions & object} InstructionOptions
  * @property {string} [uuid] - Instruction UUID
  * @property {InstructionOutcome} [outcome] - Outcome
- * @property {string} [patientSession_uuid] - Patient session UUID
- * @property {string} [programme_id] - Programme ID
  */
 
 /**
@@ -25,12 +25,29 @@ export class Instruction extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.patientSession_uuid
+
+    /** @type {PatientSession|undefined} */
+    this.patientSession
+
+    /** @type {string|undefined} */
+    this.programme_id
+
+    /** @type {Programme|undefined} */
+    this.programme
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
-    this.patientSession_uuid = options?.patientSession_uuid
-    this.programme_id = options?.programme_id
   }
 }
+
+Instruction.relate(
+  'patientSession_uuid',
+  () => PatientSession,
+  'patientSession'
+)
+Instruction.relate('programme_id', () => Programme, 'programme')
 
 /**
  * @import { InstructionOutcome } from '../enums.js'

--- a/app/models/instruction.js
+++ b/app/models/instruction.js
@@ -1,12 +1,10 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
-import { today } from '../utils/date.js'
+import { BaseModel } from './base.js'
 
 /**
- * @typedef {object} InstructionOptions
+ * @typedef {BaseModelOptions & object} InstructionOptions
  * @property {string} [uuid] - Instruction UUID
- * @property {Date} [createdAt] - Created date
- * @property {string} [createdBy_uid] - User who performed instruction
  * @property {InstructionOutcome} [outcome] - Outcome
  * @property {string} [patientSession_uuid] - Patient session UUID
  * @property {string} [programme_id] - Programme ID
@@ -15,53 +13,26 @@ import { today } from '../utils/date.js'
 /**
  * @class Instruction
  */
-export class Instruction {
+export class Instruction extends BaseModel {
+  static contextKey = 'instructions'
+  static identifierKey = 'uuid'
+  static ns = 'instruction'
+
   /**
-   * @param {InstructionOptions} options - Options
+   * @param {BaseModelOptions & InstructionOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.createdBy_uid = options?.createdBy_uid
     this.patientSession_uuid = options?.patientSession_uuid
     this.programme_id = options?.programme_id
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - Instruction UUID
-   * @param {object} context - Context
-   * @returns {Instruction|undefined} Instruction
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.instructions?.[uuid]) {
-      return new Instruction(context.instructions[uuid], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {object} instruction - Instruction
-   * @param {object} context - Context
-   * @returns {Instruction} Created instruction
-   * @static
-   */
-  static create(instruction, context) {
-    const createdInstruction = new Instruction(instruction)
-
-    // Update context
-    context.instructions = context.instructions || {}
-    context.instructions[createdInstruction.uuid] = createdInstruction
-
-    return createdInstruction
   }
 }
 
 /**
  * @import { InstructionOutcome } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/location.js
+++ b/app/models/location.js
@@ -14,7 +14,6 @@ import { BaseModel } from './base.js'
  * @property {string} [addressLine2] - Address line 2
  * @property {string} [addressLevel1] - Address level 1
  * @property {string} [postalCode] - Postcode
- * @property {string} [team_id] - Team ID
  * @property {Array<SessionPresetName>} [presetNames] - Session preset names
  */
 
@@ -31,6 +30,12 @@ export class Location extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.team_id
+
+    /** @type {Team|undefined} */
+    this.team
+
     this.context = context
     this.id = options?.id || faker.helpers.replaceSymbols('?#####')
     this.name = options?.name
@@ -38,7 +43,6 @@ export class Location extends BaseModel {
     this.addressLine2 = options?.addressLine2
     this.addressLevel1 = options?.addressLevel1
     this.postalCode = options?.postalCode
-    this.team_id = options?.team_id
     this.presetNames = options?.presetNames || []
   }
 
@@ -67,22 +71,6 @@ export class Location extends BaseModel {
     return {
       name: this.name,
       ...this.address
-    }
-  }
-
-  /**
-   * Get team
-   *
-   * @returns {Team|undefined} Team
-   */
-  get team() {
-    try {
-      const team = this.context?.teams[this.team_id]
-      if (team) {
-        return new Team(team)
-      }
-    } catch (error) {
-      console.error('Location.team', error.message)
     }
   }
 
@@ -162,6 +150,8 @@ export class Location extends BaseModel {
     )
   }
 }
+
+Location.relate('team_id', () => Team, 'team')
 
 /**
  * @import { SessionPreset, SessionPresetName } from '../enums.js'

--- a/app/models/location.js
+++ b/app/models/location.js
@@ -4,8 +4,10 @@ import programmesData from '../datasets/programmes.js'
 import { SessionPresets } from '../enums.js'
 import { Programme, Team } from '../models.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} LocationOptions
+ * @typedef {BaseModelOptions & object} LocationOptions
  * @property {string} [name] - Name
  * @property {string} [id] - Location ID
  * @property {string} [addressLine1] - Address line 1
@@ -19,12 +21,16 @@ import { Programme, Team } from '../models.js'
 /**
  * @class Location
  */
-export class Location {
+export class Location extends BaseModel {
+  static ns = 'location'
+
   /**
    * @param {LocationOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.id = options?.id || faker.helpers.replaceSymbols('?#####')
     this.name = options?.name
@@ -155,17 +161,9 @@ export class Location {
       }
     )
   }
-
-  /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'location'
-  }
 }
 
 /**
  * @import { SessionPreset, SessionPresetName } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/move.js
+++ b/app/models/move.js
@@ -1,7 +1,6 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
-import schools from '../datasets/schools.js'
-import { Patient, Team } from '../models.js'
+import { Patient, School, Team } from '../models.js'
 import { formatDate } from '../utils/date.js'
 
 import { BaseModel } from './base.js'
@@ -11,10 +10,6 @@ import { BaseModel } from './base.js'
  * @property {string} [uuid] - Move UUID
  * @property {boolean} [ignored] - Reported move is ignored
  * @property {MoveSource} [source] - Reporting source
- * @property {string} [team_id] - Team ID (moving from)
- * @property {string} [from_urn] - Current school URN (moving from)
- * @property {string} [to_urn] - Proposed school URN (moving to)
- * @property {string} [patient_uuid] - Patient UUID
  */
 
 /**
@@ -31,29 +26,34 @@ export class Move extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.from_urn
+
+    /** @type {School|undefined} */
+    this.from
+
+    /** @type {string|undefined} */
+    this.patient_uuid
+
+    /** @type {Patient|undefined} */
+    this.patient
+
+    /** @type {string|undefined} */
+    this.team_id
+
+    /** @type {Team|undefined} */
+    this.team
+
+    /** @type {string|undefined} */
+    this.to_urn
+
+    /** @type {School|undefined} */
+    this.to
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
     this.ignored = options?.ignored || false
     this.source = options?.source
-    this.team_id = options?.team_id
-    this.from_urn = options?.from_urn
-    this.to_urn = options?.to_urn
-    this.patient_uuid = options?.patient_uuid
-  }
-
-  /**
-   * Get patient
-   *
-   * @returns {Patient|undefined} Patient
-   */
-  get patient() {
-    try {
-      if (this.patient_uuid) {
-        return Patient.findOne(this.patient_uuid, this.context)
-      }
-    } catch (error) {
-      console.error('Move.patient', error.message)
-    }
   }
 
   get movement() {
@@ -74,17 +74,15 @@ export class Move extends BaseModel {
       {},
       {
         get: (_target, prop) => {
-          const getTeam = () => Team.findOne(this.team_id, this.context)
-
           switch (prop) {
             case 'createdAt':
               return formatDate(this.createdAt, { dateStyle: 'long' })
             case 'team_id':
-              return this.team_id ? getTeam()?.name : 'Unknown team'
+              return this.team?.name || 'Unknown team'
             case 'from_urn':
-              return schools[this.from_urn]?.name || 'Unknown school'
+              return this.from?.name || 'Unknown school'
             case 'to_urn':
-              return schools[this.to_urn]?.name || 'Unknown school'
+              return this.to?.name || 'Unknown school'
             default:
               return undefined
           }
@@ -126,6 +124,11 @@ export class Move extends BaseModel {
     Move.delete(uuid, context)
   }
 }
+
+Move.relate('from_urn', () => School, 'from')
+Move.relate('patient_uuid', () => Patient, 'patient')
+Move.relate('team_id', () => Team, 'team')
+Move.relate('to_urn', () => School, 'to')
 
 /**
  * @import { MoveSource } from '../enums.js'

--- a/app/models/move.js
+++ b/app/models/move.js
@@ -2,13 +2,13 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 
 import schools from '../datasets/schools.js'
 import { Patient, Team } from '../models.js'
-import { formatDate, getDateValueDifference, today } from '../utils/date.js'
+import { formatDate } from '../utils/date.js'
+
+import { BaseModel } from './base.js'
 
 /**
- * @typedef {object} MoveOptions
+ * @typedef {BaseModelOptions & object} MoveOptions
  * @property {string} [uuid] - Move UUID
- * @property {Date} [createdAt] - Reported date
- * @property {Date} [updatedAt] - Updated date
  * @property {boolean} [ignored] - Reported move is ignored
  * @property {MoveSource} [source] - Reporting source
  * @property {string} [team_id] - Team ID (moving from)
@@ -20,18 +20,19 @@ import { formatDate, getDateValueDifference, today } from '../utils/date.js'
 /**
  * @class Move
  */
-export class Move {
+export class Move extends BaseModel {
+  static contextKey = 'moves'
+  static ns = 'move'
+
   /**
    * @param {MoveOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.updatedAt = options?.updatedAt
-      ? new Date(options.updatedAt)
-      : undefined
     this.ignored = options?.ignored || false
     this.source = options?.source
     this.team_id = options?.team_id
@@ -93,85 +94,12 @@ export class Move {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'move'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/moves/${this.uuid}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Move>|undefined} Moves
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context?.moves ?? {})
-      .map((move) => new Move(move, context))
-      .filter((move) => !move.ignored)
-      .sort((a, b) => getDateValueDifference(a.createdAt, b.createdAt))
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - Move UUID
-   * @param {object} context - Context
-   * @returns {Move|undefined} Move
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.moves?.[uuid]) {
-      return new Move(context.moves[uuid], context)
-    }
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} uuid - Move UUID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Move} Updated download
-   * @static
-   */
-  static update(uuid, updates, context) {
-    const updatedMove = Object.assign(Move.findOne(uuid, context), updates)
-    updatedMove.updatedAt = today()
-
-    // Remove move context
-    delete updatedMove.context
-
-    // Delete original move (with previous UUID)
-    delete context.moves[uuid]
-
-    // Update context
-    context.moves[updatedMove.uuid] = updatedMove
-
-    return updatedMove
-  }
-
-  /**
-   * Delete
-   *
-   * @param {string} uuid - Move UUID
-   * @param {object} context - Context
-   * @static
-   */
-  static delete(uuid, context) {
-    delete context.moves[uuid]
   }
 
   /**
@@ -201,4 +129,5 @@ export class Move {
 
 /**
  * @import { MoveSource } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/notice.js
+++ b/app/models/notice.js
@@ -10,7 +10,6 @@ import { BaseModel } from './base.js'
  * @property {string} [uuid] - Notice UUID
  * @property {Date} [archivedAt] - Archived date
  * @property {NoticeType} [type] - Notice type
- * @property {string} [patient_uuid] - Patient notice applies to
  */
 
 /**
@@ -27,26 +26,16 @@ export class Notice extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.patient_uuid
+
+    /** @type {Patient|undefined} */
+    this.patient
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
     this.archivedAt = options?.archivedAt && new Date(options.archivedAt)
     this.type = options?.type
-    this.patient_uuid = options?.patient_uuid
-  }
-
-  /**
-   * Get patient
-   *
-   * @returns {Patient|undefined} Patient
-   */
-  get patient() {
-    try {
-      if (this.patient_uuid) {
-        return Patient.findOne(this.patient_uuid, this.context)
-      }
-    } catch (error) {
-      console.error('Notice.patient', error.message)
-    }
   }
 
   /**
@@ -100,6 +89,8 @@ export class Notice extends BaseModel {
     return archivedNotice
   }
 }
+
+Notice.relate('patient_uuid', () => Patient, 'patient')
 
 /**
  * @import { NoticeType } from '../enums.js'

--- a/app/models/notice.js
+++ b/app/models/notice.js
@@ -1,12 +1,13 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
 import { Patient } from '../models.js'
-import { formatDate, getDateValueDifference, today } from '../utils/date.js'
+import { formatDate } from '../utils/date.js'
+
+import { BaseModel } from './base.js'
 
 /**
- * @typedef {object} NoticeOptions
+ * @typedef {BaseModelOptions & object} NoticeOptions
  * @property {string} [uuid] - Notice UUID
- * @property {Date} [createdAt] - Created date
  * @property {Date} [archivedAt] - Archived date
  * @property {NoticeType} [type] - Notice type
  * @property {string} [patient_uuid] - Patient notice applies to
@@ -15,15 +16,19 @@ import { formatDate, getDateValueDifference, today } from '../utils/date.js'
 /**
  * @class Notice
  */
-export class Notice {
+export class Notice extends BaseModel {
+  static contextKey = 'notices'
+  static ns = 'notice'
+
   /**
-   * @param {NoticeOptions} options - Options
+   * @param {BaseModelOptions & NoticeOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
     this.archivedAt = options?.archivedAt && new Date(options.archivedAt)
     this.type = options?.type
     this.patient_uuid = options?.patient_uuid
@@ -66,48 +71,12 @@ export class Notice {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'notice'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/notices/${this.uuid}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Notice>|undefined} Notices
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.notices)
-      .map((notice) => new Notice(notice, context))
-      .sort((a, b) => getDateValueDifference(a.createdAt, b.createdAt))
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - Notice UUID
-   * @param {object} context - Context
-   * @returns {Notice|undefined} Notice
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.notices?.[uuid]) {
-      return new Notice(context.notices[uuid], context)
-    }
   }
 
   /**
@@ -134,4 +103,5 @@ export class Notice {
 
 /**
  * @import { NoticeType } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -33,8 +33,10 @@ import {
   formatWithSecondaryText
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} PatientProgrammeOptions
+ * @typedef {BaseModelOptions & object} PatientProgrammeOptions
  * @property {boolean} [invitedToClinic] - Invited to clinic
  * @property {string} [patient_uuid] - Patient UUID
  * @property {string} [programme_id] - Programme ID
@@ -43,12 +45,16 @@ import {
 /**
  * @class Patient Programme
  */
-export class PatientProgramme {
+export class PatientProgramme extends BaseModel {
+  static ns = 'patientProgramme'
+
   /**
    * @param {PatientProgrammeOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.invitedToClinic = options?.invitedToClinic
     this.patient_uuid = options?.patient_uuid
@@ -629,15 +635,6 @@ export class PatientProgramme {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'patientProgramme'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
@@ -650,4 +647,5 @@ export class PatientProgramme {
 /**
  * @import { RecordVaccineCriteria } from '../enums.js'
  * @import { PatientSession } from '../models.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -38,8 +38,6 @@ import { BaseModel } from './base.js'
 /**
  * @typedef {BaseModelOptions & object} PatientProgrammeOptions
  * @property {boolean} [invitedToClinic] - Invited to clinic
- * @property {string} [patient_uuid] - Patient UUID
- * @property {string} [programme_id] - Programme ID
  */
 
 /**
@@ -55,44 +53,20 @@ export class PatientProgramme extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.patient_uuid
+
+    /** @type {Patient|undefined} */
+    this.patient
+
+    /** @type {string|undefined} */
+    this.programme_id
+
+    /** @type {Programme|undefined} */
+    this.programme
+
     this.context = context
     this.invitedToClinic = options?.invitedToClinic
-    this.patient_uuid = options?.patient_uuid
-    this.programme_id = options?.programme_id
-  }
-
-  /**
-   * Get patient
-   *
-   * @returns {Patient|undefined} Patient
-   */
-  get patient() {
-    try {
-      if (this.patient_uuid) {
-        return Patient.findOne(this.patient_uuid, this.context)
-      }
-    } catch (error) {
-      console.error('PatientProgramme.patient', error.message)
-    }
-  }
-
-  /**
-   * Get programme
-   *
-   * @returns {Programme|undefined} Programme
-   */
-  get programme() {
-    try {
-      const programme = Programme.findOne(this.programme_id, this.context)
-
-      if (this.programme_id === 'mmr' && this.patient?.age <= 6) {
-        programme.name = 'MMRV'
-      }
-
-      return programme
-    } catch (error) {
-      console.error('PatientProgramme.programme', error.message)
-    }
   }
 
   /**
@@ -643,6 +617,9 @@ export class PatientProgramme extends BaseModel {
     return `/patients/${this.patient_uuid}/programmes/${this.programme_id}`
   }
 }
+
+PatientProgramme.relate('patient_uuid', () => Patient, 'patient')
+PatientProgramme.relate('programme_id', () => Programme, 'programme')
 
 /**
  * @import { RecordVaccineCriteria } from '../enums.js'

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -78,10 +78,6 @@ import { BaseModel } from './base.js'
  * @property {Gillick} [gillick] - Gillick assessment
  * @property {Array<AuditEvent>} [notes] - Notes
  * @property {boolean} [alternative] - Administer alternative vaccine
- * @property {string} [patient_uuid] - Patient UUID
- * @property {string} [instruction_uuid] - Instruction UUID
- * @property {string} [programme_id] - Programme ID
- * @property {string} [session_id] - Session ID
  */
 
 /**
@@ -99,30 +95,35 @@ export class PatientSession extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.instruction_uuid
+
+    /** @type {Patient|undefined} */
+    this.instruction
+
+    /** @type {string|undefined} */
+    this.patient_uuid
+
+    /** @type {Patient|undefined} */
+    this.patient
+
+    /** @type {string|undefined} */
+    this.programme_id
+
+    /** @type {Programme|undefined} */
+    this.programme
+
+    /** @type {string|undefined} */
+    this.session_id
+
+    /** @type {Session|undefined} */
+    this.session
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
     this.gillick = options?.gillick && new Gillick(options.gillick)
     this.notes = options?.notes || []
     this.alternative = options?.alternative || false
-    this.patient_uuid = options?.patient_uuid
-    this.instruction_uuid = options?.instruction_uuid
-    this.programme_id = options?.programme_id
-    this.session_id = options?.session_id
-  }
-
-  /**
-   * Get patient
-   *
-   * @returns {Patient|undefined} Patient
-   */
-  get patient() {
-    try {
-      if (this.patient_uuid) {
-        return Patient.findOne(this.patient_uuid, this.context)
-      }
-    } catch (error) {
-      console.error('PatientSession.patient', error.message)
-    }
   }
 
   /**
@@ -141,19 +142,6 @@ export class PatientSession extends BaseModel {
    */
   get yearGroup() {
     return getYearGroup(this.patient?.dob, this.session?.academicYear)
-  }
-
-  /**
-   * Get instruction
-   *
-   * @returns {Instruction|undefined} Instruction
-   */
-  get instruction() {
-    try {
-      return Instruction.findOne(this.instruction_uuid, this.context)
-    } catch (error) {
-      console.error('PatientSession.instruction', error.message)
-    }
   }
 
   /**
@@ -303,32 +291,6 @@ export class PatientSession extends BaseModel {
   get screenVaccineCriteria() {
     if (this.programme && this.responses) {
       return getScreenVaccineCriteria(this.programme, this.responses)
-    }
-  }
-
-  /**
-   * Get programme
-   *
-   * @returns {Programme|undefined} Programme
-   */
-  get programme() {
-    try {
-      return Programme.findOne(this.programme_id, this.context)
-    } catch (error) {
-      console.error('PatientSession.programme', error.message)
-    }
-  }
-
-  /**
-   * Get session
-   *
-   * @returns {Session|undefined} Session
-   */
-  get session() {
-    try {
-      return Session.findOne(this.session_id, this.context)
-    } catch (error) {
-      console.error('PatientSession.session', error.message)
     }
   }
 
@@ -1192,6 +1154,11 @@ export class PatientSession extends BaseModel {
     })
   }
 }
+
+PatientSession.relate('instruction_uuid', () => Instruction, 'instruction')
+PatientSession.relate('patient_uuid', () => Patient, 'patient')
+PatientSession.relate('programme_id', () => Programme, 'programme')
+PatientSession.relate('session_id', () => Session, 'session')
 
 /**
  * @import { InstructionOutcome, ScreenVaccineCriteria } from '../enums.js'

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -36,8 +36,7 @@ import {
 import {
   formatDate,
   getDateValueDifference,
-  getYearGroup,
-  today
+  getYearGroup
 } from '../utils/date.js'
 import {
   getInstructionOutcome,
@@ -71,12 +70,11 @@ import {
   getScreenVaccineCriteria
 } from '../utils/triage.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} PatientSessionOptions
+ * @typedef {BaseModelOptions & object} PatientSessionOptions
  * @property {string} [uuid] - Patient session UUID
- * @property {Date} [createdAt] - Created date
- * @property {string} [createdBy_uid] - User who created patient session
- * @property {Date} [updatedAt] - Updated date
  * @property {Gillick} [gillick] - Gillick assessment
  * @property {Array<AuditEvent>} [notes] - Notes
  * @property {boolean} [alternative] - Administer alternative vaccine
@@ -89,17 +87,20 @@ import {
 /**
  * @class Patient Session
  */
-export class PatientSession {
+export class PatientSession extends BaseModel {
+  static contextKey = 'patientSessions'
+  static identifierKey = 'uuid'
+  static ns = 'patientSession'
+
   /**
    * @param {PatientSessionOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.createdBy_uid = options?.createdBy_uid
-    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
     this.gillick = options?.gillick && new Gillick(options.gillick)
     this.notes = options?.notes || []
     this.alternative = options?.alternative || false
@@ -1015,94 +1016,12 @@ export class PatientSession {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'patientSession'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/sessions/${this.session_id}/patients/${this.patient?.nhsn}/${this.programme_id}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<PatientSession>|undefined} Patient sessions
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.patientSessions).map(
-      (patientSession) => new PatientSession(patientSession, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - Patient UUID
-   * @param {object} context - Context
-   * @returns {PatientSession|undefined} Patient
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.patientSessions?.[uuid]) {
-      return new PatientSession(context.patientSessions[uuid], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {object} patientSession - Patient session
-   * @param {object} context - Context
-   * @returns {PatientSession} Created patient session
-   * @static
-   */
-  static create(patientSession, context) {
-    const createdPatientSession = new PatientSession(patientSession)
-
-    // Update context
-    context.patientSessions = context.patientSessions || {}
-    context.patientSessions[createdPatientSession.uuid] = createdPatientSession
-
-    return createdPatientSession
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} uuid - Patient UUID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {PatientSession} Updated patient session
-   * @static
-   */
-  static update(uuid, updates, context) {
-    const updatedPatientSession = Object.assign(
-      PatientSession.findOne(uuid, context),
-      updates
-    )
-    updatedPatientSession.updatedAt = today()
-
-    // Remove patient context
-    delete updatedPatientSession.context
-
-    // Delete original patient session (with previous UUID)
-    delete context.patientSessions[uuid]
-
-    // Update context
-    context.patientSessions[updatedPatientSession.uuid] = updatedPatientSession
-
-    return updatedPatientSession
   }
 
   /**
@@ -1277,4 +1196,5 @@ export class PatientSession {
 /**
  * @import { InstructionOutcome, ScreenVaccineCriteria } from '../enums.js'
  * @import { Contact, PatientProgramme, Reply, Vaccination, Vaccine } from '../models.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -23,6 +23,7 @@ import {
   Reply,
   Vaccination
 } from '../models.js'
+import { getUpdatedFields } from '../utils/audit-event.js'
 import { getDateValueDifference, removeDays, today } from '../utils/date.js'
 import { tokenize } from '../utils/object.js'
 import { getPreferredNames } from '../utils/reply.js'
@@ -606,50 +607,16 @@ export class Patient extends Child {
    * @param {string} uuid - Patient record UUID
    * @param {object} updates - Updates
    * @param {object} context - Context
-   * @param {boolean} log - Update activity log
    * @returns {Patient} Updated patient record
    * @static
    */
-  static update(uuid, updates, context, log = false) {
+  static update(uuid, updates, context) {
     // Sanitise any checkbox values in the updates
     if (updates?.clinicProgramme_ids) {
       updates.clinicProgramme_ids = stringToArray(updates.clinicProgramme_ids)
     }
 
-    const patient = Patient.findOne(uuid, context)
     const updatedPatient = _.merge(Patient.findOne(uuid, context), updates)
-
-    // Add update to activity log
-    // TODO: Make this work with nested values
-    if (log) {
-      const updatedFields = []
-      const thing = new Patient(updatedPatient, context)
-      for (let key of Object.keys(updates)) {
-        // Prefer ISO 8601 date value instead date input object
-        if (key.endsWith('_')) {
-          key = key.slice(0, -1)
-        }
-
-        const before = patient.formatted?.[key] || patient?.[key]
-        const after = thing.formatted?.[key] || thing?.[key]
-
-        if (!_.isMatch(before, after)) {
-          updatedFields.push({
-            key: `patient.${key}.label`,
-            before: String(before).replace('<br>', ', '),
-            after: String(after).replace('<br>', ', ')
-          })
-        }
-      }
-
-      updatedPatient.addEvent({
-        name: activity.patient.updated(),
-        type: AuditEventType.Record,
-        createdAt: today(),
-        createdBy_uid: updates.createdBy_uid,
-        updatedFields
-      })
-    }
 
     // Remove patient context
     delete updatedPatient.context
@@ -661,15 +628,6 @@ export class Patient extends Child {
     context.patients[updatedPatient.uuid] = updatedPatient
 
     return updatedPatient
-  }
-
-  /**
-   * Add event to activity log
-   *
-   * @param {object} event - Event
-   */
-  addEvent(event) {
-    this.events.push(new AuditEvent(event))
   }
 
   /**
@@ -692,6 +650,34 @@ export class Patient extends Child {
     })
 
     return archivedPatient
+  }
+
+  /**
+   * Add event to activity log
+   *
+   * @param {object} event - Event
+   */
+  addEvent(event) {
+    this.events.push(new AuditEvent(event))
+  }
+
+  /**
+   * Add updates to activity log
+   *
+   * @param {Patient} before - Original values
+   */
+  addAuditRecord(before) {
+    const updatedFields = getUpdatedFields(before, this)
+
+    if (updatedFields.length) {
+      this.addEvent({
+        name: activity.patient.updated(),
+        type: AuditEventType.Record,
+        createdAt: today(),
+        createdBy_uid: this.updatedBy_uid,
+        updatedFields
+      })
+    }
   }
 
   /**

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -1,5 +1,4 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
-import _ from 'lodash'
 
 import activity from '../datasets/activity.js'
 import programmesData from '../datasets/programmes.js'
@@ -39,7 +38,7 @@ import {
 } from '../utils/string.js'
 
 /**
- * @typedef {object} PatientOptions
+ * @typedef {ChildOptions & object} PatientOptions
  * @property {string} [nhsn] - NHS number
  * @property {boolean} [invalid] - Flagged as invalid
  * @property {boolean} [sensitive] - Flagged as sensitive
@@ -60,8 +59,12 @@ import {
  * @augments Child
  */
 export class Patient extends Child {
+  static contextKey = 'patients'
+  static identifierKey = 'uuid'
+  static ns = 'patient'
+
   /**
-   * @param {PatientOptions & ChildOptions} options - Options
+   * @param {PatientOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
@@ -538,91 +541,12 @@ export class Patient extends Child {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'patient'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/patients/${this.uuid}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Patient>|undefined} Patient records
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.patients).map(
-      (patient) => new Patient(patient, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - Patient UUID
-   * @param {object} context - Context
-   * @returns {Patient|undefined} Patient record
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.patients?.[uuid]) {
-      return new Patient(context.patients[uuid], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @template {Child | Patient} PatientType
-   * @param {PatientType} patient - Patient record
-   * @param {object} context - Context
-   * @returns {Patient} Created patient record
-   * @static
-   */
-  static create(patient, context) {
-    const createdPatient = new Patient(patient)
-
-    // Update context
-    context.patients = context.patients || {}
-    context.patients[createdPatient.uuid] = createdPatient
-
-    return createdPatient
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} uuid - Patient record UUID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Patient} Updated patient record
-   * @static
-   */
-  static update(uuid, updates, context) {
-    const updatedPatient = _.merge(Patient.findOne(uuid, context), updates)
-
-    // Remove patient context
-    delete updatedPatient.context
-
-    // Delete original patient (with previous UUID)
-    delete context.patients[uuid]
-
-    // Update context
-    context.patients[updatedPatient.uuid] = updatedPatient
-
-    return updatedPatient
   }
 
   /**
@@ -635,7 +559,9 @@ export class Patient extends Child {
    * @static
    */
   static archive(uuid, archive, context) {
-    const archivedPatient = Patient.update(uuid, archive, context)
+    const archivedPatient = /** @type {Patient} */ (
+      super.update(uuid, archive, context)
+    )
 
     archivedPatient.addEvent({
       name: activity.patient.archived(archive),

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -47,8 +47,8 @@ import {
  * @property {Partial<Child>} [pendingChanges] - Pending changes to record values
  * @property {ArchiveRecordReason} [archiveReason] - Archival reason
  * @property {string} [archiveReasonOther] - Other archival reason
- * @property {Array<string>} [clinicProgramme_ids] - Clinic programme invitations
  * @property {Array<AuditEvent>} [events] - Events
+ * @property {Array<string>} [clinicProgramme_ids] - Clinic programme invitations
  * @property {Array<string>} [reply_uuids] - Reply IDs
  * @property {Array<string>} [contact_uuids] - Contact UUIDS
  * @property {Array<string>} [patientSession_uuids] - Patient session IDs
@@ -78,12 +78,12 @@ export class Patient extends Child {
     this.archiveReasonOther = options?.archiveReasonOther
     this.pendingChanges = options?.pendingChanges || {}
 
-    this.clinicProgramme_ids = options?.clinicProgramme_ids || []
     this.events = options?.events || []
-    this.reply_uuids = options?.reply_uuids || []
-    this.contact_uuids = options?.contact_uuids || []
-    this.patientSession_uuids = options?.patientSession_uuids || []
-    this.vaccination_uuids = options?.vaccination_uuids || []
+    this.clinicProgramme_ids = stringToArray(options?.clinicProgramme_ids)
+    this.reply_uuids = stringToArray(options?.reply_uuids)
+    this.contact_uuids = stringToArray(options?.contact_uuids)
+    this.patientSession_uuids = stringToArray(options?.patientSession_uuids)
+    this.vaccination_uuids = stringToArray(options?.vaccination_uuids)
   }
 
   /**
@@ -611,11 +611,6 @@ export class Patient extends Child {
    * @static
    */
   static update(uuid, updates, context) {
-    // Sanitise any checkbox values in the updates
-    if (updates?.clinicProgramme_ids) {
-      updates.clinicProgramme_ids = stringToArray(updates.clinicProgramme_ids)
-    }
-
     const updatedPatient = _.merge(Patient.findOne(uuid, context), updates)
 
     // Remove patient context

--- a/app/models/pds-record.js
+++ b/app/models/pds-record.js
@@ -1,5 +1,4 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
-import _ from 'lodash'
 
 import { Child, Contact } from '../models.js'
 import { tokenize } from '../utils/object.js'
@@ -12,7 +11,7 @@ import {
 } from '../utils/string.js'
 
 /**
- * @typedef {object} PDSRecordOptions
+ * @typedef {ChildOptions & object} PDSRecordOptions
  * @property {string} [nhsn] - NHS number
  * @property {boolean} [invalid] - Flagged as invalid
  * @property {boolean} [sensitive] - Flagged as sensitive
@@ -25,8 +24,12 @@ import {
  * @augments Child
  */
 export class PDSRecord extends Child {
+  static contextKey = 'pdsRecords'
+  static identifierKey = 'uuid'
+  static ns = 'pdsRecord'
+
   /**
-   * @param {PDSRecordOptions & ChildOptions} options - Options
+   * @param {PDSRecordOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
@@ -125,90 +128,12 @@ export class PDSRecord extends Child {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'pdsRecord'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/pds/${this.uuid}/new/result`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<PDSRecord>|undefined} PDS records
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.pdsRecords).map(
-      (pdsRecord) => new PDSRecord(pdsRecord, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - PDS record UUID
-   * @param {object} context - Context
-   * @returns {PDSRecord|undefined} PDS record
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.pdsRecords?.[uuid]) {
-      return new PDSRecord(context.pdsRecords[uuid], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {PDSRecord} pdsRecord - PDS record
-   * @param {object} context - Context
-   * @returns {PDSRecord} Created PDS record
-   * @static
-   */
-  static create(pdsRecord, context) {
-    const createdRecord = new PDSRecord(pdsRecord)
-
-    // Update context
-    context.pdsRecords = context.pdsRecords || {}
-    context.pdsRecords[createdRecord.uuid] = createdRecord
-
-    return createdRecord
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} uuid - PDS record UUID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {PDSRecord} Updated PDS record
-   * @static
-   */
-  static update(uuid, updates, context) {
-    const updatedPdsRecord = _.merge(PDSRecord.findOne(uuid, context), updates)
-
-    // Remove patient context
-    delete updatedPdsRecord.context
-
-    // Delete original PDS record (with previous UUID)
-    delete context.pdsRecords[uuid]
-
-    // Update context
-    context.pdsRecords[updatedPdsRecord.uuid] = updatedPdsRecord
-
-    return updatedPdsRecord
   }
 }
 

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -10,8 +10,10 @@ import {
   sentenceCaseProgrammeName
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} ProgrammeOptions
+ * @typedef {BaseModelOptions & object} ProgrammeOptions
  * @property {string} [id] - Programme ID
  * @property {ProgrammeType} [type] - Programme type
  * @property {boolean} [hidden] - Hidden
@@ -33,12 +35,17 @@ import {
 /**
  * @class Programme
  */
-export class Programme {
+export class Programme extends BaseModel {
+  static contextKey = 'programmes'
+  static ns = 'programme'
+
   /**
    * @param {ProgrammeOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.id = options?.id
     this.type = options?.type
@@ -265,15 +272,6 @@ export class Programme {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'programme'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
@@ -281,35 +279,9 @@ export class Programme {
   get uri() {
     return `/reports/${this.id}`
   }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Programme>|undefined} Programmes
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.programmes).map(
-      (programme) => new Programme(programme, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} id - Programme ID
-   * @param {object} context - Context
-   * @returns {Programme|undefined} Programme
-   * @static
-   */
-  static findOne(id, context) {
-    if (context?.programmes?.[id]) {
-      return new Programme(context.programmes[id], context)
-    }
-  }
 }
 
 /**
  * @import { PatientStatus } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -62,10 +62,6 @@ import { BaseModel } from './base.js'
  * @property {string} [refusalReasonDetails] - Refusal reason details
  * @property {boolean} [selfConsent] - Reply given by child
  * @property {string} [note] - Note about this response
- * @property {string} [contact_uuid] - Contact UUID
- * @property {string} [patient_uuid] - Patient UUID
- * @property {string} [programme_id] - Programme ID
- * @property {string} [session_id] - Session ID
  */
 
 /**
@@ -82,6 +78,30 @@ export class Reply extends BaseModel {
    */
   constructor(options, context) {
     super(options, context)
+
+    /** @type {string|undefined} */
+    this.contact_uuid
+
+    /** @type {Contact|undefined} */
+    this.contact
+
+    /** @type {string|undefined} */
+    this.patient_uuid
+
+    /** @type {Patient|undefined} */
+    this.patient
+
+    /** @type {string|undefined} */
+    this.programme_id
+
+    /** @type {Programme|undefined} */
+    this.programme
+
+    /** @type {string|undefined} */
+    this.session_id
+
+    /** @type {Session|undefined} */
+    this.session
 
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
@@ -366,79 +386,6 @@ export class Reply extends BaseModel {
   }
 
   /**
-   * Get contact
-   *
-   * @returns {Contact|undefined} Contact
-   */
-  get contact() {
-    try {
-      if (this.contact_uuid) {
-        return Contact.findOne(this.contact_uuid, this.context)
-      }
-    } catch (error) {
-      console.error('Reply.contact (get)', error.message)
-    }
-  }
-
-  /**
-   * Set contact
-   */
-  set contact(updates) {
-    try {
-      if (this.contact_uuid) {
-        Contact.update(this.contact_uuid, updates, this.context)
-      }
-    } catch (error) {
-      console.error('Reply.contact (set)', error.message)
-    }
-  }
-
-  /**
-   * Get patient
-   *
-   * @returns {Patient|undefined} Patient
-   */
-  get patient() {
-    try {
-      if (this.patient_uuid) {
-        return Patient.findOne(this.patient_uuid, this.context)
-      }
-    } catch (error) {
-      console.error('Reply.patient', error.message)
-    }
-  }
-
-  /**
-   * Get programme
-   *
-   * @returns {Programme|undefined} User
-   */
-  get programme() {
-    try {
-      if (this.programme_id) {
-        return Programme.findOne(this.programme_id, this.context)
-      }
-    } catch (error) {
-      console.error('Upload.programme', error.message)
-    }
-  }
-
-  /**
-   * Get session
-   *
-   * @returns {Session|undefined} Session
-   */
-  get session() {
-    try {
-      if (this.session_id) {
-        return Session.findOne(this.session_id, this.context)
-      }
-    } catch (error) {
-      console.error('Reply.session', error.message)
-    }
-  }
-
-  /**
    * Get formatted values
    *
    * @returns {object} Formatted values
@@ -529,6 +476,11 @@ export class Reply extends BaseModel {
     return `${this.session.consentUrl}/${this.uuid}`
   }
 }
+
+Reply.relate('contact_uuid', () => Contact, 'contact')
+Reply.relate('patient_uuid', () => Patient, 'patient')
+Reply.relate('programme_id', () => Programme, 'programme')
+Reply.relate('session_id', () => Session, 'session')
 
 /**
  * @import { BaseModelOptions } from './base.js'

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -1,6 +1,5 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import { addMonths } from 'date-fns'
-import _ from 'lodash'
 
 import vaccines from '../datasets/vaccines.js'
 import {
@@ -21,10 +20,9 @@ import {
   Patient,
   Programme,
   Session,
-  User,
   Vaccination
 } from '../models.js'
-import { formatDate, today } from '../utils/date.js'
+import { formatDate } from '../utils/date.js'
 import {
   getConsentOutcomeStatus,
   getReplyDecisionStatus
@@ -38,12 +36,11 @@ import {
   stringToBoolean
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} ReplyOptions
+ * @typedef {BaseModelOptions & object} ReplyOptions
  * @property {string} [uuid] - Reply UUID
- * @property {Date} [createdAt] - Created date
- * @property {string} [createdBy_uid] - User who created reply
- * @property {Date} [updatedAt] - Updated date
  * @property {Child} [child] - Child
  * @property {Contact} [contact_] - Parent or guardian
  * @property {ReplyDecision} [decision] - Consent decision
@@ -74,17 +71,20 @@ import {
 /**
  * @class Reply
  */
-export class Reply {
+export class Reply extends BaseModel {
+  static contextKey = 'replies'
+  static identifierKey = 'uuid'
+  static ns = 'reply'
+
   /**
    * @param {ReplyOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.createdBy_uid = options?.createdBy_uid
-    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
     this.child = options?.child && new Child(options.child)
     this.alternative =
       options?.alternative && stringToBoolean(options?.alternative)
@@ -234,21 +234,6 @@ export class Reply {
       this.contact?.tel && this.contact?.smsStatus === NotifySmsStatus.Delivered
 
     return hasEmailGotEmail || hasTelSmsGotSms
-  }
-
-  /**
-   * Get user who created reply
-   *
-   * @returns {User|undefined} User
-   */
-  get createdBy() {
-    try {
-      if (this.createdBy_uid) {
-        return User.findOne(this.createdBy_uid, this.context)
-      }
-    } catch (error) {
-      console.error('Reply.createdBy', error.message)
-    }
   }
 
   /**
@@ -527,15 +512,6 @@ export class Reply {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'reply'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
@@ -552,74 +528,8 @@ export class Reply {
   get publicUri() {
     return `${this.session.consentUrl}/${this.uuid}`
   }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Reply>|undefined} Replies
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.replies).map(
-      (reply) => new Reply(reply, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - Reply UUID
-   * @param {object} context - Context
-   * @returns {Reply|undefined} Reply
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.replies?.[uuid]) {
-      return new Reply(context.replies[uuid], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {object} reply - Consent
-   * @param {object} context - Context
-   * @returns {Reply} Created reply
-   * @static
-   */
-  static create(reply, context) {
-    const createdReply = new Reply(reply)
-
-    // Update context
-    context.replies = context.replies || {}
-    context.replies[createdReply.uuid] = createdReply
-
-    return createdReply
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} uuid - Reply UUID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Reply} Updated reply
-   * @static
-   */
-  static update(uuid, updates, context) {
-    const updatedReply = _.merge(Reply.findOne(uuid, context), updates)
-    updatedReply.updatedAt = today()
-
-    // Remove reply context
-    delete updatedReply.context
-
-    // Delete original reply (with previous UUID)
-    delete context.replies[uuid]
-
-    // Update context
-    context.replies[updatedReply.uuid] = updatedReply
-
-    return updatedReply
-  }
 }
+
+/**
+ * @import { BaseModelOptions } from './base.js'
+ */

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -370,11 +370,6 @@ export class School extends Location {
   static create(school, context) {
     const createdSchool = new School(school)
 
-    // Add to team
-    if (context.teams) {
-      context.teams[createdSchool.team_id].school_ids.push(createdSchool.id)
-    }
-
     // Update context
     context.schools = context.schools || {}
     context.schools[createdSchool.id] = createdSchool
@@ -403,11 +398,6 @@ export class School extends Location {
       }
     )
 
-    // Update team
-    if (context.teams) {
-      context.teams[updatedSchool.team_id].school_ids.push(updatedSchool.id)
-    }
-
     // Remove school context
     delete updatedSchool.context
 
@@ -428,13 +418,6 @@ export class School extends Location {
    * @static
    */
   static delete(id, context) {
-    const school = School.findOne(id, context)
-
-    // Remove from team
-    context.teams[school.team_id].school_ids = context.teams[
-      school.team_id
-    ].school_ids.filter((item) => item !== id)
-
     delete context.schools[id]
   }
 }

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -12,6 +12,7 @@ import {
   formatLink,
   formatTag,
   formatYearGroups,
+  stringToArray,
   stringToBoolean
 } from '../utils/string.js'
 
@@ -44,33 +45,11 @@ export class School extends Location {
     this.openAt = options?.openAt && new Date(options.openAt)
     this.closeAt = options?.closeAt && new Date(options.closeAt)
     this.closeReason = options?.closeReason
-    this.linkedUrns = options?.linkedUrns || []
+    this.linkedUrns = stringToArray(options?.linkedUrns)
     this.phase = options?.phase
     this.sen = stringToBoolean(options?.sen) || false
     this.site = options?.site
-    this.yearGroups = options?.yearGroups || []
-  }
-
-  /**
-   * Get year groups for `checkboxes`s
-   *
-   * @returns {Array<string>} `checkboxes` array values
-   */
-  get yearGroups_() {
-    return this.yearGroups.map((yearGroup) => String(yearGroup))
-  }
-
-  /**
-   * Set year groups from `checkboxes`s
-   *
-   * @param {Array<string>} array - checkboxes array values
-   */
-  set yearGroups_(array) {
-    if (array) {
-      this.yearGroups = array
-        .filter((item) => item !== '_unchecked')
-        .map((yearGroup) => Number(yearGroup))
-    }
+    this.yearGroups = stringToArray(options?.yearGroups).map(Number)
   }
 
   /**
@@ -391,7 +370,7 @@ export class School extends Location {
       School.findOne(id, context),
       updates,
       (oldValue, newValue) => {
-        // yearGroups array shouldn’t be merged but replaced entirely
+        // Arrays shouldn’t be merged but replaced entirely
         if (Array.isArray(oldValue)) {
           return newValue
         }

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -1,6 +1,5 @@
 import { default as filters } from '@x-govuk/govuk-prototype-filters'
 import { isAfter, isBefore } from 'date-fns'
-import _ from 'lodash'
 
 import { SchoolClosureReason, SchoolStatus } from '../enums.js'
 import { Location, Patient, Session } from '../models.js'
@@ -17,7 +16,7 @@ import {
 } from '../utils/string.js'
 
 /**
- * @typedef {object} SchoolOptions
+ * @typedef {LocationOptions & object} SchoolOptions
  * @property {string} [urn] - URN
  * @property {Date} [openAt] - Date school opened (or will open)
  * @property {Date} [closeAt] - Date school closed (or will close)
@@ -34,8 +33,12 @@ import {
  * @augments Location
  */
 export class School extends Location {
+  static contextKey = 'schools'
+  static identifierKey = 'id'
+  static ns = 'school'
+
   /**
-   * @param {SchoolOptions & LocationOptions} options - Options
+   * @param {SchoolOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
@@ -294,110 +297,12 @@ export class School extends Location {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'school'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/schools/${this.id}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<School>|undefined} Schools
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.schools).map(
-      (school) => new School(school, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} id - School ID
-   * @param {object} context - Context
-   * @returns {School|undefined} School
-   * @static
-   */
-  static findOne(id, context) {
-    if (context?.schools?.[id]) {
-      return new School(context.schools[id], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {School} school - School
-   * @param {object} context - Context
-   * @returns {School} Created school
-   * @static
-   */
-  static create(school, context) {
-    const createdSchool = new School(school)
-
-    // Update context
-    context.schools = context.schools || {}
-    context.schools[createdSchool.id] = createdSchool
-
-    return createdSchool
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} id - School ID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {School} Updated school
-   * @static
-   */
-  static update(id, updates, context) {
-    const updatedSchool = _.mergeWith(
-      School.findOne(id, context),
-      updates,
-      (oldValue, newValue) => {
-        // Arrays shouldn’t be merged but replaced entirely
-        if (Array.isArray(oldValue)) {
-          return newValue
-        }
-      }
-    )
-
-    // Remove school context
-    delete updatedSchool.context
-
-    // Delete original school (with previous ID)
-    delete context.schools[id]
-
-    // Update context
-    context.schools[updatedSchool.id] = updatedSchool
-
-    return new School(updatedSchool, context)
-  }
-
-  /**
-   * Delete
-   *
-   * @param {string} id - School ID
-   * @param {object} context - Context
-   * @static
-   */
-  static delete(id, context) {
-    delete context.schools[id]
   }
 }
 

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -53,6 +53,7 @@ import {
   formatWithSecondaryText,
   formatYearGroups,
   sentenceCaseProgrammeName,
+  stringToArray,
   stringToBoolean
 } from '../utils/string.js'
 
@@ -77,7 +78,6 @@ import {
  *   Schools only
  * @property {string} [school_id] - School URN
  * @property {Array<number>} [yearGroups] - Year groups
- * @property {Array<string>} [yearGroups_] - Year groups (override)
  * @property {Date} [openAt] - Date consent window opens
  * @property {object} [openAt_] - Date consent window opens (from `dateInput`)
  * @property {boolean} [closed] - Session closed
@@ -105,7 +105,7 @@ export class Session {
     this.date = options?.date && new Date(options.date)
     this.date_ = options?.date_
     this.academicYear = options?.academicYear || getCurrentAcademicYear()
-    this.presetNames = options?.presetNames
+    this.presetNames = stringToArray(options?.presetNames)
     this.cancelled = options?.cancelled || false
 
     if (this.type === SessionType.Clinic) {
@@ -120,8 +120,7 @@ export class Session {
 
     if (this.type === SessionType.School) {
       this.school_id = options?.school_id
-      this.yearGroups = options?.yearGroups || []
-      this.yearGroups_ = options?.yearGroups_
+      this.yearGroups = stringToArray(options?.yearGroups).map(Number)
       this.openAt = options?.openAt
         ? new Date(options.openAt)
         : this.date
@@ -690,28 +689,6 @@ export class Session {
       } catch (error) {
         console.error('Session.school', error.message)
       }
-    }
-  }
-
-  /**
-   * Get year groups for `checkboxes`s
-   *
-   * @returns {Array<string>} `checkboxes` array values
-   */
-  get yearGroups_() {
-    return this.yearGroups.map((yearGroup) => String(yearGroup))
-  }
-
-  /**
-   * Set year groups from `checkboxes`s
-   *
-   * @param {Array<string>} array - checkboxes array values
-   */
-  set yearGroups_(array) {
-    if (array) {
-      this.yearGroups = array
-        .filter((item) => item !== '_unchecked')
-        .map((yearGroup) => Number(yearGroup))
     }
   }
 
@@ -1300,7 +1277,7 @@ export class Session {
       Session.findOne(id, context),
       updates,
       (oldValue, newValue) => {
-        // yearGroups array shouldn’t be merged but replaced entirely
+        // Arrays shouldn’t be merged but replaced entirely
         if (Array.isArray(oldValue)) {
           return newValue
         }

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -57,11 +57,11 @@ import {
   stringToBoolean
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} SessionOptions
+ * @typedef {BaseModelOptions & object} SessionOptions
  * @property {string} [id] - School ID
- * @property {Date} [createdAt] - Created date
- * @property {string} [createdBy_uid] - User who created session
  * @property {SessionType} [type] - Session type
  * @property {Date} [date] - Dates
  * @property {object} [date_] - Dates (from `dateInput`s)
@@ -91,16 +91,20 @@ import {
 /**
  * @class Session
  */
-export class Session {
+export class Session extends BaseModel {
+  static contextKey = 'sessions'
+  static identifierKey = 'id'
+  static ns = 'session'
+
   /**
    * @param {SessionOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.id = options?.id || faker.helpers.replaceSymbols('###')
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.createdBy_uid = options?.createdBy_uid
     this.type = options?.type || SessionType.School
     this.date = options?.date && new Date(options.date)
     this.date_ = options?.date_
@@ -1199,102 +1203,12 @@ export class Session {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'session'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
    */
   get uri() {
     return `/sessions/${this.id}`
-  }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Session>|undefined} Sessions
-   * @static
-   */
-  static findAll(context) {
-    if (context?.sessions) {
-      return Object.values(context.sessions).map(
-        (session) => new Session(session, context)
-      )
-    }
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} id - Session ID
-   * @param {object} context - Context
-   * @returns {Session|undefined} Session
-   * @static
-   */
-  static findOne(id, context) {
-    if (context?.sessions?.[id]) {
-      return new Session(context.sessions[id], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {object} session - Session
-   * @param {object} context - Context
-   * @returns {Session} Created session
-   * @static
-   */
-  static create(session, context) {
-    const createdSession = new Session(session)
-
-    // Update context
-    context.sessions = context.sessions || {}
-    context.sessions[createdSession.id] = createdSession
-
-    return createdSession
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} id - Session ID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Session} Updated session
-   * @static
-   */
-  static update(id, updates, context) {
-    const updatedSession = _.mergeWith(
-      Session.findOne(id, context),
-      updates,
-      (oldValue, newValue) => {
-        // Arrays shouldn’t be merged but replaced entirely
-        if (Array.isArray(oldValue)) {
-          return newValue
-        }
-      }
-    )
-    updatedSession.updatedAt = today()
-
-    // Remove session context
-    delete updatedSession.context
-
-    // Delete original session (with previous ID)
-    delete context.sessions[id]
-
-    // Update context
-    context.sessions[updatedSession.id] = updatedSession
-
-    return new Session(updatedSession, context)
   }
 
   /**
@@ -1306,18 +1220,9 @@ export class Session {
   updateRegister(patient_uuid, registration) {
     this.register[patient_uuid] = registration
   }
-
-  /**
-   * Delete the session with the given ID
-   *
-   * @param {string} id - Session ID
-   * @param {object} context - the context on which the session is stored
-   */
-  static delete(id, context) {
-    delete context.sessions[id]
-  }
 }
 
 /**
  * @import { RegistrationOutcome, SessionMMRConsent, SessionPreset } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -71,12 +71,10 @@ import { BaseModel } from './base.js'
  * @property {boolean} [registration] - Does session have registration?
  *
  *   Clinics only
- * @property {string} [clinic_id] - Clinic ID
  * @property {Array<ClinicVaccinationPeriod>} [vaccinationPeriods] - Vaccination periods
  * @property {number} [appointmentLength] - Standard length of the clinic appointment, in minutes
  *
  *   Schools only
- * @property {string} [school_id] - School URN
  * @property {Array<number>} [yearGroups] - Year groups
  * @property {Date} [openAt] - Date consent window opens
  * @property {object} [openAt_] - Date consent window opens (from `dateInput`)
@@ -103,6 +101,18 @@ export class Session extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.clinic_id
+
+    /** @type {Clinic|undefined} */
+    this.clinic
+
+    /** @type {string|undefined} */
+    this.school_id
+
+    /** @type {School|undefined} */
+    this.school
+
     this.context = context
     this.id = options?.id || faker.helpers.replaceSymbols('###')
     this.type = options?.type || SessionType.School
@@ -113,7 +123,6 @@ export class Session extends BaseModel {
     this.cancelled = options?.cancelled || false
 
     if (this.type === SessionType.Clinic) {
-      this.clinic_id = options?.clinic_id
       this.vaccinationPeriods = options?.vaccinationPeriods
         ? options.vaccinationPeriods.map(
             (period) => new ClinicVaccinationPeriod(period)
@@ -123,7 +132,6 @@ export class Session extends BaseModel {
     }
 
     if (this.type === SessionType.School) {
-      this.school_id = options?.school_id
       this.yearGroups = stringToArray(options?.yearGroups).map(Number)
       this.openAt = options?.openAt
         ? new Date(options.openAt)
@@ -374,21 +382,6 @@ export class Session extends BaseModel {
         return SessionStatus.Completed
       default:
         return SessionStatus.Planned
-    }
-  }
-
-  /**
-   * Get clinic
-   *
-   * @returns {Clinic|undefined}} Clinic
-   */
-  get clinic() {
-    if (this.clinic_id) {
-      try {
-        return Clinic.findOne(this.clinic_id, this.context)
-      } catch (error) {
-        console.error('Session.clinic', error.message)
-      }
     }
   }
 
@@ -679,21 +672,6 @@ export class Session extends BaseModel {
     })
 
     return appointmentsWithoutVaccinators
-  }
-
-  /**
-   * Get school
-   *
-   * @returns {School|undefined} School
-   */
-  get school() {
-    if (this.school_id) {
-      try {
-        return School.findOne(this.school_id, this.context)
-      } catch (error) {
-        console.error('Session.school', error.message)
-      }
-    }
   }
 
   /**
@@ -1221,6 +1199,9 @@ export class Session extends BaseModel {
     this.register[patient_uuid] = registration
   }
 }
+
+Session.relate('clinic_id', () => Clinic, 'clinic')
+Session.relate('school_id', () => School, 'school')
 
 /**
  * @import { RegistrationOutcome, SessionMMRConsent, SessionPreset } from '../enums.js'

--- a/app/models/team.js
+++ b/app/models/team.js
@@ -22,7 +22,6 @@ import { stringToBoolean } from '../utils/string.js'
  * @property {number} [clinicInjectionDuration] - Minutes to allocate each injection
  * @property {boolean} [clinicSessionRegistration] - Should clinic sessions have registration
  * @property {Array<string>} [clinic_ids] - Clinic IDs
- * @property {Array<string>} [school_ids] - School URNs
  */
 
 /**
@@ -58,7 +57,6 @@ export class Team {
       stringToBoolean(options.clinicSessionRegistration) ??
       TeamDefaults.ClinicSessionRegistration
     this.clinic_ids = options?.clinic_ids || []
-    this.school_ids = options?.school_ids || []
   }
 
   /**
@@ -83,9 +81,8 @@ export class Team {
    */
   get schools() {
     try {
-      return this?.school_ids
-        .filter((id) => !['888888', '999999'].includes(id))
-        .map((id) => School.findOne(id, this.context))
+      return School.findAll(this.context)
+        .filter((school) => !['888888', '999999'].includes(school.id))
         .sort((a, b) => a.name.localeCompare(b.name))
     } catch (error) {
       console.error('Team.schools', error.message)

--- a/app/models/team.js
+++ b/app/models/team.js
@@ -21,7 +21,6 @@ import { stringToBoolean } from '../utils/string.js'
  * @property {number} [clinicNasalSprayDuration] - Minutes to allocate each nasal spray
  * @property {number} [clinicInjectionDuration] - Minutes to allocate each injection
  * @property {boolean} [clinicSessionRegistration] - Should clinic sessions have registration
- * @property {Array<string>} [clinic_ids] - Clinic IDs
  */
 
 /**
@@ -56,7 +55,6 @@ export class Team {
     this.clinicSessionRegistration =
       stringToBoolean(options.clinicSessionRegistration) ??
       TeamDefaults.ClinicSessionRegistration
-    this.clinic_ids = options?.clinic_ids || []
   }
 
   /**
@@ -66,9 +64,9 @@ export class Team {
    */
   get clinics() {
     try {
-      return this?.clinic_ids
-        .map((id) => Clinic.findOne(id, this.context))
-        .sort((a, b) => a.name.localeCompare(b.name))
+      return Clinic.findAll(this.context).sort((a, b) =>
+        a.name.localeCompare(b.name)
+      )
     } catch (error) {
       console.error('Team.clinics', error.message)
     }

--- a/app/models/team.js
+++ b/app/models/team.js
@@ -3,14 +3,14 @@ import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
 import { TeamDefaults } from '../enums.js'
 import { Clinic, School } from '../models.js'
-import { today } from '../utils/date.js'
 import { stringToBoolean } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} TeamOptions
+ * @typedef {BaseModelOptions & object} TeamOptions
  * @property {string} [id] - Team ID
  * @property {string} [ods] - ODS code
- * @property {Date} [updatedAt] - Updated date
  * @property {string} [name] - Full name
  * @property {string} [email] - Email address
  * @property {string} [tel] - Phone number
@@ -26,16 +26,20 @@ import { stringToBoolean } from '../utils/string.js'
 /**
  * @class Team
  */
-export class Team {
+export class Team extends BaseModel {
+  static contextKey = 'teams'
+  static ns = 'team'
+
   /**
    * @param {TeamOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.id = options?.id || faker.helpers.replaceSymbols('###')
     this.ods = options?.ods || faker.helpers.replaceSymbols('???')
-    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
     this.name = options?.name
     this.email = options?.email
     this.tel = options?.tel
@@ -131,15 +135,6 @@ export class Team {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'team'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
@@ -147,65 +142,8 @@ export class Team {
   get uri() {
     return `/teams/${this.id}`
   }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Team>|undefined} Teams
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.teams).map((team) => new Team(team, context))
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} id - Team ID
-   * @param {object} context - Context
-   * @returns {Team|undefined} Team
-   * @static
-   */
-  static findOne(id, context) {
-    if (context?.teams?.[id]) {
-      return new Team(context.teams[id], context)
-    }
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} id - Team ID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Team} Team
-   * @static
-   */
-  static update(id, updates, context) {
-    // Sanitise values from boolean radios
-    if (updates?.schoolSessionRegistration) {
-      updates.schoolSessionRegistration =
-        stringToBoolean(updates.schoolSessionRegistration) || false
-    }
-    if (updates?.clinicSessionRegistration) {
-      updates.clinicSessionRegistration =
-        stringToBoolean(updates.clinicSessionRegistration) || false
-    }
-
-    // Update the team instance
-    const updatedTeam = Object.assign(Team.findOne(id, context), updates)
-    updatedTeam.updatedAt = today()
-
-    // Remove team context
-    delete updatedTeam.context
-
-    // Delete original team (with previous ID)
-    delete context.teams[id]
-
-    // Update context
-    context.teams[updatedTeam.id] = updatedTeam
-
-    return updatedTeam
-  }
 }
+
+/**
+ * @import { BaseModelOptions } from './base.js'
+ */

--- a/app/models/upload.js
+++ b/app/models/upload.js
@@ -2,8 +2,8 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 import prototypeFilters from '@x-govuk/govuk-prototype-filters'
 
 import { UploadStatus, UploadType } from '../enums.js'
-import { Move, Patient, School, User } from '../models.js'
-import { formatDate, today } from '../utils/date.js'
+import { Move, Patient, School } from '../models.js'
+import { formatDate } from '../utils/date.js'
 import { getUploadStatus } from '../utils/status.js'
 import {
   formatLink,
@@ -14,15 +14,13 @@ import {
   stringToArray
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} UploadOptions
+ * @typedef {BaseModelOptions & object} UploadOptions
  * @property {string} [id] - Upload ID
  * @property {UploadStatus} [status] - Upload status
  * @property {UploadType} [type] - Upload type
- * @property {Date} [createdAt] - Created date
- * @property {string} [createdBy_uid] - User who created upload
- * @property {Date} [updatedAt] - Updated date
- * @property {string} [updatedBy_uid] - User who updated upload
  * @property {string} [fileName] - Original file name
  * @property {number} [progress] - Upload import progress
  * @property {object} [validations] - File validations
@@ -34,20 +32,22 @@ import {
 /**
  * @class Upload
  */
-export class Upload {
+export class Upload extends BaseModel {
+  static contextKey = 'uploads'
+  static identifierKey = 'id'
+  static ns = 'upload'
+
   /**
    * @param {UploadOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.id = options?.id || faker.string.hexadecimal({ length: 8, prefix: '' })
     this.status = options?.status || UploadStatus.Processing
     this.type = options?.type || UploadType.Cohort
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.createdBy_uid = options?.createdBy_uid
-    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
-    this.updatedBy_uid = options?.updatedBy_uid
     this.fileName = options?.fileName
     this.progress = options?.progress || 100
     this.validations = options?.validations || []
@@ -56,36 +56,6 @@ export class Upload {
     if (this.type === UploadType.School) {
       this.yearGroups = stringToArray(options?.yearGroups)
       this.school_id = options?.school_id
-    }
-  }
-
-  /**
-   * Get user who created upload
-   *
-   * @returns {User|undefined} User
-   */
-  get createdBy() {
-    try {
-      if (this.createdBy_uid) {
-        return User.findOne(this.createdBy_uid, this.context)
-      }
-    } catch (error) {
-      console.error('Upload.createdBy', error.message)
-    }
-  }
-
-  /**
-   * Get user who approved upload
-   *
-   * @returns {User|undefined} User
-   */
-  get updatedBy() {
-    try {
-      if (this.updatedBy_uid) {
-        return User.findOne(this.updatedBy_uid, this.context)
-      }
-    } catch (error) {
-      console.error('Upload.updatedBy', error.message)
     }
   }
 
@@ -280,15 +250,6 @@ export class Upload {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'upload'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
@@ -296,85 +257,8 @@ export class Upload {
   get uri() {
     return `/uploads/${this.id}`
   }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Upload>|undefined} Uploads
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.uploads).map(
-      (upload) => new Upload(upload, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} id - Upload ID
-   * @param {object} context - Context
-   * @returns {Upload|undefined} Upload
-   * @static
-   */
-  static findOne(id, context) {
-    if (context.uploads?.[id]) {
-      return new Upload(context.uploads[id], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {object} upload - Upload
-   * @param {object} context - Context
-   * @returns {Upload} Created upload
-   * @static
-   */
-  static create(upload, context) {
-    const createdUpload = new Upload(upload)
-
-    // Update context
-    context.uploads = context.uploads || {}
-    context.uploads[createdUpload.id] = createdUpload
-
-    return createdUpload
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} id - Upload ID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Upload} Updated upload
-   * @static
-   */
-  static update(id, updates, context) {
-    const updatedUpload = Object.assign(Upload.findOne(id, context), updates)
-    updatedUpload.updatedAt = today()
-
-    // Remove upload context
-    delete updatedUpload.context
-
-    // Delete original upload (with previous ID)
-    delete context.uploads[id]
-
-    // Update context
-    context.uploads[updatedUpload.id] = updatedUpload
-
-    return updatedUpload
-  }
-
-  /**
-   * Delete
-   *
-   * @param {string} id - Upload ID
-   * @param {object} context - Context
-   * @static
-   */
-  static delete(id, context) {
-    delete context.uploads[id]
-  }
 }
+
+/**
+ * @import { BaseModelOptions } from './base.js'
+ */

--- a/app/models/upload.js
+++ b/app/models/upload.js
@@ -25,7 +25,6 @@ import { BaseModel } from './base.js'
  * @property {number} [progress] - Upload import progress
  * @property {object} [validations] - File validations
  * @property {Array<number>} [yearGroups] - Year groups
- * @property {string} [school_id] - School IDs
  * @property {Array<string>} [patient_uuids] - Patient record UUIDs
  */
 
@@ -44,6 +43,12 @@ export class Upload extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.school_id
+
+    /** @type {School|undefined} */
+    this.school
+
     this.context = context
     this.id = options?.id || faker.string.hexadecimal({ length: 8, prefix: '' })
     this.status = options?.status || UploadStatus.Processing
@@ -55,7 +60,6 @@ export class Upload extends BaseModel {
 
     if (this.type === UploadType.School) {
       this.yearGroups = stringToArray(options?.yearGroups)
-      this.school_id = options?.school_id
     }
   }
 
@@ -136,17 +140,6 @@ export class Upload extends BaseModel {
       return Move.findAll(this.context).filter((move) =>
         this.patient_uuids.includes(move.patient_uuid)
       )
-    }
-  }
-
-  /**
-   * Get school
-   *
-   * @returns {object|undefined} School
-   */
-  get school() {
-    if (this.type === UploadType.School && this.school_id) {
-      return School.findOne(this.school_id, this.context)
     }
   }
 
@@ -258,6 +251,8 @@ export class Upload extends BaseModel {
     return `/uploads/${this.id}`
   }
 }
+
+Upload.relate('school_id', () => School, 'school')
 
 /**
  * @import { BaseModelOptions } from './base.js'

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -31,6 +31,12 @@ export class User extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.team_id
+
+    /** @type {Team|undefined} */
+    this.team
+
     this.context = context
     this.uid = options?.uid || faker.string.numeric(12)
     this.firstName = options?.firstName
@@ -66,19 +72,6 @@ export class User extends BaseModel {
    */
   get nameAndRole() {
     return `${this.fullName} (${this.role})`
-  }
-
-  /**
-   * Get team
-   *
-   * @returns {Team|undefined} Team
-   */
-  get team() {
-    try {
-      return Team.findOne(this.team_id, this.context)
-    } catch (error) {
-      console.error('User.team', error.message)
-    }
   }
 
   /**
@@ -163,6 +156,8 @@ export class User extends BaseModel {
     return `/users/${this.uid}`
   }
 }
+
+User.relate('team_id', () => Team, 'team')
 
 /**
  * @import { BaseModelOptions } from './base.js'

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,10 +3,11 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 import { UserRole, VaccineMethod } from '../enums.js'
 import { formatCode, formatLink } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
 import { Team } from './team.js'
 
 /**
- * @typedef {object} UserOptions
+ * @typedef {BaseModelOptions & object} UserOptions
  * @property {string} [uid] - User UID
  * @property {string} [firstName] - First/given name
  * @property {string} [lastName] - Last/family name
@@ -19,12 +20,17 @@ import { Team } from './team.js'
 /**
  * @class User
  */
-export class User {
+export class User extends BaseModel {
+  static contextKey = 'users'
+  static ns = 'user'
+
   /**
    * @param {UserOptions} options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.uid = options?.uid || faker.string.numeric(12)
     this.firstName = options?.firstName
@@ -149,15 +155,6 @@ export class User {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'user'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
@@ -165,29 +162,8 @@ export class User {
   get uri() {
     return `/users/${this.uid}`
   }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<User>|undefined} Users
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.users).map((user) => new User(user))
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uid - User UID
-   * @param {object} context - Context
-   * @returns {User|undefined} User
-   * @static
-   */
-  static findOne(uid, context) {
-    if (context?.users?.[uid]) {
-      return new User(context.users[uid])
-    }
-  }
 }
+
+/**
+ * @import { BaseModelOptions } from './base.js'
+ */

--- a/app/models/vaccination.js
+++ b/app/models/vaccination.js
@@ -48,16 +48,15 @@ import {
   formatWithSecondaryText
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} VaccinationOptions
+ * @typedef {BaseModelOptions & object} VaccinationOptions
  * @property {string} [uuid] - Vaccination UUID
  * @property {string} [assessedBy_uid] - Who assessed child being vaccinated
  * @property {Date} [administeredAt] - Administered date
  * @property {object} [administeredAt_] - Administered date (from `dateInput`)
  * @property {string} [administeredBy_uid] - User who administered vaccination
- * @property {Date} [createdAt] - Created date
- * @property {string} [createdBy_uid] - User who created vaccination record
- * @property {Date} [updatedAt] - Updated date
  * @property {Date} [nhseSyncedAt] - Date synced with NHS England API
  * @property {LocationType} [locationType] - Location
  * @property {string} [locationName] - Location name
@@ -93,12 +92,18 @@ import {
 /**
  * @class Vaccination
  */
-export class Vaccination {
+export class Vaccination extends BaseModel {
+  static contextKey = 'vaccinations'
+  static identifierKey = 'uuid'
+  static ns = 'vaccination'
+
   /**
    * @param {VaccinationOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
     this.administeredAt = options?.administeredAt
@@ -106,9 +111,6 @@ export class Vaccination {
       : today()
     this.administeredAt_ = options?.administeredAt_
     this.administeredBy_uid = options?.administeredBy_uid
-    this.createdAt = options?.createdAt ? new Date(options.createdAt) : today()
-    this.createdBy_uid = options?.createdBy_uid
-    this.updatedAt = options?.updatedAt && new Date(options.updatedAt)
     this.nhseSyncedAt = options?.nhseSyncedAt
       ? new Date(options.nhseSyncedAt)
       : undefined
@@ -353,21 +355,6 @@ export class Vaccination {
       }
     } catch (error) {
       console.error('Vaccination.administeredBy', error.message)
-    }
-  }
-
-  /**
-   * Get user who created vaccination record
-   *
-   * @returns {User|undefined} User
-   */
-  get createdBy() {
-    try {
-      if (this.createdBy_uid) {
-        return User.findOne(this.createdBy_uid, this.context)
-      }
-    } catch (error) {
-      console.error('Vaccination.createdBy', error.message)
     }
   }
 
@@ -632,15 +619,6 @@ export class Vaccination {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'vaccination'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
@@ -648,87 +626,9 @@ export class Vaccination {
   get uri() {
     return `/reports/${this.programme_id}/vaccinations/${this.uuid}`
   }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Vaccination>|undefined} Vaccinations
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.vaccinations).map(
-      (vaccination) => new Vaccination(vaccination, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} uuid - Vaccination UUID
-   * @param {object} context - Context
-   * @returns {Vaccination|undefined} Vaccination
-   * @static
-   */
-  static findOne(uuid, context) {
-    if (context?.vaccinations?.[uuid]) {
-      return new Vaccination(context.vaccinations[uuid], context)
-    }
-  }
-
-  /**
-   * Create
-   *
-   * @param {object} vaccination - Vaccination
-   * @param {object} context - Context
-   * @returns {Vaccination} Created vaccination
-   * @static
-   */
-  static create(vaccination, context) {
-    const createdVaccination = new Vaccination(vaccination)
-
-    // Update context
-    context.vaccinations = context.vaccinations || {}
-    context.vaccinations[createdVaccination.uuid] = createdVaccination
-
-    return createdVaccination
-  }
-
-  /**
-   * Update
-   *
-   * @param {string} uuid - Vaccination UUID
-   * @param {object} updates - Updates
-   * @param {object} context - Context
-   * @returns {Vaccination} Updated vaccination
-   * @static
-   */
-  static update(uuid, updates, context) {
-    const updatedVaccination = Object.assign(
-      Vaccination.findOne(uuid, context),
-      updates
-    )
-    updatedVaccination.updatedAt = today()
-
-    // Make sure sync isn’t always successful
-    const syncSuccess = Math.random() > 0.3
-    if (syncSuccess && updatedVaccination.given) {
-      updatedVaccination.nhseSyncedAt = today(Math.random() * 60 * 5)
-    }
-
-    // Remove patient context
-    delete updatedVaccination.context
-
-    // Delete original patient (with previous UUID)
-    delete context.vaccinations[uuid]
-
-    // Update context
-    context.vaccinations[updatedVaccination.uuid] = updatedVaccination
-
-    return updatedVaccination
-  }
 }
 
 /**
  * @import { Session } from '../models.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/vaccination.js
+++ b/app/models/vaccination.js
@@ -1,9 +1,6 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import { isBefore } from 'date-fns'
 
-import clinics from '../datasets/clinics.js'
-import schools from '../datasets/schools.js'
-import vaccines from '../datasets/vaccines.js'
 import {
   LocationType,
   ProgrammeType,
@@ -53,10 +50,8 @@ import { BaseModel } from './base.js'
 /**
  * @typedef {BaseModelOptions & object} VaccinationOptions
  * @property {string} [uuid] - Vaccination UUID
- * @property {string} [assessedBy_uid] - Who assessed child being vaccinated
  * @property {Date} [administeredAt] - Administered date
  * @property {object} [administeredAt_] - Administered date (from `dateInput`)
- * @property {string} [administeredBy_uid] - User who administered vaccination
  * @property {Date} [nhseSyncedAt] - Date synced with NHS England API
  * @property {LocationType} [locationType] - Location
  * @property {string} [locationName] - Location name
@@ -78,15 +73,8 @@ import { BaseModel } from './base.js'
  * @property {string} [protocol] - Protocol
  * @property {boolean} [scheduled] - Vaccination date was on schedule
  * @property {string} [note] - Note
- * @property {string} [clinic_id] - Clinic ID
- * @property {string} [school_id] - School ID
- * @property {string} [patient_uuid] - Patient UUID (used outside of a session)
- * @property {string} [patientSession_uuid] - Patient session UUID
- * @property {string} [programme_id] - Programme ID
  * @property {string} [programmeOther] - Non-NHS programme name
- * @property {string} [batch_id] - Batch ID
  * @property {boolean} [variant] - Is programme variant?
- * @property {string} [vaccine_snomed] - Vaccine SNOMED code
  */
 
 /**
@@ -104,13 +92,66 @@ export class Vaccination extends BaseModel {
   constructor(options, context) {
     super(options, context)
 
+    /** @type {string|undefined} */
+    this.administeredBy_uid
+
+    /** @type {User|undefined} */
+    this.administeredBy
+
+    /** @type {string|undefined} */
+    this.assessedBy_uid
+
+    /** @type {User|undefined} */
+    this.assessedBy
+
+    /** @type {string|undefined} */
+    this.batch_id
+
+    /** @type {Batch|undefined} */
+    this.batch
+
+    /** @type {string|undefined} */
+    this.clinic_id
+
+    /** @type {Clinic|undefined} */
+    this.clinic
+
+    /** @type {string|undefined} */
+    this.school_id
+
+    /** @type {School|undefined} */
+    this.school
+
+    /** @type {string|undefined} */
+    this.patient_uuid
+
+    /** @type {Patient|undefined} */
+    this.patient
+
+    /** @type {string|undefined} */
+    this.patientSession_uuid
+
+    /** @type {PatientSession|undefined} */
+    this.patientSession
+
+    /** @type {string|undefined} */
+    this.programme_id
+
+    /** @type {Programme|undefined} */
+    this.programme
+
+    /** @type {string|undefined} */
+    this.vaccine_snomed
+
+    /** @type {Vaccine|undefined} */
+    this.vaccine
+
     this.context = context
     this.uuid = options?.uuid || faker.string.uuid()
     this.administeredAt = options?.administeredAt
       ? new Date(options.administeredAt)
       : today()
     this.administeredAt_ = options?.administeredAt_
-    this.administeredBy_uid = options?.administeredBy_uid
     this.nhseSyncedAt = options?.nhseSyncedAt
       ? new Date(options.nhseSyncedAt)
       : undefined
@@ -136,22 +177,10 @@ export class Vaccination extends BaseModel {
       : undefined
     this.scheduled = stringToBoolean(options.scheduled)
     this.note = options?.note || ''
-    this.clinic_id = options?.clinic_id
-    this.school_id = options?.school_id
-    this.patient_uuid = options?.patient_uuid
-    this.patientSession_uuid = options?.patientSession_uuid
-    this.programme_id = options?.programme_id
     this.programmeOther = options?.programmeOther
-    this.batch_id = this.given ? options?.batch_id || '' : undefined
     this.variant = options?.variant
       ? stringToBoolean(options.variant)
       : undefined
-    this.vaccine_snomed = options?.vaccine_snomed
-
-    // Only VGD protocol needs a practitioner recording
-    if (this.protocol === VaccinationProtocol.VGD) {
-      this.assessedBy_uid = options?.assessedBy_uid
-    }
 
     if (this.outcome === VaccinationOutcome.AlreadyVaccinated) {
       this.addressLine1 = options?.addressLine1
@@ -213,21 +242,6 @@ export class Vaccination extends BaseModel {
   }
 
   /**
-   * Get batch
-   *
-   * @returns {Batch|undefined} Batch
-   */
-  get batch() {
-    try {
-      if (this.batch_id) {
-        return Batch.findOne(this.batch_id, this.context)
-      }
-    } catch (error) {
-      console.error('Vaccination.batch', error.message)
-    }
-  }
-
-  /**
    * Get batch expiry date for `dateInput`
    *
    * @returns {object|string} `dateInput` object
@@ -245,17 +259,6 @@ export class Vaccination extends BaseModel {
     if (object) {
       this.context.batches[this.batch_id].expiry =
         convertObjectToIsoDate(object)
-    }
-  }
-
-  /**
-   * Get vaccine
-   *
-   * @returns {object|undefined} Vaccine
-   */
-  get vaccine() {
-    if (this.vaccine_snomed) {
-      return new Vaccine(vaccines[this.vaccine_snomed])
     }
   }
 
@@ -307,32 +310,6 @@ export class Vaccination extends BaseModel {
   }
 
   /**
-   * Get patient session
-   *
-   * @returns {PatientSession|undefined} Patient session
-   */
-  get patientSession() {
-    try {
-      return PatientSession.findOne(this.patientSession_uuid, this.context)
-    } catch (error) {
-      console.error('Instruction.patientSession', error.message)
-    }
-  }
-
-  /**
-   * Get patient
-   *
-   * @returns {Patient|undefined} Patient
-   */
-  get patient() {
-    if (this.patient_uuid) {
-      return Patient.findOne(this.patient_uuid, this.context)
-    } else if (this.patientSession_uuid) {
-      return this.patientSession.patient
-    }
-  }
-
-  /**
    * Get session
    *
    * @returns {Session|undefined} Session
@@ -340,71 +317,6 @@ export class Vaccination extends BaseModel {
   get session() {
     if (this.patientSession) {
       return this.patientSession.session
-    }
-  }
-
-  /**
-   * Get user who administered vaccination
-   *
-   * @returns {User|undefined} User
-   */
-  get administeredBy() {
-    try {
-      if (this.createdBy_uid) {
-        return User.findOne(this.administeredBy_uid, this.context)
-      }
-    } catch (error) {
-      console.error('Vaccination.administeredBy', error.message)
-    }
-  }
-
-  /**
-   * Get user who assessed child being vaccinated
-   *
-   * @returns {User|undefined} User
-   */
-  get assessedBy() {
-    try {
-      if (this.assessedBy_uid) {
-        return User.findOne(this.assessedBy_uid, this.context)
-      }
-    } catch (error) {
-      console.error('Vaccination.assessedBy', error.message)
-    }
-  }
-
-  /**
-   * Get programme
-   *
-   * @returns {Programme|undefined} Programme
-   */
-  get programme() {
-    try {
-      return Programme.findOne(this.programme_id, this.context)
-    } catch (error) {
-      console.error('Vaccination.programme', error.message)
-    }
-  }
-
-  /**
-   * Get clinic
-   *
-   * @returns {Clinic|undefined} Clinic
-   */
-  get clinic() {
-    if (this.clinic_id) {
-      return new Clinic(clinics[this.clinic_id])
-    }
-  }
-
-  /**
-   * Get school
-   *
-   * @returns {School|undefined} School
-   */
-  get school() {
-    if (this.school_id) {
-      return new School(schools[this.school_id])
     }
   }
 
@@ -555,13 +467,13 @@ export class Vaccination extends BaseModel {
             case 'batch':
               return this.batch?.summary
             case 'batch_id':
-              return formatCode(this.batch_id)
+              return formatCode(this.batch.id)
             case 'dose':
               return formatMillilitres(this.dose)
             case 'sequence':
               return this.sequence && formatSequence(this.sequence)
             case 'vaccine_snomed':
-              return this.vaccine_snomed ? this.vaccine?.brand : 'Unknown'
+              return this.vaccine.snomed ? this.vaccine?.brand : 'Unknown'
             case 'note':
               return formatMarkdown(this.note)
             case 'outcome':
@@ -624,9 +536,23 @@ export class Vaccination extends BaseModel {
    * @returns {string} URI
    */
   get uri() {
-    return `/reports/${this.programme_id}/vaccinations/${this.uuid}`
+    return `/reports/${this.programme.id}/vaccinations/${this.uuid}`
   }
 }
+
+Vaccination.relate('administeredBy_uid', () => User, 'administeredBy')
+Vaccination.relate('assessedBy_uid', () => User, 'assessedBy')
+Vaccination.relate('batch_id', () => Batch, 'batch')
+Vaccination.relate('clinic_id', () => Clinic, 'clinic')
+Vaccination.relate('patient_uuid', () => Patient, 'patient')
+Vaccination.relate(
+  'patientSession_uuid',
+  () => PatientSession,
+  'patientSession'
+)
+Vaccination.relate('programme_id', () => Programme, 'programme')
+Vaccination.relate('school_id', () => School, 'school')
+Vaccination.relate('vaccine_snomed', () => Vaccine, 'vaccine')
 
 /**
  * @import { Session } from '../models.js'

--- a/app/models/vaccine.js
+++ b/app/models/vaccine.js
@@ -9,8 +9,10 @@ import {
   formatMillilitres
 } from '../utils/string.js'
 
+import { BaseModel } from './base.js'
+
 /**
- * @typedef {object} VaccineOptions
+ * @typedef {BaseModelOptions & object} VaccineOptions
  * @property {string} [snomed] - SNOMED code
  * @property {string} [type] - Type
  * @property {string} [brand] - Brand
@@ -27,12 +29,17 @@ import {
 /**
  * @class Vaccine
  */
-export class Vaccine {
+export class Vaccine extends BaseModel {
+  static contextKey = 'vaccines'
+  static ns = 'vaccine'
+
   /**
    * @param {VaccineOptions} options - Options
    * @param {object} [context] - Context
    */
   constructor(options, context) {
+    super(options, context)
+
     this.context = context
     this.snomed = options?.snomed || faker.string.numeric(14)
     this.type = options?.type
@@ -119,15 +126,6 @@ export class Vaccine {
   }
 
   /**
-   * Get namespace
-   *
-   * @returns {string} Namespace
-   */
-  get ns() {
-    return 'vaccine'
-  }
-
-  /**
    * Get URI
    *
    * @returns {string} URI
@@ -135,46 +133,9 @@ export class Vaccine {
   get uri() {
     return `/vaccines/${this.snomed}`
   }
-
-  /**
-   * Find all
-   *
-   * @param {object} context - Context
-   * @returns {Array<Vaccine>|undefined} Vaccines
-   * @static
-   */
-  static findAll(context) {
-    return Object.values(context.vaccines).map(
-      (vaccine) => new Vaccine(vaccine, context)
-    )
-  }
-
-  /**
-   * Find one
-   *
-   * @param {string} snomed - SNOMED code
-   * @param {object} context - Context
-   * @returns {Vaccine|undefined} Vaccine
-   * @static
-   */
-  static findOne(snomed, context) {
-    if (context?.vaccines?.[snomed]) {
-      return new Vaccine(context.vaccines[snomed], context)
-    }
-  }
-
-  /**
-   * Delete
-   *
-   * @param {string} snomed - SNOMED code
-   * @param {object} context - Context
-   * @static
-   */
-  static delete(snomed, context) {
-    delete context.vaccines[snomed]
-  }
 }
 
 /**
  * @import { PreScreenQuestion, VaccinationProtocol, VaccineCriteria, VaccineSideEffect, VaccineMethod } from '../enums.js'
+ * @import { BaseModelOptions } from './base.js'
  */

--- a/app/utils/audit-event.js
+++ b/app/utils/audit-event.js
@@ -1,0 +1,28 @@
+import _ from 'lodash'
+
+/**
+ * Diff two model instances and return changed fields with display values
+ *
+ * @param {object} before - Model instance before update
+ * @param {object} after - Model instance after update
+ * @returns {{ key: string, before: string, after: string }[]} Updated fields
+ */
+export function getUpdatedFields(before, after) {
+  const keys = Object.keys(before).filter((key) => !key.includes('_'))
+  const updatedFields = []
+
+  for (const key of keys) {
+    const valueBefore = before.formatted?.[key] || before?.[key]
+    const valueAfter = after.formatted?.[key] || after?.[key]
+
+    if (!_.isMatch(valueBefore, valueAfter)) {
+      updatedFields.push({
+        key: `${after.ns}.${key}.label`,
+        before: String(valueBefore ?? '').replace('<br>', ', '),
+        after: String(valueAfter ?? '').replace('<br>', ', ')
+      })
+    }
+  }
+
+  return updatedFields
+}

--- a/app/utils/audit-event.js
+++ b/app/utils/audit-event.js
@@ -8,7 +8,8 @@ import _ from 'lodash'
  * @returns {{ key: string, before: string, after: string }[]} Updated fields
  */
 export function getUpdatedFields(before, after) {
-  const keys = Object.keys(before).filter((key) => !key.includes('_'))
+  const foreignKeys = Object.keys(before.constructor.foreignKeys)
+  const keys = Object.keys(before).filter((key) => !foreignKeys.includes(key))
   const updatedFields = []
 
   for (const key of keys) {

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -30,8 +30,8 @@ export function camelToKebabCase(string) {
 /**
  * Convert string to boolean
  *
- * @template {string | boolean} T
- * @param {T | Array<T>} value - Value to test
+ * @template {string|boolean} T
+ * @param {T|Array<T>} value - Value to test
  * @returns {boolean} Boolean
  */
 export function stringToBoolean(value) {
@@ -46,13 +46,21 @@ export function stringToBoolean(value) {
 /**
  * Convert string to array
  *
- * @template {string|number|boolean} T
- * @param {T|Array<T>} value - Value to test
- * @returns {Array<T>} Array
+ * @param {string|Array|undefined} value - Value to test
+ * @returns {Array} Array
  */
 export function stringToArray(value) {
-  const array = Array.isArray(value) ? value : []
-  return array.filter((item) => item !== '_unchecked')
+  if (value === undefined) {
+    return []
+  }
+
+  if (Array.isArray(value)) {
+    return value.includes('_unchecked')
+      ? value.filter((item) => item !== '_unchecked')
+      : value
+  }
+
+  return [value].filter((item) => item !== '_unchecked')
 }
 
 /**

--- a/app/utils/url.js
+++ b/app/utils/url.js
@@ -40,9 +40,7 @@ export function getFilterParams(request, radioKeys = [], checkboxKeys = []) {
   }
 
   for (const key of checkboxKeys) {
-    const values = [request.body[key]]
-      .flat()
-      .filter((value) => value && value !== '_unchecked')
+    const values = [request.body[key]].flat().filter((value) => value)
     values.forEach((value) => params.append(key, value))
   }
 

--- a/app/views/download/form/cohort.njk
+++ b/app/views/download/form/cohort.njk
@@ -36,6 +36,6 @@
       }
     },
     items: enumItems(DownloadVariable),
-    decorate: "download.variables_"
+    decorate: "download.variables"
   }) }}
 {% endblock %}

--- a/app/views/school/form/year-groups.njk
+++ b/app/views/school/form/year-groups.njk
@@ -14,6 +14,6 @@
       }
     },
     items: yearGroupItems,
-    decorate: "school.yearGroups_"
+    decorate: "school.yearGroups"
   }) }}
 {% endblock %}

--- a/app/views/session/form/check-answers.njk
+++ b/app/views/session/form/check-answers.njk
@@ -8,6 +8,8 @@
     title: title
   }) }}
 
+  {{ inspect(session) }}
+
   {% if session.type === SessionType.School %}
     {{ summaryList({
       card: {

--- a/app/views/session/form/year-groups.njk
+++ b/app/views/session/form/year-groups.njk
@@ -11,6 +11,6 @@
       }
     },
     items: yearGroupItems,
-    decorate: "session.yearGroups_"
+    decorate: "session.yearGroups"
   }) }}
 {% endblock %}

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -224,7 +224,9 @@ for (const preset of Object.values(SessionPresets)) {
   if (preset.clinicOnly) {
     const clinicsPerPreset = 3
     const clinic_ids = faker.helpers.arrayElements(
-      Object.values(context.teams).flatMap((team) => team.clinic_ids),
+      Team.findAll(context).flatMap((team) =>
+        team.clinics.map((clinic) => clinic.id)
+      ),
       clinicsPerPreset
     )
     for (const clinic_id of clinic_ids) {


### PR DESCRIPTION
There’s a lot of boiler plate in the models, repeated code that does exactly the same thing. 

This PR creates a new `BaseModel` which other models can inherit. It provides the following:

- `get createdBy`
- `get createdAt_`
- `set createdAt_`
- `get updatedBy`
- `get ns`
- `foreign`
- `toJSON()`
- `static findOne()`
- `static findAll()`
- `static create()`
- `static update()`
- `static delete()`

To enable consistent implementation across models, the `Team` model no longer stores (and therefore needs up update) a list of schools and clinics.

This PR also refactors how arrays are handled, performing normalisation on the constructor so save needing to filter `_unchecked` values in different parts of the code base. 