### PR TITLE
Default dates entered in forms to having a time of midday to avoid issues with daylight saving

### DIFF
--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -272,7 +272,6 @@ export const bookIntoClinicController = {
       const clinicDateItems = []
       scheduledClinicSessions.forEach((session) => {
         const midday = new Date(session.date)
-        setMidday(midday)
 
         const availableTimes = session.availableAppointmentTimes
         const morningAvailable = availableTimes.some((time) => time < midday)

--- a/app/controllers/book-into-a-clinic.js
+++ b/app/controllers/book-into-a-clinic.js
@@ -20,7 +20,6 @@ import {
   getBookableClinicSessions,
   getScheduledClinicLocationItems
 } from '../utils/clinic-booking.js'
-import { setMidday } from '../utils/date.js'
 import {
   ConjunctionType,
   programmeNamesListForSentence

--- a/app/generators/clinic-vaccination-periods.js
+++ b/app/generators/clinic-vaccination-periods.js
@@ -26,8 +26,8 @@ export function generateClinicVaccinationPeriods(session) {
     breakLength
 
   const sessionDate = new Date(session.date)
-  const earliestSessionStartTime = new Date(sessionDate.setUTCHours(9, 0)) // 9am
-  const latestSessionFinishTime = new Date(sessionDate.setUTCHours(20, 0)) // 8pm
+  const earliestSessionStartTime = new Date(sessionDate.setHours(9, 0, 0, 0)) // 9am
+  const latestSessionFinishTime = new Date(sessionDate.setHours(20, 0, 0, 0)) // 8pm
   const sessionWindow = Math.floor(
     (latestSessionFinishTime.getTime() - earliestSessionStartTime.getTime()) /
       1000 /

--- a/app/utils/date.js
+++ b/app/utils/date.js
@@ -55,13 +55,13 @@ export function convertObjectToIsoDate(object, namePrefix) {
     day = Number(object[`${namePrefix}-day`])
     month = Number(parseMonth(object[`${namePrefix}-month`])) - 1
     year = Number(object[`${namePrefix}-year`])
-    hour = Number(object[`${namePrefix}-hour`])
-    minute = Number(object[`${namePrefix}-minute`])
+    hour = Number(object[`${namePrefix}-hour`]) || 12
+    minute = Number(object[`${namePrefix}-minute`]) || 0
   } else {
     day = Number(object?.day)
     month = Number(parseMonth(object?.month)) - 1
     year = Number(object?.year)
-    hour = Number(object?.hour) || 0
+    hour = Number(object?.hour) || 12
     minute = Number(object?.minute) || 0
   }
 
@@ -69,10 +69,8 @@ export function convertObjectToIsoDate(object, namePrefix) {
     if (!day) {
       return new Date(year, month)
     }
-    const seconds = new Date().getSeconds()
-    const ms = new Date().getMilliseconds()
 
-    return new Date(year, month, day, hour, minute, seconds, ms)
+    return new Date(year, month, day, hour, minute, 0, 0)
   } catch (error) {
     console.error(error.message.split(':')[0])
   }

--- a/app/utils/date.js
+++ b/app/utils/date.js
@@ -320,7 +320,7 @@ export function getTermDates(year, term) {
  * @returns {Date} Date with time set to midday
  */
 export function setMidday(date) {
-  date.setUTCHours(12, 0, 0, 0)
+  date.setHours(12, 0, 0, 0)
   return date
 }
 


### PR DESCRIPTION
Previously, the use of UTC in setMidday had caused dates that were just after midnight to be set back to midday of the previous day. This change brings timezone usage into line with the rest of the prototype, avoiding that odd behaviour.

We also now default user-entered dates to have a time of exactly midday rather than midnight — or rather, a random handful of seconds after midnight — to further distance ourselves from daylight saving issues.