### PR TITLE
Split `patient` and `patientProgramme` routes and controllers

### DIFF
--- a/app/controllers/patient-programme.js
+++ b/app/controllers/patient-programme.js
@@ -1,0 +1,139 @@
+import { ProgrammeType, VaccinationOutcome } from '../enums.js'
+import {
+  PatientProgramme,
+  Patient,
+  Vaccination,
+  PatientSession,
+  Session
+} from '../models.js'
+import { saveAndRedirect } from '../utils/redirect.js'
+
+export const patientProgrammeController = {
+  /**
+   * @type {RequestHandler<Record<string, string>>}
+   */
+  read(request, response, next) {
+    const { programme_id } = request.params
+    const { data } = request.session
+    const { patient } = response.locals
+
+    if (!programme_id) {
+      return saveAndRedirect(request, response, patient.uri)
+    }
+
+    const patientProgramme = new PatientProgramme(
+      patient.programmes[String(programme_id)],
+      data
+    )
+
+    response.locals.activeClinicsItems = patientProgramme.activeClinics.map(
+      (session) => ({
+        text: session.location.name,
+        hint: { text: session.clinic.formatted.address },
+        value: session.id
+      })
+    )
+
+    response.locals.patientProgramme = patientProgramme
+
+    return next()
+  },
+
+  /**
+   * @type {RequestHandler<Record<string, string>>}
+   */
+  show(request, response) {
+    const view = request.params.view || 'programme'
+
+    return response.render(`patient/${view}`)
+  },
+
+  /**
+   * @type {RequestHandler<Record<string, string>>}
+   */
+  addToSession(request, response) {
+    const { session_id } = request.body
+    const { programme_id } = request.params
+    const { data } = request.session
+    const { __, account, patient, patientProgramme } = response.locals
+
+    if (patientProgramme.scheduledClinicsCount === 0) {
+      return saveAndRedirect(request, response, `/sessions/new`)
+    }
+
+    // Get session
+    const session = Session.findOne(session_id, data)
+
+    // Create and add patient session
+    const patientSession = PatientSession.create(
+      {
+        createdBy_uid: account.uid,
+        patient_uuid: patient.uuid,
+        programme_id,
+        session_id
+      },
+      data
+    )
+
+    // Add to session
+    patient.addToSession(patientSession)
+
+    // Update session data
+    Patient.update(patient.uuid, patient, data)
+
+    request.flash(
+      'success',
+      __(`patientProgramme.addToSession.success`, { patient, session })
+    )
+
+    const returnUri = PatientSession.findOne(patientSession.uuid, data).uri
+    saveAndRedirect(request, response, returnUri)
+  },
+
+  /**
+   * @param {string} type - Form type
+   * @returns {RequestHandler<Record<string, string>>} Request handler
+   */
+  vaccination(type) {
+    return (request, response) => {
+      const { programme_id } = request.params
+      const { data } = request.session
+      const { account, patient } = response.locals
+
+      const patientProgramme = new PatientProgramme(
+        patient.programmes[String(programme_id)],
+        data
+      )
+
+      // Vaccination
+      const vaccination = Vaccination.create(
+        {
+          outcome: VaccinationOutcome.AlreadyVaccinated,
+          patient_uuid: patient.uuid,
+          createdBy_uid: account.uid,
+          administeredBy_uid: account.uid,
+          ...(type === 'new' && { programme_id })
+        },
+        data.wizard
+      )
+
+      let startPage = 'administered-at'
+      if (!vaccination.programme_id) {
+        startPage = 'programme'
+      } else if (patientProgramme.programme.type === ProgrammeType.MMR) {
+        startPage = 'variant'
+      }
+
+      saveAndRedirect(
+        request,
+        response,
+        `${patientProgramme.programme.uri}/vaccinations/${vaccination.uuid}/new/${startPage}?referrer=${patientProgramme.uri}`
+      )
+    }
+  }
+}
+
+/**
+ * @import { RequestHandler, RequestParamHandler } from 'express'
+ * @import { PatientFilterQuery } from '../../typings/index.d.ts'
+ */

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -4,19 +4,10 @@ import {
   ArchiveRecordReason,
   PatientClinicStatus,
   PatientStatus,
-  ProgrammeType,
   SessionStatus,
-  SessionType,
-  VaccinationOutcome
+  SessionType
 } from '../enums.js'
