### PR TITLE
Support programme years for seasonal flu and add ‘Not eligible’ sub-statuses

### DIFF
--- a/app/controllers/consent.js
+++ b/app/controllers/consent.js
@@ -104,7 +104,6 @@ export const consentController = {
     // Filter by display option
     for (const key of [
       'hasAdjustment',
-      'hasAgedOutOfProgrammes',
       'hasImpairment',
       'hasMissingNhsNumber',
       'isArchived'

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -49,17 +49,15 @@ export const patientController = {
         href: `${patient.uri}/contacts`,
         current: currentPath === `${patient.uri}/contacts`
       },
-      ...Object.values(patient.programmes)
-        .filter((patientProgramme) => patientProgramme.isActive)
-        .map((patientProgramme) => {
-          if (!account.isSchoolUser) {
-            return {
-              text: patientProgramme.programme.name,
-              href: patientProgramme.uri,
-              current: currentPath === patientProgramme.uri
-            }
+      ...Object.values(patient.activeProgrammes).map((patientProgramme) => {
+        if (!account.isSchoolUser) {
+          return {
+            text: patientProgramme.programme.name,
+            href: patientProgramme.uri,
+            current: currentPath === patientProgramme.uri
           }
-        })
+        }
+      })
     ]
 
     response.locals.archiveRecordReasonItems = Object.values(
@@ -124,6 +122,7 @@ export const patientController = {
       clinicStatus: request.query.clinicStatus || 'none',
       patientConsent: request.query.patientConsent || 'none',
       patientDeferred: request.query.patientDeferred || 'none',
+      patientIneligible: request.query.patientIneligible || 'none',
       patientRefused: request.query.patientRefused || 'none',
       patientTriage: request.query.patientTriage || 'none',
       patientVaccinated: request.query.patientVaccinated || 'none',
@@ -134,8 +133,7 @@ export const patientController = {
     if (programme_id && filters.report !== PatientStatus.Ineligible) {
       results = results.filter((patient) =>
         programme_ids.some(
-          (programme_id) =>
-            patient.programmes[programme_id].status !== PatientStatus.Ineligible
+          (programme_id) => !patient.programmes[programme_id].isIneligible
         )
       )
     }
@@ -181,7 +179,7 @@ export const patientController = {
       )
     }
 
-    // Filter by sub-status(es)
+    // Filter by sub-status(es) (from last patient session)
     for (const [patientStatus, status] of Object.entries({
       [PatientStatus.Consent]: 'patientConsent',
       [PatientStatus.Deferred]: 'patientDeferred',
@@ -204,6 +202,21 @@ export const patientController = {
       }
     }
 
+    // Filter by ineligible sub-status (from patient programme)
+    if (
+      filters.report === PatientStatus.Ineligible &&
+      filters.patientIneligible !== 'none'
+    ) {
+      const ids = programme_ids || programmes.map((programme) => programme.id)
+      results = results.filter((patient) =>
+        ids.some(
+          (id) =>
+            patient.programmes[id].ineligibilityStatus ===
+            filters.patientIneligible
+        )
+      )
+    }
+
     // Filter by year group
     if (yearGroup) {
       results = results.filter((patient) =>
@@ -214,7 +227,6 @@ export const patientController = {
     // Filter by display option
     for (const key of [
       'hasAdjustment',
-      'hasAgedOutOfProgrammes',
       'hasImpairment',
       'hasMissingNhsNumber',
       'isArchived'
@@ -259,6 +271,7 @@ export const patientController = {
     delete data.option
     delete data.patientConsent
     delete data.patientDeferred
+    delete data.patientIneligible
     delete data.patientRefused
     delete data.patientTriage
     delete data.patientVaccinated
@@ -326,6 +339,7 @@ export const patientController = {
         'option',
         'patientConsent',
         'patientDeferred',
+        'patientIneligible',
         'patientRefused',
         'patientTriage',
         'patientVaccinated',

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -49,15 +49,17 @@ export const patientController = {
         href: `${patient.uri}/contacts`,
         current: currentPath === `${patient.uri}/contacts`
       },
-      ...Object.values(patient.programmes).map((patientProgramme) => {
-        if (!account.isSchoolUser) {
-          return {
-            text: patientProgramme.programme.name,
-            href: patientProgramme.uri,
-            current: currentPath === patientProgramme.uri
+      ...Object.values(patient.programmes)
+        .filter((patientProgramme) => patientProgramme.isActive)
+        .map((patientProgramme) => {
+          if (!account.isSchoolUser) {
+            return {
+              text: patientProgramme.programme.name,
+              href: patientProgramme.uri,
+              current: currentPath === patientProgramme.uri
+            }
           }
-        }
-      })
+        })
     ]
 
     response.locals.archiveRecordReasonItems = Object.values(

--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -158,6 +158,7 @@ export const schoolController = {
       clinicStatus: request.query.clinicStatus || 'none',
       patientConsent: request.query.patientConsent || 'none',
       patientDeferred: request.query.patientDeferred || 'none',
+      patientIneligible: request.query.patientIneligible || 'none',
       patientRefused: request.query.patientRefused || 'none',
       patientTriage: request.query.patientTriage || 'none',
       patientVaccinated: request.query.patientVaccinated || 'none',
@@ -203,7 +204,7 @@ export const schoolController = {
       )
     }
 
-    // Filter by sub-status(es)
+    // Filter by sub-status(es) (from last patient session)
     for (const [patientStatus, status] of Object.entries({
       [PatientStatus.Consent]: 'patientConsent',
       [PatientStatus.Deferred]: 'patientDeferred',
@@ -227,6 +228,22 @@ export const schoolController = {
       }
     }
 
+    // Filter by ineligible sub-status (from patient programme)
+    if (
+      filters.report === PatientStatus.Ineligible &&
+      filters.patientIneligible !== 'none'
+    ) {
+      const ids =
+        programme_ids || school.programmes.map((programme) => programme.id)
+      results = results.filter((patient) =>
+        ids.some(
+          (id) =>
+            patient.programmes[id].ineligibilityStatus ===
+            filters.patientIneligible
+        )
+      )
+    }
+
     // Filter by year group
     if (yearGroup) {
       results = results.filter((patient) =>
@@ -237,7 +254,6 @@ export const schoolController = {
     // Filter by display option
     for (const key of [
       'hasAdjustment',
-      'hasAgedOutOfProgrammes',
       'hasImpairment',
       'hasMissingNhsNumber',
       'isArchived'
@@ -276,6 +292,7 @@ export const schoolController = {
     delete data.option
     delete data.patientConsent
     delete data.patientDeferred
+    delete data.patientIneligible
     delete data.patientRefused
     delete data.patientTriage
     delete data.patientVaccinated
@@ -301,6 +318,7 @@ export const schoolController = {
         'option',
         'patientConsent',
         'patientDeferred',
+        'patientIneligible',
         'patientRefused',
         'patientTriage',
         'patientVaccinated',

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -429,6 +429,7 @@ export const sessionController = {
       clinicStatus: request.query.clinicStatus || 'none',
       patientConsent: request.query.patientConsent || 'none',
       patientDeferred: request.query.patientDeferred || 'none',
+      patientIneligible: request.query.patientIneligible || 'none',
       patientRefused: request.query.patientRefused || 'none',
       patientTriage: request.query.patientTriage || 'none',
       patientVaccinated: request.query.patientVaccinated || 'none',
@@ -462,6 +463,22 @@ export const sessionController = {
       }
     }
 
+    // Filter by ineligible sub-status (from patient programme)
+    if (
+      filters.report === PatientStatus.Ineligible &&
+      filters.patientIneligible !== 'none'
+    ) {
+      const ids =
+        programme_ids || session.programmes.map((programme) => programme.id)
+      results = results.filter((patientSession) =>
+        ids.some(
+          (id) =>
+            patientSession.patient.programmes[id].ineligibilityStatus ===
+            filters.patientIneligible
+        )
+      )
+    }
+
     // Filter by year group
     if (yearGroup) {
       results = results.filter(({ patient }) =>
@@ -472,7 +489,6 @@ export const sessionController = {
     // Filter patient by display option
     for (const key of [
       'hasAdjustment',
-      'hasAgedOutOfProgrammes',
       'hasImpairment',
       'hasMissingNhsNumber',
       'isArchived'
@@ -573,6 +589,7 @@ export const sessionController = {
     delete data.option
     delete data.patientConsent
     delete data.patientDeferred
+    delete data.patientIneligible
     delete data.patientRefused
     delete data.patientTriage
     delete data.patientVaccinated
@@ -600,6 +617,7 @@ export const sessionController = {
         'option',
         'patientConsent',
         'patientDeferred',
+        'patientIneligible',
         'patientRefused',
         'patientTriage',
         'patientVaccinated',

--- a/app/controllers/unmatched-appointment.js
+++ b/app/controllers/unmatched-appointment.js
@@ -121,7 +121,6 @@ export const unmatchedAppointmentController = {
     // Filter by display option
     for (const key of [
       'hasAdjustment',
-      'hasAgedOutOfProgrammes',
       'hasImpairment',
       'hasMissingNhsNumber',
       'isArchived'

--- a/app/datasets/programmes.js
+++ b/app/datasets/programmes.js
@@ -58,6 +58,7 @@ export default {
       url: 'https://www.gov.uk/government/publications/flu-vaccination-leaflets-and-posters',
       hint: 'including in other languages and alternative formats, including BSL and Braille'
     },
+    isSeasonal: true,
     sequence: ['1P'],
     immunocompromisedSequence: ['1P', '2P'],
     sequenceDefault: '1P',

--- a/app/enums.js
+++ b/app/enums.js
@@ -430,6 +430,16 @@ export const PatientConsentStatus = {
  * @readonly
  * @enum {string}
  */
+export const PatientIneligibleStatus = {
+  Pending: 'Not eligible yet',
+  AgedOut: 'Not eligible for school age immunisation',
+  Expired: 'No longer eligible'
+}
+
+/**
+ * @readonly
+ * @enum {string}
+ */
 export const PatientTriageStatus = {
   Responses: 'Review health questions',
   Consultation: 'Triage in person'

--- a/app/generators/session.js
+++ b/app/generators/session.js
@@ -2,27 +2,44 @@ import { fakerEN_GB as faker } from '@faker-js/faker'
 
 import { SessionPresetName, SessionType, TeamDefaults } from '../enums.js'
 import { Session } from '../models.js'
-import { addDays, getTermDates, removeDays, setMidday } from '../utils/date.js'
+import {
+  addDays,
+  getCurrentAcademicYear,
+  getTermDates,
+  removeDays,
+  setMidday
+} from '../utils/date.js'
 import { getSessionYearGroups } from '../utils/session.js'
 
 /**
  * Generate fake session
  *
  * @param {SessionPreset} preset - Session preset
- * @param {number} academicYear - Academic year
  * @param {User} user - User
  * @param {object} options - Options
  * @param {string} [options.clinic_id] - Clinic ID
  * @param {string} [options.school_id] - School URN
  * @returns {Session|undefined} Session
  */
-export function generateSession(preset, academicYear, user, options) {
+export function generateSession(preset, user, options) {
   // Don’t generate sessions for inactive session preset
   if (!preset.active) {
     return
   }
 
   const { clinic_id, school_id } = options
+
+  // Generate some school sessions for flu in the previous academic year
+  let academicYear = getCurrentAcademicYear()
+  const isPreviousAcademicYear = faker.datatype.boolean(0.5)
+  if (
+    school_id &&
+    isPreviousAcademicYear &&
+    preset.name === SessionPresetName.Flu
+  ) {
+    academicYear = academicYear - 1
+  }
+
   const term = getTermDates(academicYear, preset.term)
 
   let date = faker.date.between({

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2034,6 +2034,9 @@ export const en = {
     statusNotes: {
       label: 'Notes'
     },
+    otherSeasons: {
+      label: 'Other vaccinations for %s'
+    },
     tetanus: {
       label: 'Previous vaccinations for tetanus, diptheria and polio'
     },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1857,7 +1857,6 @@ export const en = {
       dob: 'Child’s date of birth',
       showOnly: 'Show only',
       hasAdjustment: 'Children needing reasonable adjustments',
-      hasAgedOutOfProgrammes: 'Children aged out of programmes',
       hasImpairment: 'Children with impairments',
       hasMissingNhsNumber: 'Children missing an NHS&nbsp;number',
       isArchived: 'Archived records'

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -20,8 +20,10 @@ import {
   Vaccination
 } from '../models.js'
 import {
+  formatDate,
   getCurrentAcademicYear,
   getDateValueDifference,
+  isBetweenDates,
   today
 } from '../utils/date.js'
 import { ordinal } from '../utils/number.js'
@@ -37,6 +39,7 @@ import { BaseModel } from './base.js'
 
 /**
  * @typedef {BaseModelOptions & object} PatientProgrammeOptions
+ * @property {number} [academicYear] - Programme year
  * @property {boolean} [wasInvitedToClinic] - Invited to clinic
  */
 
@@ -66,34 +69,58 @@ export class PatientProgramme extends BaseModel {
     this.programme
 
     this.context = context
+    this.academicYear = options?.academicYear || this.#currentAcademicYear
     this.wasInvitedToClinic = options?.wasInvitedToClinic
   }
 
   /**
-   * Year patient is eligible for programme
+   * Current academic year for today’s date
    *
-   * @returns {number|undefined} Year patient becomes eligible for programme
+   * @returns {number} Academic year a date sits within
    */
-  get year() {
-    if (!this.programme) {
-      return
+  get #currentAcademicYear() {
+    return getCurrentAcademicYear()
+  }
+
+  /**
+   * Get patient programme ID
+   *
+   * @returns {string} Patient programme ID
+   */
+  get id() {
+    if (this.programme.isSeasonal) {
+      return this.#currentAcademicYear === this.academicYear
+        ? this.programme.id
+        : `${this.programme.id}-${this.academicYear}`
+    }
+
+    return this.programme.id
+  }
+
+  /**
+   * Get programme name
+   *
+   * @returns {string} Programme name
+   */
+  get name() {
+    if (this.programme.type === ProgrammeType.MMR && this.patient?.age <= 6) {
+      return 'MMRV'
     }
 
     if (this.programme.type === ProgrammeType.Flu) {
-      const academicYear = getCurrentAcademicYear()
-
-      // If flu season has finished, make eligible for next year’s programme
-      if (isAfter(today(), `${academicYear + 1}-03-31`)) {
-        return academicYear + 1
-      }
-
-      return academicYear
+      return `Flu (${this.eligibilityStartAt.getFullYear()} to ${this.eligibilityEndAt.getFullYear()} season)`
     }
 
-    const yearsUntilEligible =
-      this.programme.targetYearGroup - this.patient.yearGroup
+    return this.programme.name
+  }
 
-    return getCurrentAcademicYear() + yearsUntilEligible
+  /**
+   * Is active programme
+   *
+   * @returns {boolean} Is active programme
+   */
+  get isActive() {
+    return this.academicYear === this.#currentAcademicYear
   }
 
   /**
@@ -108,6 +135,13 @@ export class PatientProgramme extends BaseModel {
       .filter(({ programme_ids }) =>
         programme_ids?.some((id) => this.programme_id === id)
       )
+      .filter(({ createdAt }) =>
+        isBetweenDates(
+          createdAt,
+          this.eligibilityStartAt,
+          this.eligibilityEndAt
+        )
+      )
       .sort((a, b) => getDateValueDifference(b.createdAt, a.createdAt))
   }
 
@@ -119,7 +153,9 @@ export class PatientProgramme extends BaseModel {
   get patientSessions() {
     return this.patient?.patientSessions
       .filter(
-        (patientSession) => patientSession?.programme_id === this.programme_id
+        ({ programme_id, session }) =>
+          programme_id === this.programme_id &&
+          session.academicYear === this.academicYear
       )
       .sort((a, b) => getDateValueDifference(a.session.date, b.session.date))
   }
@@ -261,7 +297,7 @@ export class PatientProgramme extends BaseModel {
         SessionStatus.Closed,
         SessionStatus.Cancelled
       ].includes(latestSchoolSession?.status) &&
-      latestSchoolSession?.academicYear === getCurrentAcademicYear()
+      latestSchoolSession?.academicYear === this.#currentAcademicYear
     )
   }
 
@@ -308,15 +344,73 @@ export class PatientProgramme extends BaseModel {
   }
 
   /**
-   * Eligible for programme in the current academic year
+   * Date patient becomes eligible for programme
    *
-   * @returns {boolean} Eligible for programme
+   * @returns {Date|undefined} Date patient becomes eligible for programme
+   */
+  get eligibilityStartAt() {
+    if (!this.programme) {
+      return
+    }
+
+    if (this.programme.isSeasonal) {
+      return new Date(`${this.academicYear}-09-01`)
+    }
+
+    let yearsUntilEligible =
+      this.programme.targetYearGroup - this.patient.yearGroup
+
+    return new Date(`${this.#currentAcademicYear + yearsUntilEligible}-09-01`)
+  }
+
+  /**
+   * Date patient left eligible for programme
+   *
+   * @returns {Date|undefined} Date patient left eligible for programme
+   */
+  get eligibilityEndAt() {
+    if (!this.programme?.isSeasonal) {
+      return
+    }
+
+    return new Date(`${this.academicYear + 1}-03-31`)
+  }
+
+  /**
+   * Eligible for programme in the current academic year has started
+   *
+   * @returns {boolean} Eligible for programme has started
    */
   get isEligible() {
     return (
       !this.patient?.hasAgedOutOfProgrammes &&
-      getCurrentAcademicYear() >= this.year
+      isAfter(today(), this.eligibilityStartAt)
     )
+  }
+
+  /**
+   * Eligible for programme in the current academic year has ended
+   *
+   * @returns {boolean} Eligible for programme has ended
+   */
+  get wasEligible() {
+    return this.programme?.isSeasonal && isAfter(today(), this.eligibilityEndAt)
+  }
+
+  /**
+   * Get expanded description about ineligibility status
+   *
+   * @returns {string|undefined} Ineligibility description
+   */
+  get ineligibilityDescription() {
+    switch (true) {
+      case this.patient?.hasAgedOutOfProgrammes:
+        return 'Not eligible for school age immunisation'
+      case this.wasEligible:
+        return `Programme ended on ${this.formatted.eligibilityEndAt}`
+      default:
+        return `Eligible from ${this.formatted.eligibilityStartAt}`
+    }
   }
 
   /**
@@ -326,7 +420,9 @@ export class PatientProgramme extends BaseModel {
    */
   get vaccinationOutcomes() {
     return this.patient?.vaccinations.filter(
-      ({ programme }) => programme.id === this.programme_id
+      ({ programme, session }) =>
+        programme.id === this.programme_id &&
+        session?.academicYear === this.academicYear
     )
   }
 
@@ -451,6 +547,32 @@ export class PatientProgramme extends BaseModel {
     return this.programme.sequence[this.doseDue - 1]
   }
 
+  /**
+   * Get other seasons for this programme
+   *
+   * @returns {Array<PatientProgramme>|undefined} - Other seasons for this programme
+   */
+  get otherSeasons() {
+    if (this.programme.isSeasonal) {
+      return Object.values(this.patient.programmes).filter(
+        ({ programme, id }) =>
+          this.programme.id === programme.id && this.id !== id
+      )
+    }
+  }
+
+  /**
+   * Get the active season for this programme
+   *
+   * @returns {PatientProgramme} - Active season for this programme
+   */
+  get activeSeason() {
+    return Object.values(this.patient.programmes).find(
+      ({ programme, isActive }) =>
+        this.programme.id === programme.id && isActive
+    )
+  }
+
   get ttcvVaccinations() {
     if (this.programme.type === ProgrammeType.TdIPV) {
       return [
@@ -519,14 +641,20 @@ export class PatientProgramme extends BaseModel {
    * @returns {PatientStatus} Status properties
    */
   get status() {
-    // Not eligible for programme yet
-    if (!this.isEligible) {
+    // No longer eligible for any school-age vaccination programmes or
+    // not eligible for this programme yet
+    if (this.patient.hasAgedOutOfProgrammes || !this.isEligible) {
       return PatientStatus.Ineligible
     }
 
     // Is fully vaccinated
     if (this.dosesRemaining === 0) {
       return PatientStatus.Vaccinated
+    }
+
+    // No longer eligible for this programme
+    if (this.wasEligible) {
+      return PatientStatus.Ineligible
     }
 
     // Has been invited to a session
@@ -555,9 +683,7 @@ export class PatientProgramme extends BaseModel {
   get statusNotes() {
     switch (this.status) {
       case PatientStatus.Ineligible:
-        return this.patient?.hasAgedOutOfProgrammes
-          ? 'Not eligible for school age immunisation'
-          : `Eligible from 1 September ${this.year}`
+        return this.ineligibilityDescription
       case PatientStatus.Vaccinated:
         return `Vaccinated on ${this.lastVaccinationGiven.formatted.administeredAt_date}`
       case PatientStatus.Triage:
@@ -621,6 +747,10 @@ export class PatientProgramme extends BaseModel {
           switch (prop) {
             case 'doseDue':
               return ordinal(this.doseDue)
+            case 'eligibilityStartAt':
+              return formatDate(this.eligibilityStartAt, { dateStyle: 'long' })
+            case 'eligibilityEndAt':
+              return formatDate(this.eligibilityEndAt, { dateStyle: 'long' })
             case 'status':
               return getStatusTag()
             case 'statusWithNotes':
@@ -659,7 +789,7 @@ export class PatientProgramme extends BaseModel {
    * @returns {string} URI
    */
   get uri() {
-    return `/patients/${this.patient_uuid}/programmes/${this.programme_id}`
+    return `/patients/${this.patient_uuid}/programmes/${this.id}`
   }
 }
 

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -1,4 +1,4 @@
-import { addMonths, addWeeks, isAfter } from 'date-fns'
+import { addMonths, addWeeks, isAfter, isBefore } from 'date-fns'
 
 import {
   AuditEventType,
@@ -6,6 +6,7 @@ import {
   PatientConsentStatus,
   PatientDeferredStatus,
   PatientDueStatus,
+  PatientIneligibleStatus,
   PatientRefusedStatus,
   PatientStatus,
   ProgrammeType,
@@ -377,36 +378,62 @@ export class PatientProgramme extends BaseModel {
   }
 
   /**
-   * Eligible for programme in the current academic year has started
+   * Is not yet eligible for programme
    *
-   * @returns {boolean} Eligible for programme has started
+   * @returns {boolean} Is not yet eligible for programme
    */
-  get isEligible() {
-    return (
-      !this.patient?.hasAgedOutOfProgrammes &&
-      isAfter(today(), this.eligibilityStartAt)
-    )
+  get isNotEligibleYet() {
+    return isBefore(today(), this.eligibilityStartAt)
   }
 
   /**
-   * Eligible for programme in the current academic year has ended
+   * Is no longer eligible for programme
    *
-   * @returns {boolean} Eligible for programme has ended
+   * @returns {boolean} Is no longer eligible for programme
    */
-  get wasEligible() {
-    return this.programme?.isSeasonal && isAfter(today(), this.eligibilityEndAt)
+  get isNoLongerEligible() {
+    return isAfter(today(), this.eligibilityEndAt)
+  }
+
+  /**
+   * Ineligible for programme
+   *
+   * @returns {boolean} Ineligible for programme
+   */
+  get isIneligible() {
+    return (
+      this.patient?.hasAgedOutOfProgrammes ||
+      this.isNotEligibleYet ||
+      this.isNoLongerEligible
+    )
   }
 
   /**
    * Get expanded description about ineligibility status
    *
-   * @returns {string|undefined} Ineligibility description
+   * @returns {PatientIneligibleStatus} Ineligibility description
    */
-  get ineligibilityDescription() {
+  get ineligibilityStatus() {
     switch (true) {
       case this.patient?.hasAgedOutOfProgrammes:
+        return PatientIneligibleStatus.AgedOut
+      case this.isNoLongerEligible:
+        return PatientIneligibleStatus.Expired
+      default:
+        return PatientIneligibleStatus.Pending
+    }
+  }
+
+  /**
+   * Get expanded description about ineligibility status
+   *
+   * @returns {string} Ineligibility description
+   */
+  get ineligibilityDescription() {
+    switch (this.ineligibilityStatus) {
+      case PatientIneligibleStatus.AgedOut:
         return 'Not eligible for school age immunisation'
-      case this.wasEligible:
+      case PatientIneligibleStatus.Expired:
         return `Programme ended on ${this.formatted.eligibilityEndAt}`
       default:
         return `Eligible from ${this.formatted.eligibilityStartAt}`
@@ -641,29 +668,29 @@ export class PatientProgramme extends BaseModel {
    * @returns {PatientStatus} Status properties
    */
   get status() {
-    // No longer eligible for any school-age vaccination programmes or
-    // not eligible for this programme yet
-    if (this.patient.hasAgedOutOfProgrammes || !this.isEligible) {
-      return PatientStatus.Ineligible
-    }
+    switch (true) {
+      // No longer eligible for any school-age vaccination
+      // Not eligible for this programme yet
+      case this.patient.hasAgedOutOfProgrammes:
+      case this.isNotEligibleYet:
+        return PatientStatus.Ineligible
 
-    // Is fully vaccinated
-    if (this.dosesRemaining === 0) {
-      return PatientStatus.Vaccinated
-    }
+      // Is fully vaccinated
+      case this.dosesRemaining === 0:
+        return PatientStatus.Vaccinated
 
-    // No longer eligible for this programme
-    if (this.wasEligible) {
-      return PatientStatus.Ineligible
-    }
+      // No longer eligible for this programme
+      case this.isNoLongerEligible:
+        return PatientStatus.Ineligible
 
-    // Has been invited to a session
-    if (this.lastPatientSession) {
-      return getReportOutcome(this.lastPatientSession)
-    }
+      // Has been invited to a session
+      case !!this.lastPatientSession:
+        return getReportOutcome(this.lastPatientSession)
 
-    // Needs to be invited to a session
-    return PatientStatus.Consent
+      // Needs to be invited to a session
+      default:
+        return PatientStatus.Consent
+    }
   }
 
   /**

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -134,7 +134,11 @@ export class PatientSession extends BaseModel {
    * @returns {PatientProgramme|undefined} Patient programme
    */
   get patientProgramme() {
-    return this.patient?.programmes[this.programme_id]
+    return Object.values(this.patient?.programmes).find(
+      (patientProgramme) =>
+        patientProgramme.programme_id === this.programme_id &&
+        patientProgramme.academicYear === this.session.academicYear
+    )
   }
 
   /**
@@ -475,7 +479,9 @@ export class PatientSession extends BaseModel {
     try {
       if (this.patient?.vaccinations && this.programme_id) {
         return this.patient.vaccinations.filter(
-          ({ programme }) => programme?.id === this.programme_id
+          ({ programme, session }) =>
+            programme?.id === this.programme_id &&
+            session?.academicYear === this.patientProgramme.academicYear
         )
       }
     } catch (error) {
@@ -882,6 +888,8 @@ export class PatientSession extends BaseModel {
    */
   get reportDescription() {
     switch (this.report) {
+      case PatientStatus.Ineligible:
+        return this.patientProgramme?.ineligibilityDescription
       case PatientStatus.Vaccinated:
         return `${this.patient?.firstName} was vaccinated by ${this.lastVaccinationOutcome.createdBy.fullName} on ${this.lastVaccinationOutcome.formatted.createdAt}.`
       case PatientStatus.Due:

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -412,6 +412,19 @@ export class Patient extends Child {
   }
 
   /**
+   * Get active patient programmes
+   *
+   * @returns {Record<string, PatientProgramme>} Active patient programmes
+   */
+  get activeProgrammes() {
+    return Object.fromEntries(
+      Object.entries(this.programmes).filter(
+        ([, programme]) => programme.isActive
+      )
+    )
+  }
+
+  /**
    * Get the IDs of programmes for which this patient can be invited to clinic
    *
    * @returns {Array<string>} the IDs of programmes for which this patient is clinic-ready

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -25,7 +25,13 @@ import {
   Vaccination
 } from '../models.js'
 import { getUpdatedFields } from '../utils/audit-event.js'
-import { getDateValueDifference, removeDays, today } from '../utils/date.js'
+import {
+  getAllAcademicYears,
+  getCurrentAcademicYear,
+  getDateValueDifference,
+  removeDays,
+  today
+} from '../utils/date.js'
 import { tokenize } from '../utils/object.js'
 import { getPreferredNames } from '../utils/reply.js'
 import {
@@ -370,20 +376,36 @@ export class Patient extends Child {
     for (const programme of Object.values(programmesData).filter(
       (programme) => !programme.isHidden
     )) {
-      const patientProgramme = new PatientProgramme(
-        {
-          patient_uuid: this.uuid,
-          programme_id: programme.id
-        },
-        this.context
-      )
+      if (programme.isSeasonal) {
+        for (const academicYear of getAllAcademicYears()) {
+          const previousPatientProgramme = new PatientProgramme(
+            {
+              academicYear,
+              patient_uuid: this.uuid,
+              programme_id: programme.id
+            },
+            this.context
+          )
 
-      // Patient invited to clinic if invitation sent
-      patientProgramme.wasInvitedToClinic = this.clinicProgramme_ids.includes(
-        programme.id
-      )
+          programmes[previousPatientProgramme.id] = previousPatientProgramme
+        }
+      } else {
+        const patientProgramme = new PatientProgramme(
+          {
+            academicYear: getCurrentAcademicYear(),
+            patient_uuid: this.uuid,
+            programme_id: programme.id
+          },
+          this.context
+        )
 
-      programmes[programme.id] = patientProgramme
+        // Patient invited to clinic if invitation sent
+        patientProgramme.wasInvitedToClinic = this.clinicProgramme_ids.includes(
+          programme.id
+        )
+
+        programmes[patientProgramme.id] = patientProgramme
+      }
     }
 
     return programmes

--- a/app/models/programme.js
+++ b/app/models/programme.js
@@ -22,6 +22,7 @@ import { BaseModel } from './base.js'
  * @property {object} [emailNames] - Email names
  * @property {object} [information] - NHS.UK programme information
  * @property {object} [guidance] - GOV.UK guidance
+ * @property {boolean} [isSeasonal] - Is seasonal vaccination programme
  * @property {Array<string>} [sequence] - Vaccine dose sequence
  * @property {Array<string>} [immunocompromisedSequence] - Vaccine dose sequence for immunocompromised patients
  * @property {string} [sequenceDefault] - Default vaccine dose sequence
@@ -55,6 +56,7 @@ export class Programme extends BaseModel {
     this.emailNames = options?.emailNames
     this.information = options?.information
     this.guidance = options?.guidance
+    this.isSeasonal = options?.isSeasonal || false
     this.sequence = options?.sequence
     this.immunocompromisedSequence = options?.immunocompromisedSequence
     this.sequenceDefault = options?.sequenceDefault

--- a/app/utils/date.js
+++ b/app/utils/date.js
@@ -9,7 +9,7 @@ import {
   nextMonday
 } from 'date-fns'
 
-import { SchoolTerm } from '../enums.js'
+import { AcademicYear, SchoolTerm } from '../enums.js'
 
 const ALLOWED_VALUES_FOR_MONTHS = [
   ['1', '01', 'jan', 'january'],
@@ -197,6 +197,34 @@ export function getAcademicYear(date) {
  */
 export function getCurrentAcademicYear() {
   return getAcademicYear(today())
+}
+
+/**
+ * Get the latest academic year available, including next academic year
+ * if the 1 August preparation period has started
+ *
+ * @returns {number} Latest available academic year
+ */
+export function getLatestAcademicYear() {
+  const date = today()
+  const currentAcademicYear = getAcademicYear(date)
+  const isPreparationPeriod = date.getMonth() + 1 === 8
+
+  return isPreparationPeriod ? currentAcademicYear + 1 : currentAcademicYear
+}
+
+/**
+ * Get all academic years available, including the next academic year
+ * if the 1 August preparation period has started
+ *
+ * @returns {number[]} Latest available academic year
+ */
+export function getAllAcademicYears() {
+  const latestAcademicYear = getLatestAcademicYear()
+
+  return Object.keys(AcademicYear)
+    .map(Number)
+    .filter((year) => year <= latestAcademicYear)
 }
 
 /**

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -133,8 +133,15 @@
         value: "none",
         checked: not data.report or data.report == "none"
       }, {
-        text: PatientStatus.Ineligible
-      }, {
+        text: PatientStatus.Ineligible,
+        conditional: {
+          html: checkboxes({
+            small: true,
+            items: enumItems(PatientIneligibleStatus),
+            decorate: "patientIneligible"
+          })
+        } if data.report == PatientStatus.Ineligible
+      } if not params.hidePatientIneligibleStatus, {
         text: PatientStatus.Consent,
         conditional: {
           html: checkboxes({
@@ -268,10 +275,6 @@
           {
             value: "hasMissingNhsNumber",
             html: __("patient.search.hasMissingNhsNumber")
-          },
-          {
-            value: "hasAgedOutOfProgrammes",
-            text: __("patient.search.hasAgedOutOfProgrammes")
           }
         ],
         decorate: "option"

--- a/app/views/patient-programme/show.njk
+++ b/app/views/patient-programme/show.njk
@@ -189,7 +189,7 @@
           variant: "secondary",
           href: patientProgramme.uri + "/clinics"
         }]
-      }) if patientProgramme.status != PatientStatus.Vaccinated and patientProgramme.isEligible and patientProgramme.isActive }}
+      }) if patientProgramme.status != PatientStatus.Vaccinated and not patientProgramme.isIneligible and patientProgramme.isActive }}
     {% endcall %}
   {% endif %}
 

--- a/app/views/patient-programme/show.njk
+++ b/app/views/patient-programme/show.njk
@@ -15,16 +15,29 @@
     }, {
       text: __("patient.list.title"),
       href: "/patients"
-    }]
+    }, {
+      text: patient.fullName,
+      href: patient.uri
+    } if patientProgramme.activeSeason and not patientProgramme.isActive, {
+      text: patientProgramme.activeSeason.programme.name,
+      href: patientProgramme.activeSeason.uri
+    } if patientProgramme.activeSeason and not patientProgramme.isActive]
   }) }}
 {% endblock %}
 
 {% block form %}
   {{ super() }}
 
-  {{ patientNavigation({
-    patient: patient
-  }) }}
+  {% if patientProgramme.isActive %}
+    {{ patientNavigation({
+      patient: patient
+    }) }}
+  {% else %}
+    {{ appHeading({
+      caption: patient.fullName,
+      title: patientProgramme.name
+    }) }}
+  {% endif %}
 
   {% call card({
     heading: __mf("patientProgramme.vaccinationsGiven.count", {
@@ -73,7 +86,7 @@
     {{ actionLink({
       text: __("vaccination.new.alreadyVaccinated.title"),
       href: patientProgramme.uri + "/new/vaccination"
-    }) }}
+    }) if patientProgramme.isActive }}
   {% endcall %}
 
   {% if patientProgramme.ttcvVaccinations %}
@@ -176,7 +189,7 @@
           variant: "secondary",
           href: patientProgramme.uri + "/clinics"
         }]
-      }) if patientProgramme.status != PatientStatus.Vaccinated and patientProgramme.isEligible }}
+      }) if patientProgramme.status != PatientStatus.Vaccinated and patientProgramme.isEligible and patientProgramme.isActive }}
     {% endcall %}
   {% endif %}
 
@@ -187,4 +200,40 @@
       items: timelineItems(patientProgramme.auditEvents)
     })
   }) if patientProgramme.auditEvents.length }}
+
+  {% if patientProgramme.otherSeasons %}
+    {% call card({
+      heading: __("patientProgramme.otherSeasons.label", patientProgramme.programme.nameSentenceCase),
+      headingLevel: 3
+    }) %}
+      {% set otherSeasonRows = [] %}
+      {% for patientProgramme in patientProgramme.otherSeasons %}
+        {% set otherSeasonRows = otherSeasonRows | push([
+          {
+            header: __("patientProgramme.name.label"),
+            html: link(patientProgramme.uri, patientProgramme.name)
+          },
+          {
+            header: __("patientProgramme.status.label"),
+            html: patientProgramme.formatted.status
+          },
+          {
+            header: __("patientProgramme.statusNotes.label"),
+            html: patientProgramme.statusNotes
+          }
+        ]) %}
+      {% endfor %}
+
+      {{ table({
+        id: "other-seasons",
+        responsive: true,
+        head: [
+          { text: __("patientProgramme.name.label") },
+          { text: __("patientProgramme.status.label") },
+          { text: __("patientProgramme.statusNotes.label") }
+        ],
+        rows: otherSeasonRows
+      }) }}
+    {% endcall %}
+  {% endif %}
 {% endblock %}

--- a/app/views/patient-session/_report.njk
+++ b/app/views/patient-session/_report.njk
@@ -37,6 +37,6 @@
   {# Actions #}
   {{ actionLink({
     text: __("patientSession.patientProgramme.label", programme.nameSentenceCase),
-    href: patient.uri + "/programmes/" + programme.id + "?referrer=" + referrer
+    href: patientSession.patientProgramme.uri + "?referrer=" + referrer
   }) }}
 {% endcall %}

--- a/app/views/patient/list.njk
+++ b/app/views/patient/list.njk
@@ -68,13 +68,13 @@
         {% for patient in results.page %}
           {% set reportStatusHtml -%}
             {%- if data.programme_id %}
-              {%- for id, patientProgramme in patient.programmes -%}
+              {%- for id, patientProgramme in patient.activeProgrammes -%}
                 {%- if data.programme_id | includes(id) -%}
                   {{ patientProgramme.formatted.programmeStatus | nhsukMarkdown }}
                 {%- endif -%}
               {%- endfor %}
             {% else %}
-              {%- for id, patientProgramme in patient.programmes -%}
+              {%- for id, patientProgramme in patient.activeProgrammes -%}
                 {{ patientProgramme.formatted.programmeStatus | nhsukMarkdown }}
               {%- endfor %}
             {% endif %}
@@ -82,13 +82,13 @@
 
           {% set consentStatusHtml -%}
             {%- if data.programme_id %}
-              {%- for id, patientProgramme in patient.programmes -%}
+              {%- for id, patientProgramme in patient.activeProgrammes -%}
                 {%- if data.programme_id | includes(id) -%}
                   {{ patientProgramme.formatted.consentStatus | nhsukMarkdown }}
                 {%- endif -%}
               {%- endfor %}
             {% else %}
-              {%- for id, patientProgramme in patient.programmes -%}
+              {%- for id, patientProgramme in patient.activeProgrammes -%}
                 {{ patientProgramme.formatted.consentStatus | nhsukMarkdown }}
               {%- endfor %}
             {% endif %}

--- a/app/views/patient/show.njk
+++ b/app/views/patient/show.njk
@@ -88,7 +88,7 @@
   {% set canInviteToClinic = false %}
   {% set canBookIntoClinic = false %}
   {% for id, patientProgramme in patient.programmes %}
-    {% if account.isSchoolUser %}
+    {% if patientProgramme.isActive and account.isSchoolUser %}
       {% set patientProgrammeRows = patientProgrammeRows | push([
         {
           header: __("patientProgramme.name.label"),
@@ -99,7 +99,7 @@
           html: patientProgramme.formatted.consentStatus
         }
       ]) %}
-    {% else %}
+    {% elif patientProgramme.isActive %}
       {% set patientProgrammeRows = patientProgrammeRows | push([
         {
           header: __("patientProgramme.name.label"),

--- a/app/views/session/activity.njk
+++ b/app/views/session/activity.njk
@@ -24,6 +24,7 @@
           checkboxFilters: checkboxFilters,
           radioFilters: radioFilters,
           hideClinicStatuses: true,
+          hidePatientIneligibleStatus: true,
           hideProgrammeStatuses: account.isSchoolUser,
           view: view
         }) }}

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -61,8 +61,7 @@ import {
   getDateValueDifference,
   formatDate,
   removeDays,
-  today,
-  getCurrentAcademicYear
+  today
 } from '../app/utils/date.js'
 import { range } from '../app/utils/number.js'
 
@@ -199,8 +198,6 @@ for (const school of Object.values(context.schools)) {
 // Sessions
 context.sessions = {}
 for (const preset of Object.values(SessionPresets)) {
-  const year = getCurrentAcademicYear()
-
   // Schedule school sessions
   if (!preset.clinicOnly) {
     const ids = Object.values(context.schools)
@@ -213,7 +210,7 @@ for (const preset of Object.values(SessionPresets)) {
 
     // Schedule school sessions
     for (const school_id of ids) {
-      const schoolSession = generateSession(preset, year, nurse, { school_id })
+      const schoolSession = generateSession(preset, nurse, { school_id })
       if (schoolSession) {
         context.sessions[schoolSession.id] = new Session(schoolSession, context)
       }
@@ -230,7 +227,7 @@ for (const preset of Object.values(SessionPresets)) {
       clinicsPerPreset
     )
     for (const clinic_id of clinic_ids) {
-      const clinicSession = generateSession(preset, year, nurse, { clinic_id })
+      const clinicSession = generateSession(preset, nurse, { clinic_id })
       if (clinicSession) {
         generateClinicVaccinationPeriods(clinicSession)
         context.sessions[clinicSession.id] = new Session(clinicSession, context)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,6 +4,7 @@ export interface PatientFilterQuery {
   instruct?: string
   patientConsent?: string
   patientDeferred?: string
+  patientIneligible?: string
   patientRefused?: string
   patientTriage?: string
   patientVaccinated?: string


### PR DESCRIPTION
Jira issue: [MAV-1753](https://nhsd-jira.digital.nhs.uk/browse/MAV-1753)

This PR adds support for multiple seasonal flu programmes and introduces sub-statuses for the ‘Not eligible’ programme status.

## Supporting multiple (flu) seasons

When showing a seasonal programme status (i.e., for flu), the following rules apply:

- When a flu programme is in progress (1 September-31 March), the child record shows details of the current season
  - Children will have multiple programme statuses (but not **Not eligible**)
- When a flu programme has ended (1 April-31 July), the child record shows details of the last season
  - Vaccinated children will have a **Fully vaccinated** programme status
  - Unvaccinated children will have the **Not eligible** (No longer eligible) programme status
- During the preparation period (1-31 August), the child record shows details for the upcoming season
  - All children will have the **Not eligible** (Not eligible yet) programme status

Any previous (and/or future) seasons are shown on the child’s flu record, linked to from the bottom of a seasonal programme page.

## Introducing ‘Not eligible’ programme sub statuses

Supporting multiple seasons of flu (and considering support in the future for fine-grained eligibility vaccination statues) means we need to introduce sub-statuses for ‘Not eligible’:

- **Not eligible yet**
  - Season programmes (flu): the season hasn’t started yet
  - Other programmes: the child is not old enough for the programme yet
- **No longer eligible**
  - Season programmes (flu): the season has concluded
  - Other programmes: the child is too old for the programme

We can also move the ‘Children aged out of programmes’ advanced filter and make it a ‘Not eligible’ sub-status.

The ‘Not eligible’ status is shown on all lists of children, except those for school sessions (because all children in a school session are eligible).

<img width="320" height="340" alt="‘Not eligible’ programme sub status filters." src="https://github.com/user-attachments/assets/8470fd5f-2620-4e46-b947-f3d757ea7a2a" />

## Screenshots

### Child record

Only shows the current (or most recent or upcoming) season.

<img width="2400" height="4334" alt="Child record." src="https://github.com/user-attachments/assets/3c3bfebb-8c3a-4e16-8a42-d1daa7c04c4f" />

### Flu record (current season)

<img width="2400" height="4620" alt="Programme record (current season)." src="https://github.com/user-attachments/assets/508acb2c-b689-4f74-9ffe-16ab9708e5a5" />

### Flu record (previous season)

Consent was refused so the overall programme status is now ‘Not eligible’. No actions can be performed on this record (i.e. can’t record a previous vaccination or invite to a clinic).

<img width="2400" height="4316" alt="Programme record (previous season)." src="https://github.com/user-attachments/assets/704f45fe-e36e-4af7-89c9-0061e82aac5b" />