### PR TITLE
Filter schools by those missing sessions for programme(s)

### DIFF
--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -89,7 +89,7 @@ export const schoolController = {
     }
 
     // Filter by display option
-    for (const key of ['isClosed']) {
+    for (const key of ['isClosed', 'hasNoPlannedSessions']) {
       if (option?.includes(key)) {
         results = results.filter((school) => school[key])
       }

--- a/app/controllers/school.js
+++ b/app/controllers/school.js
@@ -2,7 +2,7 @@ import wizard from '@x-govuk/govuk-prototype-wizard'
 import _ from 'lodash'
 
 import { PatientStatus } from '../enums.js'
-import { Patient, School } from '../models.js'
+import { Patient, Programme, School } from '../models.js'
 import { generateNewSiteCode } from '../utils/location.js'
 import { getResults, getPagination } from '../utils/pagination.js'
 import { saveAndRedirect } from '../utils/redirect.js'
@@ -65,9 +65,13 @@ export const schoolController = {
    * @type {RequestHandler<Record<string, string>, Record<string, unknown>, Record<string, unknown>, SchoolFilterQuery>}
    */
   list(request, response) {
-    const { option, phase, q } = request.query
+    const { option, phase, programme_id, q } = request.query
     const { data } = request.session
     const { schools } = response.locals
+
+    const programmes = Programme.findAll(data)
+      ?.filter((programme) => !programme.isHidden)
+      .sort((a, b) => a.name.localeCompare(b.name))
 
     let results = schools
 
@@ -78,9 +82,12 @@ export const schoolController = {
       )
     }
 
-    // Filter by status (only show open schools by default)
-    if (!option) {
-      results = results.filter((school) => school.isOpen)
+    // Convert programme IDs into an array of IDs
+    let programme_ids
+    if (programme_id) {
+      programme_ids = Array.isArray(programme_id)
+        ? programme_id
+        : [programme_id]
     }
 
     // Filter by phase
@@ -88,11 +95,31 @@ export const schoolController = {
       results = results.filter((school) => school.phase === phase)
     }
 
+    // Filter by status (only show open schools by default)
+    if (option !== 'isClosed') {
+      results = results.filter((school) => school.isOpen)
+    }
+
     // Filter by display option
-    for (const key of ['isClosed', 'hasNoPlannedSessions']) {
+    for (const key of ['isClosed']) {
       if (option?.includes(key)) {
-        results = results.filter((school) => school[key])
+        results = results.filter(
+          (school) => !school.isHomeOrUnknown && school[key]
+        )
       }
+    }
+
+    // Filter by unplanned programme
+    if (programme_id) {
+      results = results.filter(
+        (school) =>
+          !school.isHomeOrUnknown &&
+          programme_ids.every((programme_id) =>
+            school.unplannedProgrammes
+              .map((programme) => programme.id)
+              .includes(programme_id)
+          )
+      )
     }
 
     // Sort
@@ -102,10 +129,18 @@ export const schoolController = {
     response.locals.results = getResults(results, request.query, 40)
     response.locals.pages = getPagination(results, request.query, 40)
 
+    // Programme filter options
+    response.locals.unplannedProgrammeItems = programmes.map((programme) => ({
+      text: programme.name,
+      value: programme.id,
+      checked: programme_id === programme.id
+    }))
+
     // Clean up session data
     delete data.option
     delete data.q
     delete data.phase
+    delete data.programme_id
 
     return response.render('school/list')
   },
@@ -114,7 +149,11 @@ export const schoolController = {
    * @type {RequestHandler<Record<string, string>>}
    */
   filterList(request, response) {
-    const params = getFilterParams(request, ['phase', 'q'], ['option'])
+    const params = getFilterParams(
+      request,
+      ['phase', 'q'],
+      ['option', 'programme_id']
+    )
 
     return saveAndRedirect(request, response, `/schools?${params}`)
   },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2696,7 +2696,9 @@ export const en = {
     },
     patients: {
       label: 'Children',
-      title: 'Children'
+      title: 'Children',
+      count:
+        '{count, plural, =0 {No children} one {1 child} other {# children}}'
     },
     sessions: {
       label: 'Sessions',
@@ -2705,6 +2707,11 @@ export const en = {
       isPlanned: 'Scheduled sessions',
       isCompleted: 'Completed sessions'
     },
+    plannedSessions: {
+      label: 'Upcoming sessions',
+      count:
+        '{count, plural, =0 {No upcoming sessions} one {# upcoming session} other{# upcoming sessions}}'
+    },
     results:
       '{count, plural, =0 {No schools matching your search criteria were found} one{Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> record} other{Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> schools}}',
     count:
@@ -2712,6 +2719,7 @@ export const en = {
     search: {
       label: 'Find school',
       showOnly: 'Show only',
+      hasNoPlannedSessions: 'Schools with no upcoming sessions',
       isClosed: 'Closed schools'
     },
     name: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2707,10 +2707,9 @@ export const en = {
       isPlanned: 'Scheduled sessions',
       isCompleted: 'Completed sessions'
     },
-    plannedSessions: {
-      label: 'Upcoming sessions',
-      count:
-        '{count, plural, =0 {No upcoming sessions} one {# upcoming session} other{# upcoming sessions}}'
+    unplannedProgrammes: {
+      label: 'Missing sessions',
+      hint: 'Show schools with no sessions scheduled for:'
     },
     results:
       '{count, plural, =0 {No schools matching your search criteria were found} one{Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> record} other{Showing <b>{from}</b> to <b>{to}</b> of <b>{count}</b> schools}}',
@@ -2719,7 +2718,6 @@ export const en = {
     search: {
       label: 'Find school',
       showOnly: 'Show only',
-      hasNoPlannedSessions: 'Schools with no upcoming sessions',
       isClosed: 'Closed schools'
     },
     name: {

--- a/app/middleware/internationalisation.js
+++ b/app/middleware/internationalisation.js
@@ -1,16 +1,6 @@
-import i18n from 'i18n'
-
-import { en } from '../locales/en.js'
+import i18n from '../utils/i18n.js'
 
 export const internationalisation = async (request, response, next) => {
-  i18n.configure({
-    cookie: 'locale',
-    defaultLocale: 'en',
-    objectNotation: true,
-    // @ts-ignore
-    staticCatalog: { en }
-  })
-
   i18n.init(request, response)
 
   next()

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -1,7 +1,7 @@
 import { default as filters } from '@x-govuk/govuk-prototype-filters'
 import { isAfter, isBefore } from 'date-fns'
 
-import { SchoolClosureReason, SchoolStatus } from '../enums.js'
+import { SchoolClosureReason, SchoolStatus, SessionStatus } from '../enums.js'
 import { Location, Patient, Session, Team } from '../models.js'
 import { formatDate, getDateValueDifference, today } from '../utils/date.js'
 import { getSchoolStatusProperties } from '../utils/enum-properties.js'
@@ -11,6 +11,7 @@ import {
   formatLink,
   formatTag,
   formatYearGroups,
+  localise,
   stringToArray,
   stringToBoolean
 } from '../utils/string.js'
@@ -231,6 +232,26 @@ export class School extends Location {
   }
 
   /**
+   * Get planned sessions run at this school
+   *
+   * @returns {Array<Session>} Sessions
+   */
+  get plannedSessions() {
+    return this.sessions.filter(
+      ({ status }) => status === SessionStatus.Planned
+    )
+  }
+
+  /**
+   * Whether no sessions planned to run at this school
+   *
+   * @returns {boolean} `true` if there are no planned session
+   */
+  get hasNoPlannedSessions() {
+    return !this.isHomeOrUnknown && this.plannedSessions.length === 0
+  }
+
+  /**
    * Get next session at this school
    *
    * @returns {Date|undefined} Next session
@@ -285,8 +306,16 @@ export class School extends Location {
               return `${this.name} (${getId()})`
             case 'nextSessionDate':
               return formatDate(this.nextSessionDate, { dateStyle: 'full' })
+            case 'plannedSessions':
+              return !this.isHomeOrUnknown
+                ? localise('school.plannedSessions.count', {
+                    count: this.plannedSessions.length
+                  })
+                : ''
             case 'patients':
-              return filters.plural(this.patients.length, 'child')
+              return localise('school.patients.count', {
+                count: this.patients.length
+              })
             case 'site':
               return formatCode(this.site)
             case 'status':

--- a/app/models/school.js
+++ b/app/models/school.js
@@ -1,8 +1,8 @@
 import { default as filters } from '@x-govuk/govuk-prototype-filters'
 import { isAfter, isBefore } from 'date-fns'
 
-import { SchoolClosureReason, SchoolStatus, SessionStatus } from '../enums.js'
-import { Location, Patient, Session, Team } from '../models.js'
+import { SchoolClosureReason, SchoolStatus } from '../enums.js'
+import { Location, Patient, Programme, Session, Team } from '../models.js'
 import { formatDate, getDateValueDifference, today } from '../utils/date.js'
 import { getSchoolStatusProperties } from '../utils/enum-properties.js'
 import { tokenize } from '../utils/object.js'
@@ -221,25 +221,16 @@ export class School extends Location {
   /**
    * Get sessions run at this school
    *
-   * @returns {Array<Session>|undefined} Sessions
-   */
-  get sessions() {
-    if (this.context) {
-      return Session.findAll(this.context)
-        .filter((session) => session.school_id === this.id)
-        .sort((a, b) => getDateValueDifference(a.date, b.date))
-    }
-  }
-
-  /**
-   * Get planned sessions run at this school
-   *
    * @returns {Array<Session>} Sessions
    */
-  get plannedSessions() {
-    return this.sessions.filter(
-      ({ status }) => status === SessionStatus.Planned
-    )
+  get sessions() {
+    if (this.context && !this.isHomeOrUnknown) {
+      return Session.findAll(this.context)
+        .filter(({ school_id }) => school_id === this.id)
+        .sort((a, b) => getDateValueDifference(a.date, b.date))
+    }
+
+    return []
   }
 
   /**
@@ -247,8 +238,23 @@ export class School extends Location {
    *
    * @returns {boolean} `true` if there are no planned session
    */
-  get hasNoPlannedSessions() {
-    return !this.isHomeOrUnknown && this.plannedSessions.length === 0
+  get hasUnplannedProgrammes() {
+    return this.unplannedProgrammes.length > 0
+  }
+
+  /**
+   * Get programmes with no planned session at this school
+   *
+   * @returns {Array<Programme>} Unplanned programmes
+   */
+  get unplannedProgrammes() {
+    const plannedProgrammeIds = new Set(
+      this.sessions.flatMap((session) => session.programme_ids)
+    )
+
+    return Programme.findAll(this.context).filter(
+      ({ id, isHidden }) => !isHidden && !plannedProgrammeIds.has(id)
+    )
   }
 
   /**
@@ -306,11 +312,11 @@ export class School extends Location {
               return `${this.name} (${getId()})`
             case 'nextSessionDate':
               return formatDate(this.nextSessionDate, { dateStyle: 'full' })
-            case 'plannedSessions':
+            case 'unplannedProgrammes':
               return !this.isHomeOrUnknown
-                ? localise('school.plannedSessions.count', {
-                    count: this.plannedSessions.length
-                  })
+                ? this.unplannedProgrammes
+                    .flatMap(({ nameTag }) => nameTag)
+                    .join(' ')
                 : ''
             case 'patients':
               return localise('school.patients.count', {

--- a/app/utils/i18n.js
+++ b/app/utils/i18n.js
@@ -1,0 +1,13 @@
+import i18n from 'i18n'
+
+import { en } from '../locales/en.js'
+
+i18n.configure({
+  cookie: 'locale',
+  defaultLocale: 'en',
+  objectNotation: true,
+  // @ts-ignore
+  staticCatalog: { en }
+})
+
+export default i18n

--- a/app/utils/string.js
+++ b/app/utils/string.js
@@ -1,9 +1,20 @@
 import prototypeFilters from '@x-govuk/govuk-prototype-filters'
-import i18n from 'i18n'
 
 import { healthQuestions } from '../datasets/health-questions.js'
 
+import i18n from './i18n.js'
 import { ordinal } from './number.js'
+
+/**
+ * Translate a phrase outside the request/response cycle
+ *
+ * @param {string} phrase - Catalog key
+ * @param {object} [values] - Values for interpolation (e.g. { count })
+ * @param {string} [locale] - Locale to translate into
+ * @returns {string} Translated string
+ */
+export const localise = (phrase, values = {}, locale = 'en') =>
+  i18n.__mf({ phrase, locale }, values)
 
 /**
  * kebab-case to camelCase

--- a/app/views/school/list.njk
+++ b/app/views/school/list.njk
@@ -65,6 +65,10 @@
           small: true,
           items: [
             {
+              value: "hasNoPlannedSessions",
+              text: __("school.search.hasNoPlannedSessions")
+            },
+            {
               value: "isClosed",
               text: __("school.search.isClosed")
             }
@@ -127,6 +131,7 @@
             status: {},
             phase: {},
             address: {},
+            plannedSessions: {},
             nextSessionDate: {}
           })
         }) }}

--- a/app/views/school/list.njk
+++ b/app/views/school/list.njk
@@ -46,14 +46,17 @@
         {{ checkboxes({
           fieldset: {
             legend: {
-              text: __("programme.label"),
+              text: __("school.unplannedProgrammes.label"),
               size: "s"
             }
           },
+          hint: {
+            text: __("school.unplannedProgrammes.hint")
+          },
           small: true,
-          items: programmeItems,
+          items: unplannedProgrammeItems,
           decorate: "programme_id"
-        }) if programmeItems }}
+        }) }}
 
         {{ checkboxes({
           fieldset: {
@@ -64,10 +67,6 @@
           },
           small: true,
           items: [
-            {
-              value: "hasNoPlannedSessions",
-              text: __("school.search.hasNoPlannedSessions")
-            },
             {
               value: "isClosed",
               text: __("school.search.isClosed")
@@ -131,8 +130,8 @@
             status: {},
             phase: {},
             address: {},
-            plannedSessions: {},
-            nextSessionDate: {}
+            nextSessionDate: {},
+            unplannedProgrammes: {}
           })
         }) }}
       {% endfor %}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -20,5 +20,6 @@ export interface PatientFilterQuery {
 export interface SchoolFilterQuery {
   option?: string | string[]
   phase?: string | string[]
+  programme_id?: string | string[]
   q?: string
 }


### PR DESCRIPTION
[Jira Issue - MAV-11837](https://nhsd-jira.digital.nhs.uk/browse/MAV-11837)

Adds a new ‘Schools missing programmes’ display option for schools list, and shows which programmes a school may be missing in the result card.

Additionally, it’s possible to further filter results on a per programme basis.

Need to have a think about what the right labelling is here, not sure ‘missing programmes’ is quite right.

<img width="2400" alt="Schools  list filtered by missing HPV programme." src="https://github.com/user-attachments/assets/60f933dd-b8cc-41f3-adb6-5e65e8d12bd0" />