-import {
-  PatientProgramme,
-  Patient,
-  Programme,
-  Vaccination,
-  PatientSession,
-  Session
-} from '../models.js'
+import { PatientProgramme, Patient, Programme, Session } from '../models.js'
 import { getResults, getPagination } from '../utils/pagination.js'
 import {
   ConjunctionType,
@@ -687,90 +678,6 @@ export const patientController = {
     request.flash('success', __(`patient.notes.new.success`, { patient }))
 
     return saveAndRedirect(request, response, patient.uri)
-  },
-
-  /**
-   * @type {RequestHandler<Record<string, string>>}
-   */
-  addToSession(request, response) {
-    const { session_id } = request.body
-    const { programme_id } = request.params
-    const { data } = request.session
-    const { __, account, patient, patientProgramme } = response.locals
-
-    if (patientProgramme.scheduledClinicsCount === 0) {
-      return saveAndRedirect(request, response, `/sessions/new`)
-    }
-
-    // Get session
-    const session = Session.findOne(session_id, data)
-
-    // Create and add patient session
-    const patientSession = PatientSession.create(
-      {
-        createdBy_uid: account.uid,
-        patient_uuid: patient.uuid,
-        programme_id,
-        session_id
-      },
-      data
-    )
-
-    // Add to session
-    patient.addToSession(patientSession)
-
-    // Update session data
-    Patient.update(patient.uuid, patient, data)
-
-    request.flash(
-      'success',
-      __(`patientProgramme.addToSession.success`, { patient, session })
-    )
-
-    const returnUri = PatientSession.findOne(patientSession.uuid, data).uri
-    saveAndRedirect(request, response, returnUri)
-  },
-
-  /**
-   * @param {string} type - Form type
-   * @returns {RequestHandler<Record<string, string>>} Request handler
-   */
-  vaccination(type) {
-    return (request, response) => {
-      const { programme_id } = request.params
-      const { data } = request.session
-      const { account, patient } = response.locals
-
-      const patientProgramme = new PatientProgramme(
-        patient.programmes[String(programme_id)],
-        data
-      )
-
-      // Vaccination
-      const vaccination = Vaccination.create(
-        {
-          outcome: VaccinationOutcome.AlreadyVaccinated,
-          patient_uuid: patient.uuid,
-          createdBy_uid: account.uid,
-          administeredBy_uid: account.uid,
-          ...(type === 'new' && { programme_id })
-        },
-        data.wizard
-      )
-
-      let startPage = 'administered-at'
-      if (!vaccination.programme_id) {
-        startPage = 'programme'
-      } else if (patientProgramme.programme.type === ProgrammeType.MMR) {
-        startPage = 'variant'
-      }
-
-      saveAndRedirect(
-        request,
-        response,
-        `${patientProgramme.programme.uri}/vaccinations/${vaccination.uuid}/new/${startPage}?referrer=${patientProgramme.uri}`
-      )
-    }
   }
 }
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -22,6 +22,7 @@ import { giveOrRefuseConsentRoutes } from './routes/give-or-refuse-consent.js'
 import { homeRoutes } from './routes/home.js'
 import { moveRoutes } from './routes/move.js'
 import { noticeRoutes } from './routes/notice.js'
+import { patientProgrammeRoutes } from './routes/patient-programme.js'
 import { patientSessionRoutes } from './routes/patient-session.js'
 import { patientRoutes } from './routes/patient.js'
 import { pdsRecordRoutes } from './routes/pds-record.js'
@@ -60,6 +61,7 @@ router.use('/notices', noticeRoutes)
 router.use('/teams', teamRoutes)
 router.use('/teams/:team_id/clinics', clinicRoutes)
 router.use('/contacts', contactRoutes)
+router.use('/patients/:patient_uuid/programmes', patientProgrammeRoutes)
 router.use('/patients', patientRoutes)
 router.use('/pds', pdsRecordRoutes)
 router.use('/reports', reportRoutes)

--- a/app/routes/patient-programme.js
+++ b/app/routes/patient-programme.js
@@ -1,0 +1,31 @@
+import express from 'express'
+
+import { patientProgrammeController as patientProgramme } from '../controllers/patient-programme.js'
+import { patientController as patient } from '../controllers/patient.js'
+
+const router = express.Router({ strict: true, mergeParams: true })
+
+// Populate `response.locals.patient`
+router.use((request, response, next) =>
+  patient.read(
+    request,
+    response,
+    next,
+    request.params.patient_uuid,
+    'patient_uuid'
+  )
+)
+
+router.param('programme_id', patientProgramme.read)
+
+router.get('/:programme_id{/:view}', patientProgramme.show)
+
+router.post('/:programme_id/clinics', patientProgramme.addToSession)
+
+router.get(
+  '/:programme_id/new/vaccination',
+  patientProgramme.vaccination('new')
+)
+router.get('/:programme_id/new/ttcv', patientProgramme.vaccination('ttcv'))
+
+export const patientProgrammeRoutes = router

--- a/app/routes/patient.js
+++ b/app/routes/patient.js
@@ -24,29 +24,6 @@ router.post('/:patient_uuid/new/note', patient.note)
 router.post('/:patient_uuid/archive', patient.archive)
 router.post('/:patient_uuid/invite-to-clinic', patient.inviteOneToClinic)
 
-router.all(
-  '/:patient_uuid/programmes/:programme_id{/:view}',
-  patient.readProgramme
-)
-router.get(
-  '/:patient_uuid/programmes/:programme_id{/:view}',
-  patient.showProgramme
-)
-
-router.post(
-  '/:patient_uuid/programmes/:programme_id/clinics',
-  patient.addToSession
-)
-
-router.get(
-  '/:patient_uuid/programmes/:programme_id/new/vaccination',
-  patient.vaccination('new')
-)
-router.get(
-  '/:patient_uuid/programmes/:programme_id/new/ttcv',
-  patient.vaccination('ttcv')
-)
-
 router.get('/:patient_uuid{/:view}', patient.show)
 
 export const patientRoutes = router


### PR DESCRIPTION
As we already have a `PatientProgramme` model, we should follow the conventions we use else where and have controllers and routes in the same namespace.

This is also useful as we start to build out more programme-level features on the patient pages.