### PR TITLE
Consistently use ‘status’ over ‘outcome’

### DIFF
--- a/app/controllers/activity.js
+++ b/app/controllers/activity.js
@@ -3,7 +3,7 @@ import {
   ArchiveRecordReason,
   AuditEventType,
   ReplyDecision,
-  ScreenOutcome
+  ScreenStatus
 } from '../enums.js'
 import { generateContact } from '../generators/contact.js'
 import {
@@ -327,7 +327,7 @@ export const activityController = {
         items: [
           auditEvent({
             name: activity.triage.decision({
-              outcome: ScreenOutcome.DelayVaccination
+              outcome: ScreenStatus.DelayVaccination
             }),
             note: 'A brief note about the triage decision.',
             createdBy_uid,

--- a/app/controllers/activity.js
+++ b/app/controllers/activity.js
@@ -327,7 +327,7 @@ export const activityController = {
         items: [
           auditEvent({
             name: activity.triage.decision({
-              outcome: ScreenStatus.DelayVaccination
+              status: ScreenStatus.DelayVaccination
             }),
             note: 'A brief note about the triage decision.',
             createdBy_uid,

--- a/app/controllers/patient-programme.js
+++ b/app/controllers/patient-programme.js
@@ -141,7 +141,7 @@ export const patientProgrammeController = {
     }
 
     patientProgramme.recordTriage({
-      outcome: triage.outcome,
+      status: triage.status,
       outcomeAt_: triage.outcomeAt_,
       note: triage.note,
       createdBy_uid: account.uid

--- a/app/controllers/patient-programme.js
+++ b/app/controllers/patient-programme.js
@@ -142,7 +142,7 @@ export const patientProgrammeController = {
 
     patientProgramme.recordTriage({
       status: triage.status,
-      outcomeAt_: triage.outcomeAt_,
+      statusInvalidAt_: triage.statusInvalidAt_,
       note: triage.note,
       createdBy_uid: account.uid
     })

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -5,7 +5,7 @@ import {
   InstructionOutcome,
   PatientStatus,
   PreScreenQuestion,
-  RegistrationOutcome,
+  RegistrationStatus,
   SessionType,
   UserRole,
   VaccinationOutcome,
@@ -233,7 +233,7 @@ export const patientSessionController = {
     )
 
     if (
-      register === RegistrationOutcome.Absent &&
+      register === RegistrationStatus.Absent &&
       patientSession.status !== PatientStatus.Consent
     ) {
       // Record vaccination outcome as absent if safe to vaccinate

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -2,7 +2,7 @@ import {
   AuditEventType,
   ConsentOutcome,
   ConsentWindow,
-  InstructionOutcome,
+  InstructionStatus,
   PatientStatus,
   PreScreenQuestion,
   RegistrationStatus,
@@ -65,7 +65,7 @@ export const patientSessionController = {
     // Nurses can record all vaccines
     // HCAs can only record nasal sprays for children with a PSD
     const userIsHCA = account.role === UserRole.HCA
-    const patientHasPsd = patientSession.instruct === InstructionOutcome.Given
+    const patientHasPsd = patientSession.instruct === InstructionStatus.Given
     if (userIsHCA && !patientHasPsd) {
       // Remove permissions for HCAs as patient doesn’t have a PSD
       account.vaccineMethods = []

--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -1,6 +1,6 @@
 import {
   AuditEventType,
-  ConsentOutcome,
+  ConsentStatus,
   ConsentWindow,
   InstructionStatus,
   PatientStatus,
@@ -90,7 +90,7 @@ export const patientSessionController = {
         !patient.hasNoContactDetails &&
         session.consentWindow === ConsentWindow.Open &&
         !session.isActive &&
-        consent === ConsentOutcome.NoResponse,
+        consent === ConsentStatus.NoResponse,
       // Perform Gillick assessment
       canGillick:
         session.isActive && !vaccinated && !consentGiven && !userIsHCA,

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -20,7 +20,7 @@ import { saveAndRedirect } from '../utils/redirect.js'
 import { countAnswersNeedingTriage } from '../utils/reply.js'
 import { formatContact } from '../utils/string.js'
 import {
-  getScreenOutcomesForConsentMethod,
+  getScreenStatusesForConsentMethod,
   getScreenVaccineCriteria
 } from '../utils/triage.js'
 
@@ -322,8 +322,8 @@ export const replyController = {
         )
       }
 
-      response.locals.screenOutcomesForConsentMethod =
-        getScreenOutcomesForConsentMethod(programme, [reply])
+      response.locals.screenStatusesForConsentMethod =
+        getScreenStatusesForConsentMethod(programme, [reply])
 
       response.locals.screenVaccineCriteria = getScreenVaccineCriteria(
         programme,

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -125,7 +125,7 @@ export const replyController = {
           delete reply.contact_uuid
         }
 
-        if (triage?.outcome) {
+        if (triage?.status) {
           patientSession.patientProgramme.recordTriage({
             ...triage,
             ...data?.wizard?.triage, // Wizard values

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -3,7 +3,7 @@ import _ from 'lodash'
 
 import {
   AcademicYear,
-  InstructionOutcome,
+  InstructionStatus,
   PatientStatus,
   ProgrammeType,
   RecordVaccineCriteria,
@@ -567,10 +567,10 @@ export const sessionController = {
     const radioFilters = {
       patients: {
         register: showRegistration && RegistrationStatus,
-        instruct: session.hasPsdProtocol && InstructionOutcome
+        instruct: session.hasPsdProtocol && InstructionStatus
       },
       instruct: {
-        instruct: InstructionOutcome
+        instruct: InstructionStatus
       }
     }
 
@@ -1045,7 +1045,7 @@ export const sessionController = {
 
     const patientsToInstruct = session.patientSessions
       .filter(({ status }) => status === PatientStatus.Due)
-      .filter(({ instruct }) => instruct === InstructionOutcome.Needed)
+      .filter(({ instruct }) => instruct === InstructionStatus.Needed)
 
     for (const patientSession of patientsToInstruct) {
       const instruction = Instruction.create(

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -446,7 +446,7 @@ export const sessionController = {
     }
 
     // Filter by sub-status(es)
-    for (const [programmeOutcome, status] of Object.entries({
+    for (const [programmeStatus, status] of Object.entries({
       [PatientStatus.Consent]: 'patientConsent',
       [PatientStatus.Deferred]: 'patientDeferred',
       [PatientStatus.Due]: 'vaccineCriteria',
@@ -454,7 +454,7 @@ export const sessionController = {
       [PatientStatus.Triage]: 'patientTriage',
       [PatientStatus.Vaccinated]: 'patientVaccinated'
     })) {
-      if (filters.status === programmeOutcome && filters[status] !== 'none') {
+      if (filters.status === programmeStatus && filters[status] !== 'none') {
         let statuses = filters[status]
         statuses = Array.isArray(statuses) ? statuses : [statuses]
         results = results.filter((patientSession) =>

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -7,7 +7,7 @@ import {
   PatientStatus,
   ProgrammeType,
   RecordVaccineCriteria,
-  RegistrationOutcome,
+  RegistrationStatus,
   SchoolPhase,
   SessionPresetName,
   SessionStatus,
@@ -506,7 +506,7 @@ export const sessionController = {
       results = results.filter(
         ({ register, status, vaccine }) =>
           status === PatientStatus.Due &&
-          register !== RegistrationOutcome.Pending &&
+          register !== RegistrationStatus.Pending &&
           account.vaccineMethods?.includes(vaccine?.method)
       )
     }
@@ -566,7 +566,7 @@ export const sessionController = {
 
     const radioFilters = {
       patients: {
-        register: showRegistration && RegistrationOutcome,
+        register: showRegistration && RegistrationStatus,
         instruct: session.hasPsdProtocol && InstructionOutcome
       },
       instruct: {

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -498,7 +498,7 @@ export const sessionController = {
       }
     }
 
-    // Remove patient sessions where outcome returns false
+    // Remove patient sessions where status returns false
     results = results.filter((patientSession) => patientSession[view] !== false)
 
     // Only show patients ready to vaccinate, and that a user can vaccinate

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -543,18 +543,19 @@ export const sessionController = {
     const programmeTypes = session.programmes.map((programme) => programme.type)
     if (programmeTypes.includes(ProgrammeType.Flu)) {
       vaccineCriteria = Object.values(RecordVaccineCriteria).filter(
-        (outcome) =>
+        (criteria) =>
           ![
             RecordVaccineCriteria.NoMMRPreference,
             RecordVaccineCriteria.AlternativeMMRInjectionOnly
-          ].includes(outcome)
+          ].includes(criteria)
       )
     } else if (programmeTypes.includes(ProgrammeType.MMR)) {
-      vaccineCriteria = Object.values(RecordVaccineCriteria).filter((outcome) =>
-        [
-          RecordVaccineCriteria.NoMMRPreference,
-          RecordVaccineCriteria.AlternativeMMRInjectionOnly
-        ].includes(outcome)
+      vaccineCriteria = Object.values(RecordVaccineCriteria).filter(
+        (criteria) =>
+          [
+            RecordVaccineCriteria.NoMMRPreference,
+            RecordVaccineCriteria.AlternativeMMRInjectionOnly
+          ].includes(criteria)
       )
     }
 

--- a/app/datasets/activity.js
+++ b/app/datasets/activity.js
@@ -1,4 +1,4 @@
-import { InstructionStatus, PatientStatus, ScreenOutcome } from '../enums.js'
+import { InstructionStatus, PatientStatus, ScreenStatus } from '../enums.js'
 import { lowerCaseFirst } from '../utils/string.js'
 
 export default {
@@ -110,7 +110,7 @@ export default {
   },
   triage: {
     decision: (triage) =>
-      triage.outcome === ScreenOutcome.NeedsTriage
+      triage.outcome === ScreenStatus.NeedsTriage
         ? 'Triage decision: keep in triage'
         : `Triage decision: ${lowerCaseFirst(triage.outcome)}`
   },

--- a/app/datasets/activity.js
+++ b/app/datasets/activity.js
@@ -1,4 +1,4 @@
-import { InstructionOutcome, PatientStatus, ScreenOutcome } from '../enums.js'
+import { InstructionStatus, PatientStatus, ScreenOutcome } from '../enums.js'
 import { lowerCaseFirst } from '../utils/string.js'
 
 export default {
@@ -98,7 +98,7 @@ export default {
     created: 'Completed pre-screening checks'
   },
   psd: {
-    added: InstructionOutcome.Given,
+    added: InstructionStatus.Given,
     invalidated: 'PSD invalidated'
   },
   session: {

--- a/app/datasets/activity.js
+++ b/app/datasets/activity.js
@@ -110,9 +110,9 @@ export default {
   },
   triage: {
     decision: (triage) =>
-      triage.outcome === ScreenStatus.NeedsTriage
+      triage.status === ScreenStatus.NeedsTriage
         ? 'Triage decision: keep in triage'
-        : `Triage decision: ${lowerCaseFirst(triage.outcome)}`
+        : `Triage decision: ${lowerCaseFirst(triage.status)}`
   },
   vaccination: {
     added: 'Vaccination record added manually',

--- a/app/enums.js
+++ b/app/enums.js
@@ -104,7 +104,7 @@ export const ClinicBookingJourneyType = {
  * @readonly
  * @enum {string}
  */
-export const ConsentOutcome = {
+export const ConsentStatus = {
   NotDelivered: 'Request failed',
   NoResponse: 'No response',
   Inconsistent: 'Conflicting consent',

--- a/app/enums.js
+++ b/app/enums.js
@@ -777,7 +777,7 @@ export const ScreenVaccineCriteria = {
  * @readonly
  * @enum {string}
  */
-export const ScreenOutcome = {
+export const ScreenStatus = {
   Vaccinate: 'Safe to vaccinate',
   VaccinateAlternativeFluInjectionOnly: 'Safe to vaccinate with injection',
   VaccinateAlternativeMMRInjectionOnly:

--- a/app/enums.js
+++ b/app/enums.js
@@ -678,7 +678,7 @@ export const RecordVaccineCriteria = {
  * @readonly
  * @enum {string}
  */
-export const RegistrationOutcome = {
+export const RegistrationStatus = {
   Pending: 'Not registered yet',
   Present: 'Attending session',
   Absent: 'Absent from session',

--- a/app/enums.js
+++ b/app/enums.js
@@ -303,7 +303,7 @@ export const Impairment = {
  * @readonly
  * @enum {string}
  */
-export const InstructionOutcome = {
+export const InstructionStatus = {
   Given: 'PSD added',
   Needed: 'PSD not added'
 }

--- a/app/globals.js
+++ b/app/globals.js
@@ -4,7 +4,7 @@ import { decorate } from 'nhsuk-decorated-components'
 import { healthQuestions } from './datasets/health-questions.js'
 import {
   AuditEventType,
-  InstructionOutcome,
+  InstructionStatus,
   PatientConsentStatus,
   PatientRefusedStatus
 } from './enums.js'
@@ -429,7 +429,7 @@ export default () => {
       instruct: {
         view: 'instruct',
         key: 'instruct',
-        value: InstructionOutcome.Needed,
+        value: InstructionStatus.Needed,
         ...(account.canPrescribe && { action: 'instructions' })
       },
       record: {

--- a/app/globals.js
+++ b/app/globals.js
@@ -217,7 +217,7 @@ export default () => {
       value === 'or'
         ? { divider: 'or' }
         : {
-            text: __(`triage.outcome.${value}`),
+            text: __(`triage.status.${value}`),
             value
           }
     )

--- a/app/globals.js
+++ b/app/globals.js
@@ -205,15 +205,15 @@ export default () => {
   }
 
   /**
-   * Get triage outcome form field items
+   * Get triage status form field items
    *
-   * @param {Array} outcomes - Screen outcomes
+   * @param {Array<string>} statuses - Screening statuses
    * @returns {object} Form field items
    */
-  globals.triageOutcomeItems = function (outcomes) {
+  globals.triageStatusItems = function (statuses) {
     const { __ } = this.ctx
 
-    return Object.values(outcomes).map((value) =>
+    return Object.values(statuses).map((value) =>
       value === 'or'
         ? { divider: 'or' }
         : {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2,7 +2,7 @@ import { healthQuestions } from '../datasets/health-questions.js'
 import {
   AcademicYear,
   DownloadType,
-  RegistrationOutcome,
+  RegistrationStatus,
   ReplyDecision,
   ReplyRefusal,
   ScreenOutcome,
@@ -2242,11 +2242,11 @@ export const en = {
         }
       },
       success: {
-        [RegistrationOutcome.Present]:
+        [RegistrationStatus.Present]:
           '{{patientSession.patient.fullName}} is attending today’s session.',
-        [RegistrationOutcome.Absent]:
+        [RegistrationStatus.Absent]:
           '{{patientSession.patient.fullName}} has been recorded as absent from today’s session.',
-        [RegistrationOutcome.Pending]:
+        [RegistrationStatus.Pending]:
           '{{patientSession.patient.fullName}} has not been registered yet.'
       }
     },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1635,7 +1635,7 @@ export const en = {
       label: 'Note',
       hint: 'Notes are visible to all users, and cannot be edited or deleted'
     },
-    outcome: {
+    status: {
       label: 'Outcome'
     }
   },
@@ -3417,7 +3417,7 @@ export const en = {
     note: {
       label: 'Triage notes'
     },
-    outcome: {
+    status: {
       label: 'Outcome',
       [ScreenStatus.Vaccinate]: 'Yes, it’s safe to vaccinate',
       [ScreenStatus.VaccinateAlternativeFluInjectionOnly]:

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -5,7 +5,7 @@ import {
   RegistrationStatus,
   ReplyDecision,
   ReplyRefusal,
-  ScreenOutcome,
+  ScreenStatus,
   SessionPresetName,
   UploadStatus
 } from '../enums.js'
@@ -3419,17 +3419,17 @@ export const en = {
     },
     outcome: {
       label: 'Outcome',
-      [ScreenOutcome.Vaccinate]: 'Yes, it’s safe to vaccinate',
-      [ScreenOutcome.VaccinateAlternativeFluInjectionOnly]:
+      [ScreenStatus.Vaccinate]: 'Yes, it’s safe to vaccinate',
+      [ScreenStatus.VaccinateAlternativeFluInjectionOnly]:
         'Yes, it’s safe to vaccinate with injected vaccine',
-      [ScreenOutcome.VaccinateAlternativeMMRInjectionOnly]:
+      [ScreenStatus.VaccinateAlternativeMMRInjectionOnly]:
         'Yes, it’s safe to vaccinate with gelatine-free vaccine',
-      [ScreenOutcome.VaccinateIntranasalOnly]:
+      [ScreenStatus.VaccinateIntranasalOnly]:
         'Yes, it’s safe to vaccinate with nasal spray',
-      [ScreenOutcome.DoNotVaccinate]: 'No, do not vaccinate',
-      [ScreenOutcome.InvitedToClinic]: 'No, invite to clinic',
-      [ScreenOutcome.DelayVaccination]: 'No, delay vaccination',
-      [ScreenOutcome.NeedsTriage]: 'No, keep in triage'
+      [ScreenStatus.DoNotVaccinate]: 'No, do not vaccinate',
+      [ScreenStatus.InvitedToClinic]: 'No, invite to clinic',
+      [ScreenStatus.DelayVaccination]: 'No, delay vaccination',
+      [ScreenStatus.NeedsTriage]: 'No, keep in triage'
     },
     psd: {
       label: 'Do you want to add a PSD?'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -3408,7 +3408,7 @@ export const en = {
       title: 'Update triage outcome',
       success: 'Triage outcome updated'
     },
-    outcomeAt: {
+    statusInvalidAt: {
       label: 'Delayed until',
       title:
         'What is the earliest date {{patient.firstName}} can be vaccinated?',

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -33,8 +33,8 @@ import { BaseModel } from './base.js'
  * @property {string} [messageTemplate] - Message template
  * @property {Array} [updatedFields] - Updated fields
  * @property {string} [status] - Status for activity type
- * @property {Date} [outcomeAt] - Date status invalidates
- * @property {object} [outcomeAt_] - Date status invalidates (from `dateInput`)
+ * @property {Date} [statusInvalidAt] - Date status invalidates
+ * @property {object} [statusInvalidAt_] - Date status invalidates (from `dateInput`)
  * @property {Array<string>} [programme_ids] - Programme IDs
  */
 
@@ -83,8 +83,9 @@ export class AuditEvent extends BaseModel {
     this.messageTemplate = options?.messageTemplate
     this.updatedFields = options?.updatedFields
     this.status = options?.status
-    this.outcomeAt = options?.outcomeAt && new Date(options.outcomeAt)
-    this.outcomeAt_ = options?.outcomeAt_
+    this.statusInvalidAt =
+      options?.statusInvalidAt && new Date(options.statusInvalidAt)
+    this.statusInvalidAt_ = options?.statusInvalidAt_
     this.programme_ids = stringToArray(options?.programme_ids)
   }
 
@@ -106,8 +107,8 @@ export class AuditEvent extends BaseModel {
    *
    * @returns {object|string} `dateInput` object
    */
-  get outcomeAt_() {
-    return convertIsoDateToObject(this.outcomeAt)
+  get statusInvalidAt_() {
+    return convertIsoDateToObject(this.statusInvalidAt)
   }
 
   /**
@@ -115,9 +116,9 @@ export class AuditEvent extends BaseModel {
    *
    * @param {object} object - dateInput object
    */
-  set outcomeAt_(object) {
+  set statusInvalidAt_(object) {
     if (object) {
-      this.outcomeAt = convertObjectToIsoDate(object)
+      this.statusInvalidAt = convertObjectToIsoDate(object)
     }
   }
 
@@ -201,10 +202,10 @@ export class AuditEvent extends BaseModel {
               return (
                 this.status && formatTag(getScreenStatusProperties(this.status))
               )
-            case 'outcomeAt':
+            case 'statusInvalidAt':
               return (
-                this.outcomeAt &&
-                formatDate(this.outcomeAt, { dateStyle: 'long' })
+                this.statusInvalidAt &&
+                formatDate(this.statusInvalidAt, { dateStyle: 'long' })
               )
             case 'programmes':
               return this.programmes.flatMap(({ nameTag }) => nameTag).join(' ')

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -14,7 +14,7 @@ import {
   formatDate,
   today
 } from '../utils/date.js'
-import { getScreenOutcomeProperties } from '../utils/enum-properties.js'
+import { getScreenStatusProperties } from '../utils/enum-properties.js'
 import {
   formatTag,
   formatMarkdown,
@@ -200,7 +200,7 @@ export class AuditEvent extends BaseModel {
             case 'outcome':
               return (
                 this.outcome &&
-                formatTag(getScreenOutcomeProperties(this.outcome))
+                formatTag(getScreenStatusProperties(this.outcome))
               )
             case 'outcomeAt':
               return (

--- a/app/models/audit-event.js
+++ b/app/models/audit-event.js
@@ -32,9 +32,9 @@ import { BaseModel } from './base.js'
  * @property {object} [messageRecipient] - Message recipient
  * @property {string} [messageTemplate] - Message template
  * @property {Array} [updatedFields] - Updated fields
- * @property {string} [outcome] - Outcome for activity type
- * @property {Date} [outcomeAt] - Date outcome invalidates
- * @property {object} [outcomeAt_] - Date outcome invalidates (from `dateInput`)
+ * @property {string} [status] - Status for activity type
+ * @property {Date} [outcomeAt] - Date status invalidates
+ * @property {object} [outcomeAt_] - Date status invalidates (from `dateInput`)
  * @property {Array<string>} [programme_ids] - Programme IDs
  */
 
@@ -82,7 +82,7 @@ export class AuditEvent extends BaseModel {
     this.messageRecipient = options?.messageRecipient
     this.messageTemplate = options?.messageTemplate
     this.updatedFields = options?.updatedFields
-    this.outcome = options?.outcome
+    this.status = options?.status
     this.outcomeAt = options?.outcomeAt && new Date(options.outcomeAt)
     this.outcomeAt_ = options?.outcomeAt_
     this.programme_ids = stringToArray(options?.programme_ids)
@@ -102,7 +102,7 @@ export class AuditEvent extends BaseModel {
   }
 
   /**
-   * Get date outcome invalidates for `dateInput`
+   * Get date status invalidates for `dateInput`
    *
    * @returns {object|string} `dateInput` object
    */
@@ -111,7 +111,7 @@ export class AuditEvent extends BaseModel {
   }
 
   /**
-   * Set date outcome invalidates from `dateInput`
+   * Set date status invalidates from `dateInput`
    *
    * @param {object} object - dateInput object
    */
@@ -197,10 +197,9 @@ export class AuditEvent extends BaseModel {
               })
             case 'note':
               return this.note && formatMarkdown(this.note)
-            case 'outcome':
+            case 'status':
               return (
-                this.outcome &&
-                formatTag(getScreenStatusProperties(this.outcome))
+                this.status && formatTag(getScreenStatusProperties(this.status))
               )
             case 'outcomeAt':
               return (

--- a/app/models/clinic-appointment.js
+++ b/app/models/clinic-appointment.js
@@ -10,7 +10,7 @@ import {
   Impairment,
   ParentalRelationship,
   ProgrammeType,
-  RegistrationOutcome,
+  RegistrationStatus,
   ReplyDecision,
   SessionStatus,
   VaccineCriteria,
@@ -424,7 +424,7 @@ export class ClinicAppointment {
   /**
    * Get the registration status for this appointment's child i.e. have they turned up?
    *
-   * @returns {RegistrationOutcome|undefined} the registration status if a matched child, or undefined if not yet matched
+   * @returns {RegistrationStatus|undefined} the registration status if a matched child, or undefined if not yet matched
    */
   get register() {
     // Return undefined if not yet matched as registration is tied to a patient record

--- a/app/models/gillick.js
+++ b/app/models/gillick.js
@@ -34,9 +34,9 @@ export class Gillick extends BaseModel {
   }
 
   /**
-   * Get Gillick competency outcome
+   * Get Gillick competency
    *
-   * @returns {object|undefined} Gillick competency outcome
+   * @returns {object|undefined} Gillick competency
    */
   get competent() {
     const questions = [this.q1, this.q2, this.q3, this.q4, this.q5]

--- a/app/models/instruction.js
+++ b/app/models/instruction.js
@@ -7,7 +7,7 @@ import { BaseModel } from './base.js'
 /**
  * @typedef {BaseModelOptions & object} InstructionOptions
  * @property {string} [uuid] - Instruction UUID
- * @property {InstructionOutcome} [outcome] - Outcome
+ * @property {InstructionStatus} [status] - Status
  */
 
 /**
@@ -46,6 +46,6 @@ Instruction.relate('patient_uuid', () => Patient, 'patient')
 Instruction.relate('programme_id', () => Programme, 'programme')
 
 /**
- * @import { InstructionOutcome } from '../enums.js'
+ * @import { InstructionStatus } from '../enums.js'
  * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -258,7 +258,7 @@ export class PatientProgramme extends BaseModel {
             return false
           case PatientDeferredStatus.DelayVaccination: {
             const firstSafeDate =
-              this.lastPatientSession?.triageNotes?.at(-1)?.outcomeAt
+              this.lastPatientSession?.triageNotes?.at(-1)?.statusInvalidAt
             return firstSafeDate === undefined || today() > firstSafeDate
           }
           default:
@@ -842,7 +842,7 @@ export class PatientProgramme extends BaseModel {
       note: event.note,
       type: AuditEventType.ProgrammeNote,
       status: event.status,
-      outcomeAt_: event.outcomeAt_,
+      statusInvalidAt_: event.statusInvalidAt_,
       createdAt: event.createdAt,
       createdBy_uid: event.createdBy_uid,
       programme_ids: [this.programme_id]

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -31,7 +31,7 @@ import {
   today
 } from '../utils/date.js'
 import {
-  getConsentOutcomeProperties,
+  getConsentStatusProperties,
   getPatientClinicStatusProperties,
   getPatientStatusProperties
 } from '../utils/enum-properties.js'
@@ -736,9 +736,9 @@ export class PatientProgramme extends BaseModel {
   }
 
   /**
-   * Get consent outcome
+   * Get consent status
    *
-   * @returns {ConsentOutcome|PatientStatus} Consent outcome
+   * @returns {ConsentStatus|PatientStatus} Consent status
    */
   get consent() {
     return this.lastPatientSession?.consent
@@ -778,7 +778,7 @@ export class PatientProgramme extends BaseModel {
               return this.consent
                 ? formatProgrammeStatus(
                     this.programme,
-                    getConsentOutcomeProperties(this.consent)
+                    getConsentStatusProperties(this.consent)
                   )
                 : formatProgrammeStatus(
                     this.programme,
@@ -883,7 +883,7 @@ PatientProgramme.relate('patient_uuid', () => Patient, 'patient')
 PatientProgramme.relate('programme_id', () => Programme, 'programme')
 
 /**
- * @import { ConsentOutcome, RecordVaccineCriteria } from '../enums.js'
+ * @import { ConsentStatus, RecordVaccineCriteria } from '../enums.js'
  * @import { PatientSession } from '../models.js'
  * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -241,7 +241,7 @@ export class PatientProgramme extends BaseModel {
   }
 
   /**
-   * Can the child be vaccinated (assuming we get the right consent and triage outcomes, if required)?
+   * Can the child be vaccinated (assuming we get the right consent and triage statuses, if required)?
    *
    * @returns {boolean} OK to invite to clinic for a vaccination based on patient status (`true`), or otherwise (`false`)
    */
@@ -841,7 +841,7 @@ export class PatientProgramme extends BaseModel {
       name: activity.triage.decision(event),
       note: event.note,
       type: AuditEventType.ProgrammeNote,
-      outcome: event.outcome,
+      status: event.status,
       outcomeAt_: event.outcomeAt_,
       createdAt: event.createdAt,
       createdBy_uid: event.createdBy_uid,
@@ -849,7 +849,7 @@ export class PatientProgramme extends BaseModel {
     })
 
     let messageTemplate
-    switch (event.outcome) {
+    switch (event.status) {
       case ScreenStatus.DelayVaccination:
         messageTemplate = 'triage-delay-vaccination'
         break

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -11,7 +11,7 @@ import {
   PatientRefusedStatus,
   PatientStatus,
   ProgrammeType,
-  ScreenOutcome,
+  ScreenStatus,
   SessionStatus,
   SessionType
 } from '../enums.js'
@@ -850,13 +850,13 @@ export class PatientProgramme extends BaseModel {
 
     let messageTemplate
     switch (event.outcome) {
-      case ScreenOutcome.DelayVaccination:
+      case ScreenStatus.DelayVaccination:
         messageTemplate = 'triage-delay-vaccination'
         break
-      case ScreenOutcome.DoNotVaccinate:
+      case ScreenStatus.DoNotVaccinate:
         messageTemplate = 'triage-do-not-vaccinate'
         break
-      case ScreenOutcome.InvitedToClinic:
+      case ScreenStatus.InvitedToClinic:
         messageTemplate = 'triage-invite-to-clinic'
         break
       default:

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -189,7 +189,7 @@ export class PatientSession extends BaseModel {
     return this.auditEvents
       .filter(({ type }) => type === AuditEventType.ProgrammeNote)
       .filter(({ programme_ids }) => programme_ids.includes(this.programme_id))
-      .filter(({ outcome }) => outcome)
+      .filter(({ status }) => status)
   }
 
   /**

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -8,20 +8,20 @@ import {
   ClinicAttendanceType,
   ConsentStatus,
   PatientStatus,
+  PatientClinicStatus,
   PatientConsentStatus,
   PatientDeferredStatus,
   PatientRefusedStatus,
+  PatientTriageStatus,
   PatientVaccinatedStatus,
+  ProgrammeType,
   RecordVaccineCriteria,
   ReplyDecision,
   ReplyRefusal,
   RegistrationStatus,
-  ScreenOutcome,
-  VaccinationOutcome,
-  ProgrammeType,
-  PatientClinicStatus,
+  ScreenStatus,
   SessionType,
-  PatientTriageStatus
+  VaccinationOutcome
 } from '../enums.js'
 import {
   AuditEvent,
@@ -41,7 +41,7 @@ import {
   getConsentStatusProperties,
   getInstructionStatusProperties,
   getRegistrationStatusProperties,
-  getScreenOutcomeProperties,
+  getScreenStatusProperties,
   getVaccinationOutcomeProperties
 } from '../utils/enum-properties.js'
 import {
@@ -57,7 +57,7 @@ import {
   getPatientVaccinatedStatus,
   getRegistrationStatus,
   getRegistrationStatusDescription,
-  getScreenOutcomeDescription,
+  getScreenStatusDescription,
   getVaccinationOutcome
 } from '../utils/patient-session.js'
 import {
@@ -74,8 +74,8 @@ import {
   formatYearGroup
 } from '../utils/string.js'
 import {
-  getScreenOutcome,
-  getScreenOutcomesForConsentMethod,
+  getScreenStatus,
+  getScreenStatusesForConsentMethod,
   getScreenVaccineCriteria
 } from '../utils/triage.js'
 
@@ -280,13 +280,13 @@ export class PatientSession extends BaseModel {
   }
 
   /**
-   * Get screen outcomes for vaccination method(s) consented to
+   * Get screen statuses for vaccination method(s) consented to
    *
-   * @returns {Array<ScreenOutcome>|undefined} Screen outcomes
+   * @returns {Array<ScreenStatus>|undefined} Screen statuses
    */
-  get screenOutcomesForConsentMethod() {
+  get screenStatusesForConsentMethod() {
     if (this.programme && this.responses) {
-      return getScreenOutcomesForConsentMethod(this.programme, this.responses)
+      return getScreenStatusesForConsentMethod(this.programme, this.responses)
     }
   }
 
@@ -393,12 +393,12 @@ export class PatientSession extends BaseModel {
       return alternativeVaccine
     }
 
-    // Return vaccine based on consent (and triage) outcomes
+    // Return vaccine based on consent (and triage) statuses
     const hasScreenedForInjection =
       this.screen &&
       [
-        ScreenOutcome.VaccinateAlternativeFluInjectionOnly,
-        ScreenOutcome.VaccinateAlternativeMMRInjectionOnly
+        ScreenStatus.VaccinateAlternativeFluInjectionOnly,
+        ScreenStatus.VaccinateAlternativeMMRInjectionOnly
       ].includes(String(this.screen))
 
     return this.hasConsentForAlternativeInjectionOnly || hasScreenedForInjection
@@ -428,14 +428,14 @@ export class PatientSession extends BaseModel {
     if (this.programme.type === ProgrammeType.Flu) {
       if (
         this.consent === ConsentStatus.GivenForIntranasal ||
-        this.screen === ScreenOutcome.VaccinateIntranasalOnly
+        this.screen === ScreenStatus.VaccinateIntranasalOnly
       ) {
         return RecordVaccineCriteria.IntranasalOnly
       }
 
       if (
         this.consent === ConsentStatus.GivenForAlternativeInjection ||
-        this.screen === ScreenOutcome.VaccinateAlternativeFluInjectionOnly
+        this.screen === ScreenStatus.VaccinateAlternativeFluInjectionOnly
       ) {
         return RecordVaccineCriteria.AlternativeFluInjectionOnly
       }
@@ -446,7 +446,7 @@ export class PatientSession extends BaseModel {
     if (this.programme.type === ProgrammeType.MMR) {
       if (
         this.consent === ConsentStatus.GivenForAlternativeInjection ||
-        this.screen === ScreenOutcome.VaccinateAlternativeMMRInjectionOnly
+        this.screen === ScreenStatus.VaccinateAlternativeMMRInjectionOnly
       ) {
         return RecordVaccineCriteria.AlternativeMMRInjectionOnly
       }
@@ -462,7 +462,7 @@ export class PatientSession extends BaseModel {
    */
   get canRecordAlternativeVaccine() {
     const hasScreenedForNasal =
-      this.screen === ScreenOutcome.VaccinateIntranasalOnly
+      this.screen === ScreenStatus.VaccinateIntranasalOnly
 
     return (
       this.hasConsentForInjection &&
@@ -632,21 +632,21 @@ export class PatientSession extends BaseModel {
   }
 
   /**
-   * Get screening outcome
+   * Get screening status
    *
-   * @returns {ScreenOutcome|boolean} Screening outcome
+   * @returns {ScreenStatus|boolean} Screening status
    */
   get screen() {
-    return getScreenOutcome(this)
+    return getScreenStatus(this)
   }
 
   /**
-   * Get expanded description about screening outcome
+   * Get expanded description about screening status
    *
    * @returns {string} Screen description
    */
   get screenDescription() {
-    return getScreenOutcomeDescription(this)
+    return getScreenStatusDescription(this)
   }
 
   /**
@@ -747,7 +747,7 @@ export class PatientSession extends BaseModel {
             case 'consent':
               return getConsentStatusProperties(this.consent)
             case 'screen':
-              return getScreenOutcomeProperties(this.screen)
+              return getScreenStatusProperties(this.screen)
             case 'instruct':
               return getInstructionStatusProperties(this.instruct)
             case 'register':

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -39,7 +39,7 @@ import {
 } from '../utils/date.js'
 import {
   getConsentOutcomeProperties,
-  getInstructionOutcomeProperties,
+  getInstructionStatusProperties,
   getRegistrationStatusProperties,
   getScreenOutcomeProperties,
   getVaccinationOutcomeProperties
@@ -47,7 +47,7 @@ import {
 import {
   canRecordOutcome,
   getConsentOutcomeDescription,
-  getInstructionOutcome,
+  getInstructionStatus,
   getPatientConsentStatus,
   getPatientDeferredDescription,
   getPatientDeferredStatus,
@@ -659,12 +659,12 @@ export class PatientSession extends BaseModel {
   }
 
   /**
-   * Get instruction outcome
+   * Get instruction status
    *
-   * @returns {InstructionOutcome|boolean} Instruction outcome
+   * @returns {InstructionStatus|boolean} Instruction status
    */
   get instruct() {
-    return getInstructionOutcome(this)
+    return getInstructionStatus(this)
   }
 
   /**
@@ -749,7 +749,7 @@ export class PatientSession extends BaseModel {
             case 'screen':
               return getScreenOutcomeProperties(this.screen)
             case 'instruct':
-              return getInstructionOutcomeProperties(this.instruct)
+              return getInstructionStatusProperties(this.instruct)
             case 'register':
               return getRegistrationStatusProperties(this.register)
             case 'outcome':
@@ -950,7 +950,7 @@ PatientSession.relate('programme_id', () => Programme, 'programme')
 PatientSession.relate('session_id', () => Session, 'session')
 
 /**
- * @import { InstructionOutcome, ScreenVaccineCriteria } from '../enums.js'
+ * @import { InstructionStatus, ScreenVaccineCriteria } from '../enums.js'
  * @import { Contact, PatientProgramme, Reply, Vaccination, Vaccine } from '../models.js'
  * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -15,7 +15,7 @@ import {
   RecordVaccineCriteria,
   ReplyDecision,
   ReplyRefusal,
-  RegistrationOutcome,
+  RegistrationStatus,
   ScreenOutcome,
   VaccinationOutcome,
   ProgrammeType,
@@ -40,7 +40,7 @@ import {
 import {
   getConsentOutcomeProperties,
   getInstructionOutcomeProperties,
-  getRegistrationOutcomeProperties,
+  getRegistrationStatusProperties,
   getScreenOutcomeProperties,
   getVaccinationOutcomeProperties
 } from '../utils/enum-properties.js'
@@ -55,8 +55,8 @@ import {
   getPatientStatusDescription,
   getPatientTriageStatus,
   getPatientVaccinatedStatus,
-  getRegistrationOutcome,
-  getRegistrationOutcomeDescription,
+  getRegistrationStatus,
+  getRegistrationStatusDescription,
   getScreenOutcomeDescription,
   getVaccinationOutcome
 } from '../utils/patient-session.js'
@@ -668,21 +668,21 @@ export class PatientSession extends BaseModel {
   }
 
   /**
-   * Get registration outcome
+   * Get registration status
    *
-   * @returns {RegistrationOutcome} Registration outcome
+   * @returns {RegistrationStatus} Registration status
    */
   get register() {
-    return getRegistrationOutcome(this)
+    return getRegistrationStatus(this)
   }
 
   /**
-   * Get expanded description about registration outcome
+   * Get expanded description about registration status
    *
    * @returns {string} Registration description
    */
   get registerDescription() {
-    return getRegistrationOutcomeDescription(this)
+    return getRegistrationStatusDescription(this)
   }
 
   /**
@@ -751,7 +751,7 @@ export class PatientSession extends BaseModel {
             case 'instruct':
               return getInstructionOutcomeProperties(this.instruct)
             case 'register':
-              return getRegistrationOutcomeProperties(this.register)
+              return getRegistrationStatusProperties(this.register)
             case 'outcome':
               return getVaccinationOutcomeProperties(this.outcome)
             case 'status':
@@ -878,14 +878,14 @@ export class PatientSession extends BaseModel {
    * Register attendance
    *
    * @param {Partial<AuditEvent>} event - Event
-   * @param {RegistrationOutcome} register - Registration
+   * @param {RegistrationStatus} register - Registration
    */
   registerAttendance(event, register) {
     this.session?.updateRegister(this.patient?.uuid, register)
 
     this.patient?.addEvent({
       name:
-        register === RegistrationOutcome.Present
+        register === RegistrationStatus.Present
           ? activity.attendance.present(this.session)
           : activity.attendance.absent(this.session),
       createdAt: event.createdAt,

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -6,7 +6,7 @@ import {
   AcademicYear,
   AuditEventType,
   ClinicAttendanceType,
-  ConsentOutcome,
+  ConsentStatus,
   PatientStatus,
   PatientConsentStatus,
   PatientDeferredStatus,
@@ -38,7 +38,7 @@ import {
   getYearGroup
 } from '../utils/date.js'
 import {
-  getConsentOutcomeProperties,
+  getConsentStatusProperties,
   getInstructionStatusProperties,
   getRegistrationStatusProperties,
   getScreenOutcomeProperties,
@@ -46,7 +46,7 @@ import {
 } from '../utils/enum-properties.js'
 import {
   canRecordOutcome,
-  getConsentOutcomeDescription,
+  getConsentStatusDescription,
   getInstructionStatus,
   getPatientConsentStatus,
   getPatientDeferredDescription,
@@ -62,7 +62,7 @@ import {
 } from '../utils/patient-session.js'
 import {
   countAnswersNeedingTriage,
-  getConsentOutcome,
+  getConsentStatus,
   getConsentHealthAnswers,
   getConsentRefusalReasons
 } from '../utils/reply.js'
@@ -427,14 +427,14 @@ export class PatientSession extends BaseModel {
 
     if (this.programme.type === ProgrammeType.Flu) {
       if (
-        this.consent === ConsentOutcome.GivenForIntranasal ||
+        this.consent === ConsentStatus.GivenForIntranasal ||
         this.screen === ScreenOutcome.VaccinateIntranasalOnly
       ) {
         return RecordVaccineCriteria.IntranasalOnly
       }
 
       if (
-        this.consent === ConsentOutcome.GivenForAlternativeInjection ||
+        this.consent === ConsentStatus.GivenForAlternativeInjection ||
         this.screen === ScreenOutcome.VaccinateAlternativeFluInjectionOnly
       ) {
         return RecordVaccineCriteria.AlternativeFluInjectionOnly
@@ -445,7 +445,7 @@ export class PatientSession extends BaseModel {
 
     if (this.programme.type === ProgrammeType.MMR) {
       if (
-        this.consent === ConsentOutcome.GivenForAlternativeInjection ||
+        this.consent === ConsentStatus.GivenForAlternativeInjection ||
         this.screen === ScreenOutcome.VaccinateAlternativeMMRInjectionOnly
       ) {
         return RecordVaccineCriteria.AlternativeMMRInjectionOnly
@@ -564,21 +564,21 @@ export class PatientSession extends BaseModel {
   }
 
   /**
-   * Get consent outcome
+   * Get consent status
    *
-   * @returns {ConsentOutcome} Consent outcome
+   * @returns {ConsentStatus} Consent status
    */
   get consent() {
-    return getConsentOutcome(this)
+    return getConsentStatus(this)
   }
 
   /**
-   * Get expanded description about consent outcome
+   * Get expanded description about consent status
    *
    * @returns {string} Consent description
    */
   get consentDescription() {
-    return getConsentOutcomeDescription(this)
+    return getConsentStatusDescription(this)
   }
 
   /**
@@ -589,9 +589,9 @@ export class PatientSession extends BaseModel {
   get consentGiven() {
     if (this.consent && !this.clinicAppointment) {
       return [
-        ConsentOutcome.Given,
-        ConsentOutcome.GivenForAlternativeInjection,
-        ConsentOutcome.GivenForIntranasal
+        ConsentStatus.Given,
+        ConsentStatus.GivenForAlternativeInjection,
+        ConsentStatus.GivenForIntranasal
       ].includes(this.consent)
     } else if (this.clinicAppointment) {
       return true
@@ -745,7 +745,7 @@ export class PatientSession extends BaseModel {
         get: (_target, prop) => {
           switch (prop) {
             case 'consent':
-              return getConsentOutcomeProperties(this.consent)
+              return getConsentStatusProperties(this.consent)
             case 'screen':
               return getScreenOutcomeProperties(this.screen)
             case 'instruct':

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -3,7 +3,7 @@ import { addMonths } from 'date-fns'
 
 import vaccines from '../datasets/vaccines.js'
 import {
-  ConsentOutcome,
+  ConsentStatus,
   ConsentVaccineCriteria,
   NotifyEmailStatus,
   NotifySmsStatus,
@@ -24,7 +24,7 @@ import {
 } from '../models.js'
 import { formatDate } from '../utils/date.js'
 import {
-  getConsentOutcomeProperties,
+  getConsentStatusProperties,
   getReplyDecisionProperties
 } from '../utils/enum-properties.js'
 import {
@@ -409,7 +409,7 @@ export class Reply extends BaseModel {
             )
             if (!this.delivered) {
               decisionStatus = formatTag(
-                getConsentOutcomeProperties(ConsentOutcome.NotDelivered)
+                getConsentStatusProperties(ConsentStatus.NotDelivered)
               )
             } else if (this.isInvalidated) {
               decisionStatus = formatWithSecondaryText(

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -5,7 +5,7 @@ import _ from 'lodash'
 
 import programmesData from '../datasets/programmes.js'
 import {
-  ConsentOutcome,
+  ConsentStatus,
   ConsentWindow,
   InstructionStatus,
   PatientStatus,
@@ -939,7 +939,7 @@ export class Session extends BaseModel {
             case 'getConsent':
               return getSessionActivityCount(this, [
                 {
-                  consent: ConsentOutcome.NoResponse
+                  consent: ConsentStatus.NoResponse
                 }
               ])
             case 'instruct':

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -1183,7 +1183,7 @@ export class Session extends BaseModel {
    * Update register
    *
    * @param {string} patient_uuid
-   * @param {RegistrationOutcome} registration
+   * @param {RegistrationStatus} registration
    */
   updateRegister(patient_uuid, registration) {
     this.register[patient_uuid] = registration
@@ -1194,6 +1194,6 @@ Session.relate('clinic_id', () => Clinic, 'clinic')
 Session.relate('school_id', () => School, 'school')
 
 /**
- * @import { RegistrationOutcome, SessionMMRConsent, SessionPreset } from '../enums.js'
+ * @import { RegistrationStatus, SessionMMRConsent, SessionPreset } from '../enums.js'
  * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -7,7 +7,7 @@ import programmesData from '../datasets/programmes.js'
 import {
   ConsentOutcome,
   ConsentWindow,
-  InstructionOutcome,
+  InstructionStatus,
   PatientStatus,
   ProgrammeType,
   RecordVaccineCriteria,
@@ -946,7 +946,7 @@ export class Session extends BaseModel {
               return getSessionActivityCount(this, [
                 {
                   status: PatientStatus.Due,
-                  instruct: InstructionOutcome.Needed
+                  instruct: InstructionStatus.Needed
                 }
               ])
             default:

--- a/app/utils/enum-properties.js
+++ b/app/utils/enum-properties.js
@@ -4,7 +4,7 @@ import {
   InstructionOutcome,
   PatientClinicStatus,
   PatientStatus,
-  RegistrationOutcome,
+  RegistrationStatus,
   ReplyDecision,
   SchoolStatus,
   ScreenOutcome,
@@ -45,10 +45,10 @@ const PATIENT_STATUS_COLOURS = {
   [PatientStatus.Due]: 'green'
 }
 
-const REGISTRATION_OUTCOME_COLOURS = {
-  [RegistrationOutcome.Present]: 'green',
-  [RegistrationOutcome.Absent]: 'red',
-  [RegistrationOutcome.Complete]: 'white'
+const REGISTRATION_STATUS_COLOURS = {
+  [RegistrationStatus.Present]: 'green',
+  [RegistrationStatus.Absent]: 'red',
+  [RegistrationStatus.Complete]: 'white'
 }
 
 const REPLY_DECISION_COLOURS = {
@@ -163,15 +163,15 @@ export function getPatientStatusProperties(status, vaccinationDue) {
 }
 
 /**
- * Get registration outcome status properties
+ * Get registration status properties
  *
- * @param {RegistrationOutcome} outcome - Registration outcome
- * @returns {object} Outcome properties
+ * @param {RegistrationStatus} status - Registration status
+ * @returns {object} Status properties
  */
-export function getRegistrationOutcomeProperties(outcome) {
+export function getRegistrationStatusProperties(status) {
   return {
-    colour: REGISTRATION_OUTCOME_COLOURS[outcome] ?? 'grey',
-    text: outcome
+    colour: REGISTRATION_STATUS_COLOURS[status] ?? 'grey',
+    text: status
   }
 }
 

--- a/app/utils/enum-properties.js
+++ b/app/utils/enum-properties.js
@@ -1,5 +1,5 @@
 import {
-  ConsentOutcome,
+  ConsentStatus,
   DownloadStatus,
   InstructionStatus,
   PatientClinicStatus,
@@ -13,16 +13,16 @@ import {
   VaccinationSyncStatus
 } from '../enums.js'
 
-const CONSENT_OUTCOME_COLOURS = {
-  [ConsentOutcome.NoResponse]: 'grey',
-  [ConsentOutcome.NotDelivered]: 'orange',
-  [ConsentOutcome.Inconsistent]: 'orange',
-  [ConsentOutcome.Given]: 'green',
-  [ConsentOutcome.GivenForAlternativeInjection]: 'green',
-  [ConsentOutcome.GivenForIntranasal]: 'green',
-  [ConsentOutcome.Declined]: 'yellow',
-  [ConsentOutcome.Refused]: 'red',
-  [ConsentOutcome.FinalRefusal]: 'red'
+const CONSENT_STATUS_COLOURS = {
+  [ConsentStatus.NoResponse]: 'grey',
+  [ConsentStatus.NotDelivered]: 'orange',
+  [ConsentStatus.Inconsistent]: 'orange',
+  [ConsentStatus.Given]: 'green',
+  [ConsentStatus.GivenForAlternativeInjection]: 'green',
+  [ConsentStatus.GivenForIntranasal]: 'green',
+  [ConsentStatus.Declined]: 'yellow',
+  [ConsentStatus.Refused]: 'red',
+  [ConsentStatus.FinalRefusal]: 'red'
 }
 
 const DOWNLOAD_STATUS_COLOURS = {
@@ -112,13 +112,13 @@ export function getPatientClinicStatusProperties(status) {
 }
 
 /**
- * Get consent outcome properties
+ * Get consent status properties
  *
- * @param {ConsentOutcome} outcome - Consent outcome
- * @returns {object} Outcome properties
+ * @param {ConsentStatus} status - Consent status
+ * @returns {object} Status properties
  */
-export function getConsentOutcomeProperties(outcome) {
-  return { colour: CONSENT_OUTCOME_COLOURS[outcome], text: outcome }
+export function getConsentStatusProperties(status) {
+  return { colour: CONSENT_STATUS_COLOURS[status], text: status }
 }
 
 /**

--- a/app/utils/enum-properties.js
+++ b/app/utils/enum-properties.js
@@ -7,7 +7,7 @@ import {
   RegistrationStatus,
   ReplyDecision,
   SchoolStatus,
-  ScreenOutcome,
+  ScreenStatus,
   UploadStatus,
   VaccinationOutcome,
   VaccinationSyncStatus
@@ -66,11 +66,11 @@ const SCHOOL_STATUS_COLOURS = {
   [SchoolStatus.Closed]: 'grey'
 }
 
-const SCREEN_OUTCOME_COLOURS = {
-  [ScreenOutcome.NeedsTriage]: 'blue',
-  [ScreenOutcome.InvitedToClinic]: 'orange',
-  [ScreenOutcome.DelayVaccination]: 'orange',
-  [ScreenOutcome.DoNotVaccinate]: 'red'
+const SCREEN_STATUS_COLOURS = {
+  [ScreenStatus.NeedsTriage]: 'blue',
+  [ScreenStatus.InvitedToClinic]: 'orange',
+  [ScreenStatus.DelayVaccination]: 'orange',
+  [ScreenStatus.DoNotVaccinate]: 'red'
 }
 
 const UPLOAD_STATUS_COLOURS = {
@@ -205,17 +205,17 @@ export function getSchoolStatusProperties(status) {
 }
 
 /**
- * Get screen outcome status properties
+ * Get screen status properties
  *
- * @param {ScreenOutcome|boolean} outcome - Screen outcome
- * @returns {object} Outcome properties
+ * @param {ScreenStatus|boolean} status - Screen status
+ * @returns {object} Status properties
  */
-export function getScreenOutcomeProperties(outcome) {
-  const hasOutcome = String(outcome) in SCREEN_OUTCOME_COLOURS
+export function getScreenStatusProperties(status) {
+  const hasStatus = String(status) in SCREEN_STATUS_COLOURS
 
   return {
-    colour: hasOutcome ? SCREEN_OUTCOME_COLOURS[outcome] : 'green',
-    text: hasOutcome ? outcome : 'No triage needed'
+    colour: hasStatus ? SCREEN_STATUS_COLOURS[status] : 'green',
+    text: hasStatus ? status : 'No triage needed'
   }
 }
 

--- a/app/utils/enum-properties.js
+++ b/app/utils/enum-properties.js
@@ -1,7 +1,7 @@
 import {
   ConsentOutcome,
   DownloadStatus,
-  InstructionOutcome,
+  InstructionStatus,
   PatientClinicStatus,
   PatientStatus,
   RegistrationStatus,
@@ -132,19 +132,19 @@ export function getDownloadStatusProperties(status) {
 }
 
 /**
- * Get instruction outcome status properties
+ * Get instruction status properties
  *
- * @param {InstructionOutcome|boolean} outcome - Instruction outcome
- * @returns {object|undefined} Outcome properties
+ * @param {InstructionStatus|boolean} status - Instruction status
+ * @returns {object|undefined} Status properties
  */
-export function getInstructionOutcomeProperties(outcome) {
-  if (!outcome) {
+export function getInstructionStatusProperties(status) {
+  if (!status) {
     return
   }
 
   return {
-    colour: outcome === InstructionOutcome.Given ? 'green' : 'grey',
-    text: outcome
+    colour: status === InstructionStatus.Given ? 'green' : 'grey',
+    text: status
   }
 }
 

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -12,7 +12,7 @@ import {
   PatientTriageStatus,
   PatientVaccinatedStatus,
   RegistrationStatus,
-  ScreenOutcome,
+  ScreenStatus,
   VaccinationOutcome,
   VaccineCriteria
 } from '../enums.js'
@@ -85,36 +85,36 @@ export function getConsentStatusDescription(patientSession) {
 }
 
 /**
- * Get expanded description about screen outcome
+ * Get expanded description about screen status
  *
  * @param {PatientSession} patientSession - Patient session
- * @returns {string} Screen outcome description
+ * @returns {string} Screen status description
  */
-export function getScreenOutcomeDescription(patientSession) {
+export function getScreenStatusDescription(patientSession) {
   const triageNote = patientSession.triageNotes.at(-1)
   const user = triageNote?.createdBy || { fullName: 'Jane Joy' }
   const person = patientSession.patient.isPost16 ? 'child' : 'parent'
 
   switch (patientSession.screen) {
-    case ScreenOutcome.NeedsTriage:
+    case ScreenStatus.NeedsTriage:
       return patientSession.clinicAppointment
         ? `You need to review the health questions with the ${person} to decide if it’s safe to vaccinate ${patientSession.patient.firstName}.`
         : `You need to decide if it’s safe to vaccinate ${patientSession.patient.firstName}.`
-    case ScreenOutcome.InvitedToClinic:
+    case ScreenStatus.InvitedToClinic:
       return `${user.fullName} decided that ${patientSession.patient.firstName}’s vaccination should take place at a clinic.`
-    case ScreenOutcome.DelayVaccination:
+    case ScreenStatus.DelayVaccination:
       return triageNote?.outcomeAt
         ? `${user.fullName} decided that ${patientSession.patient.firstName}’s vaccination should be delayed until ${triageNote.formatted.outcomeAt}.`
         : `${user.fullName} decided that ${patientSession.patient.firstName}’s vaccination should be delayed`
-    case ScreenOutcome.DoNotVaccinate:
+    case ScreenStatus.DoNotVaccinate:
       return `${user.fullName} decided that ${patientSession.patient.firstName} should not be vaccinated.`
-    case ScreenOutcome.Vaccinate:
+    case ScreenStatus.Vaccinate:
       return `${user.fullName} decided that ${patientSession.patient.firstName} is safe to vaccinate.`
-    case ScreenOutcome.VaccinateAlternativeFluInjectionOnly:
+    case ScreenStatus.VaccinateAlternativeFluInjectionOnly:
       return `${user.fullName} decided that ${patientSession.patient.firstName} is safe to vaccinate using the injected vaccine only.`
-    case ScreenOutcome.VaccinateAlternativeMMRInjectionOnly:
+    case ScreenStatus.VaccinateAlternativeMMRInjectionOnly:
       return `${user.fullName} decided that ${patientSession.patient.firstName} is safe to vaccinate using the gelatine-free injection only.`
-    case ScreenOutcome.VaccinateIntranasalOnly:
+    case ScreenStatus.VaccinateIntranasalOnly:
       return `${user.fullName} decided that ${patientSession.patient.firstName} is safe to vaccinate using the nasal spray only.`
     default:
       return `No triage is needed for ${patientSession.patient.firstName}.`
@@ -197,11 +197,11 @@ export function getVaccinationOutcome(patientSession) {
     )
   ) {
     return VaccinationOutcome.ConsentRefused
-  } else if (patientSession.screen === ScreenOutcome.InvitedToClinic) {
+  } else if (patientSession.screen === ScreenStatus.InvitedToClinic) {
     return VaccinationOutcome.InvitedToClinic
-  } else if (patientSession.screen === ScreenOutcome.DelayVaccination) {
+  } else if (patientSession.screen === ScreenStatus.DelayVaccination) {
     return VaccinationOutcome.DelayVaccination
-  } else if (patientSession.screen === ScreenOutcome.DoNotVaccinate) {
+  } else if (patientSession.screen === ScreenStatus.DoNotVaccinate) {
     return VaccinationOutcome.DoNotVaccinate
   }
 }
@@ -232,18 +232,18 @@ export function getPatientStatus(patientSession) {
 
   // Has screening outcome
   switch (patientSession.screen) {
-    case ScreenOutcome.DelayVaccination:
-    case ScreenOutcome.InvitedToClinic:
-    case ScreenOutcome.DoNotVaccinate:
+    case ScreenStatus.DelayVaccination:
+    case ScreenStatus.InvitedToClinic:
+    case ScreenStatus.DoNotVaccinate:
       return PatientStatus.Deferred
 
-    case ScreenOutcome.Vaccinate:
-    case ScreenOutcome.VaccinateAlternativeFluInjectionOnly:
-    case ScreenOutcome.VaccinateAlternativeMMRInjectionOnly:
-    case ScreenOutcome.VaccinateIntranasalOnly:
+    case ScreenStatus.Vaccinate:
+    case ScreenStatus.VaccinateAlternativeFluInjectionOnly:
+    case ScreenStatus.VaccinateAlternativeMMRInjectionOnly:
+    case ScreenStatus.VaccinateIntranasalOnly:
       return PatientStatus.Due
 
-    case ScreenOutcome.NeedsTriage:
+    case ScreenStatus.NeedsTriage:
       return PatientStatus.Triage
   }
 
@@ -336,7 +336,7 @@ export function getPatientTriageStatus(patientSession) {
   const responses = Object.values(patientSession.responses)
   const responsesToTriage = getRepliesWithHealthAnswers(responses)
 
-  if (patientSession.screen === ScreenOutcome.NeedsTriage) {
+  if (patientSession.screen === ScreenStatus.NeedsTriage) {
     if (responsesToTriage.length > 0) {
       return PatientTriageStatus.Responses
     } else if (patientSession.clinicAppointment) {
@@ -352,11 +352,11 @@ export function getPatientTriageStatus(patientSession) {
  * @returns {PatientDeferredStatus|undefined} Patient deferred status
  */
 export function getPatientDeferredStatus(patientSession) {
-  if (patientSession.screen === ScreenOutcome.DoNotVaccinate) {
+  if (patientSession.screen === ScreenStatus.DoNotVaccinate) {
     return PatientDeferredStatus.DoNotVaccinate
-  } else if (patientSession.screen === ScreenOutcome.DelayVaccination) {
+  } else if (patientSession.screen === ScreenStatus.DelayVaccination) {
     return PatientDeferredStatus.DelayVaccination
-  } else if (patientSession.screen === ScreenOutcome.InvitedToClinic) {
+  } else if (patientSession.screen === ScreenStatus.InvitedToClinic) {
     return PatientDeferredStatus.InvitedToClinic
   }
 

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -230,7 +230,7 @@ export function getPatientStatus(patientSession) {
     }
   }
 
-  // Has screening outcome
+  // Has screening status
   switch (patientSession.screen) {
     case ScreenStatus.DelayVaccination:
     case ScreenStatus.InvitedToClinic:

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -4,7 +4,7 @@ import { isToday } from 'date-fns'
 import {
   ConsentOutcome,
   ConsentWindow,
-  InstructionOutcome,
+  InstructionStatus,
   PatientConsentStatus,
   PatientDeferredStatus,
   PatientStatus,
@@ -122,20 +122,20 @@ export function getScreenOutcomeDescription(patientSession) {
 }
 
 /**
- * Get instruction outcome for nasal spray
+ * Get instruction status for nasal spray
  *
  * @param {PatientSession} patientSession - Patient session
- * @returns {InstructionOutcome|boolean} Instruction outcome
+ * @returns {InstructionStatus|boolean} Instruction status
  */
-export function getInstructionOutcome(patientSession) {
+export function getInstructionStatus(patientSession) {
   if (!patientSession.vaccine) {
     return false
   }
 
   if (patientSession.vaccine.criteria === VaccineCriteria.Intranasal) {
     return patientSession.patientProgramme.instruction
-      ? InstructionOutcome.Given
-      : InstructionOutcome.Needed
+      ? InstructionStatus.Given
+      : InstructionStatus.Needed
   }
 
   return false

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -2,7 +2,7 @@ import filters from '@x-govuk/govuk-prototype-filters'
 import { isToday } from 'date-fns'
 
 import {
-  ConsentOutcome,
+  ConsentStatus,
   ConsentWindow,
   InstructionStatus,
   PatientConsentStatus,
@@ -40,12 +40,12 @@ export function canRecordOutcome(patientSession) {
 }
 
 /**
- * Get expanded description about consent outcome
+ * Get expanded description about consent status
  *
  * @param {PatientSession} patientSession - Patient session
- * @returns {string} Consent outcome description
+ * @returns {string} Consent status description
  */
-export function getConsentOutcomeDescription(patientSession) {
+export function getConsentStatusDescription(patientSession) {
   const relationships = filters.formatList(patientSession.parentalRelationships)
   const contactNames = filters.formatList(
     patientSession.contactsRequestingFollowUp
@@ -64,21 +64,21 @@ export function getConsentOutcomeDescription(patientSession) {
   }
 
   switch (patientSession.consent) {
-    case ConsentOutcome.NoResponse:
+    case ConsentStatus.NoResponse:
       return 'No-one responded to our requests for consent.'
-    case ConsentOutcome.NotDelivered:
+    case ConsentStatus.NotDelivered:
       return 'Consent response could not be delivered.'
-    case ConsentOutcome.Inconsistent:
+    case ConsentStatus.Inconsistent:
       return 'You can only vaccinate if all respondents give consent.'
-    case ConsentOutcome.Declined:
+    case ConsentStatus.Declined:
       return `${contactNames} would like to speak to a member of the team about other options for their child’s vaccination.`
-    case ConsentOutcome.Given:
-    case ConsentOutcome.GivenForAlternativeInjection:
-    case ConsentOutcome.GivenForIntranasal:
+    case ConsentStatus.Given:
+    case ConsentStatus.GivenForAlternativeInjection:
+    case ConsentStatus.GivenForIntranasal:
       return `${relationships} gave consent.`
-    case ConsentOutcome.Refused:
+    case ConsentStatus.Refused:
       return `${relationships} refused consent.`
-    case ConsentOutcome.FinalRefusal:
+    case ConsentStatus.FinalRefusal:
       return `Refusal to give consent confirmed by ${relationships}.`
     default:
   }
@@ -192,7 +192,7 @@ export function getVaccinationOutcome(patientSession) {
   if (patientSession.lastVaccinationOutcome) {
     return patientSession.lastVaccinationOutcome.outcome
   } else if (
-    [ConsentOutcome.Refused, ConsentOutcome.FinalRefusal].includes(
+    [ConsentStatus.Refused, ConsentStatus.FinalRefusal].includes(
       patientSession.consent
     )
   ) {
@@ -247,20 +247,20 @@ export function getPatientStatus(patientSession) {
       return PatientStatus.Triage
   }
 
-  // Has consent outcome
+  // Has consent status
   if (patientSession.consentGiven) {
     return PatientStatus.Due
   }
 
   switch (patientSession.consent) {
-    case ConsentOutcome.Declined:
-    case ConsentOutcome.Inconsistent:
-    case ConsentOutcome.Refused:
-    case ConsentOutcome.FinalRefusal:
+    case ConsentStatus.Declined:
+    case ConsentStatus.Inconsistent:
+    case ConsentStatus.Refused:
+    case ConsentStatus.FinalRefusal:
       return PatientStatus.Refused
 
-    case ConsentOutcome.NotDelivered:
-    case ConsentOutcome.NoResponse:
+    case ConsentStatus.NotDelivered:
+    case ConsentStatus.NoResponse:
       return PatientStatus.Consent
 
     default:
@@ -295,15 +295,15 @@ export function getPatientConsentStatus(patientSession) {
   }
 
   switch (patientSession.consent) {
-    case ConsentOutcome.NotDelivered:
+    case ConsentStatus.NotDelivered:
       return PatientConsentStatus.NotDelivered
-    case ConsentOutcome.NoResponse:
+    case ConsentStatus.NoResponse:
       return PatientConsentStatus.NoResponse
-    case ConsentOutcome.Declined:
+    case ConsentStatus.Declined:
       return PatientRefusedStatus.FollowUp
-    case ConsentOutcome.Inconsistent:
+    case ConsentStatus.Inconsistent:
       return PatientRefusedStatus.Conflict
-    case ConsentOutcome.Refused:
+    case ConsentStatus.Refused:
       return PatientRefusedStatus.Refusal
   }
 }
@@ -316,12 +316,12 @@ export function getPatientConsentStatus(patientSession) {
  */
 export function getPatientRefusedStatus(patientSession) {
   switch (patientSession.consent) {
-    case ConsentOutcome.Inconsistent:
+    case ConsentStatus.Inconsistent:
       return PatientRefusedStatus.Conflict
-    case ConsentOutcome.Declined:
+    case ConsentStatus.Declined:
       return PatientRefusedStatus.FollowUp
-    case ConsentOutcome.Refused:
-    case ConsentOutcome.FinalRefusal:
+    case ConsentStatus.Refused:
+    case ConsentStatus.FinalRefusal:
       return PatientRefusedStatus.Refusal
   }
 }

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -11,7 +11,7 @@ import {
   PatientRefusedStatus,
   PatientTriageStatus,
   PatientVaccinatedStatus,
-  RegistrationOutcome,
+  RegistrationStatus,
   ScreenOutcome,
   VaccinationOutcome,
   VaccineCriteria
@@ -29,7 +29,7 @@ export function canRecordOutcome(patientSession) {
   const { register, status, session } = patientSession
 
   if ([PatientStatus.Due, PatientStatus.Deferred].includes(status)) {
-    if (session.hasRegistration && register !== RegistrationOutcome.Present) {
+    if (session.hasRegistration && register !== RegistrationStatus.Present) {
       return false
     }
 
@@ -142,42 +142,42 @@ export function getInstructionOutcome(patientSession) {
 }
 
 /**
- * Get registration outcome
+ * Get registration status
  *
  * @param {PatientSession} patientSession - Patient session
- * @returns {RegistrationOutcome} Registration outcome
+ * @returns {RegistrationStatus} Registration status
  */
-export function getRegistrationOutcome(patientSession) {
+export function getRegistrationStatus(patientSession) {
   const { patient, session, status } = patientSession
 
   if (!session.hasRegistration) {
-    return RegistrationOutcome.Present
+    return RegistrationStatus.Present
   }
 
   if (status === PatientStatus.Vaccinated) {
-    return RegistrationOutcome.Complete
+    return RegistrationStatus.Complete
   } else if (session.register[patient.uuid]) {
     return session.register[patient.uuid]
   }
 
-  return RegistrationOutcome.Pending
+  return RegistrationStatus.Pending
 }
 
 /**
- * Get expanded description about registration outcome
+ * Get expanded description about registration status
  *
  * @param {PatientSession} patientSession - Patient session
- * @returns {string} Registration outcome description
+ * @returns {string} Registration status description
  */
-export function getRegistrationOutcomeDescription(patientSession) {
+export function getRegistrationStatusDescription(patientSession) {
   switch (patientSession.register) {
-    case RegistrationOutcome.Present:
+    case RegistrationStatus.Present:
       return `${patientSession.patient?.firstName} is attending this session.`
-    case RegistrationOutcome.Absent:
+    case RegistrationStatus.Absent:
       return `${patientSession.patient?.firstName} is absent from this session.`
-    case RegistrationOutcome.Pending:
+    case RegistrationStatus.Pending:
       return `${patientSession.patient?.firstName} has not been registered as attending yet.`
-    case RegistrationOutcome.Complete:
+    case RegistrationStatus.Complete:
       return `${patientSession.patient?.firstName} has completed this session.`
   }
 }

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -103,8 +103,8 @@ export function getScreenStatusDescription(patientSession) {
     case ScreenStatus.InvitedToClinic:
       return `${user.fullName} decided that ${patientSession.patient.firstName}’s vaccination should take place at a clinic.`
     case ScreenStatus.DelayVaccination:
-      return triageNote?.outcomeAt
-        ? `${user.fullName} decided that ${patientSession.patient.firstName}’s vaccination should be delayed until ${triageNote.formatted.outcomeAt}.`
+      return triageNote?.statusInvalidAt
+        ? `${user.fullName} decided that ${patientSession.patient.firstName}’s vaccination should be delayed until ${triageNote.formatted.statusInvalidAt}.`
         : `${user.fullName} decided that ${patientSession.patient.firstName}’s vaccination should be delayed`
     case ScreenStatus.DoNotVaccinate:
       return `${user.fullName} decided that ${patientSession.patient.firstName} should not be vaccinated.`

--- a/app/utils/reply.js
+++ b/app/utils/reply.js
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { healthConditions } from '../datasets/health-conditions.js'
 import {
-  ConsentOutcome,
+  ConsentStatus,
   ConsentVaccineCriteria,
   ProgrammeType,
   ReplyDecision,
@@ -114,27 +114,27 @@ export function getConsentHealthAnswers(patientSession) {
 }
 
 /**
- * Get consent outcome
+ * Get confirmed consent status
  *
  * @param {Reply} reply - Reply
  * @param {Session} session - Session
- * @returns {ConsentOutcome} Consent outcome
+ * @returns {ConsentStatus} Confirmed consent status
  */
-export const getConfirmedConsentOutcome = (reply, session) => {
+export const getConfirmedConsentStatus = (reply, session) => {
   if (!reply.delivered) {
-    return ConsentOutcome.NotDelivered
+    return ConsentStatus.NotDelivered
   }
 
   if (reply.decision === ReplyDecision.NoResponse) {
-    return ConsentOutcome.NoResponse
+    return ConsentStatus.NoResponse
   }
 
   if (reply.decision === ReplyDecision.Refused && reply.hasConfirmedRefusal) {
-    return ConsentOutcome.FinalRefusal
+    return ConsentStatus.FinalRefusal
   }
 
   if (reply.hasRefusedConsent) {
-    return ConsentOutcome.Refused
+    return ConsentStatus.Refused
   }
 
   if (reply.hasGivenConsent) {
@@ -142,7 +142,7 @@ export const getConfirmedConsentOutcome = (reply, session) => {
       session.canOfferAlternativeVaccine &&
       reply.decision === ReplyDecision.OnlyAlternativeInjection
     ) {
-      return ConsentOutcome.GivenForAlternativeInjection
+      return ConsentStatus.GivenForAlternativeInjection
     }
 
     if (
@@ -150,25 +150,25 @@ export const getConfirmedConsentOutcome = (reply, session) => {
       reply.decision !== ReplyDecision.OnlyAlternativeInjection &&
       !reply.hasConsentForAlternativeVaccine
     ) {
-      return ConsentOutcome.GivenForIntranasal
+      return ConsentStatus.GivenForIntranasal
     }
 
-    return ConsentOutcome.Given
+    return ConsentStatus.Given
   }
 
   return reply.decision
 }
 
 /**
- * Get consent outcome
+ * Get consent status
  *
  * @param {PatientSession} patientSession - Patient session
- * @returns {ConsentOutcome} Consent outcome
+ * @returns {ConsentStatus} Consent status
  */
-export const getConsentOutcome = (patientSession) => {
+export const getConsentStatus = (patientSession) => {
   // If patient is 16+, assume consent given
   if (patientSession.patient.isPost16) {
-    return ConsentOutcome.Given
+    return ConsentStatus.Given
   }
 
   // Get valid replies
@@ -178,12 +178,12 @@ export const getConsentOutcome = (patientSession) => {
 
   // If no valid replies, no response
   if (validReplies.length === 0) {
-    return ConsentOutcome.NoResponse
+    return ConsentStatus.NoResponse
   }
 
   // If all valid replies were undelivered, request failed
   if (validReplies.every(({ delivered }) => !delivered)) {
-    return ConsentOutcome.NotDelivered
+    return ConsentStatus.NotDelivered
   }
 
   // Get valid and delivered replies
@@ -192,12 +192,12 @@ export const getConsentOutcome = (patientSession) => {
   // If any reply is child self consenting, use child’s decision
   const childReply = replies.find((reply) => reply.hasSelfConsent)
   if (childReply) {
-    return getConfirmedConsentOutcome(childReply, patientSession.session)
+    return getConfirmedConsentStatus(childReply, patientSession.session)
   }
 
   // If only one reply, use that decision
   if (replies.length === 1) {
-    return getConfirmedConsentOutcome(replies[0], patientSession.session)
+    return getConfirmedConsentStatus(replies[0], patientSession.session)
   }
 
   // If many replies, determine if responses are consistent or inconsistent
@@ -209,18 +209,18 @@ export const getConsentOutcome = (patientSession) => {
           hasRefusedConsent && hasConfirmedRefusal
       )
     ) {
-      return ConsentOutcome.FinalRefusal
+      return ConsentStatus.FinalRefusal
     }
 
     // If one of the replies is a refusal, consent is refused
     if (replies.find(({ hasRefusedConsent }) => hasRefusedConsent)) {
-      return ConsentOutcome.Refused
+      return ConsentStatus.Refused
     }
 
     // If one of the replies has requested follow up, show this status
     // over showing inconsistent consent
     if (replies.find(({ hasDeclinedConsent }) => hasDeclinedConsent)) {
-      return ConsentOutcome.Declined
+      return ConsentStatus.Declined
     }
 
     // If consent given, determine which vaccine method has consent
@@ -247,17 +247,17 @@ export const getConsentOutcome = (patientSession) => {
         )
 
         if (someWantInjectionOnly && someWantIntranasalOnly) {
-          return ConsentOutcome.Inconsistent
+          return ConsentStatus.Inconsistent
         }
 
         if (
           allWantInjection ||
           (someWantInjectionOnly && allAcceptAlternative)
         ) {
-          return ConsentOutcome.GivenForAlternativeInjection
+          return ConsentStatus.GivenForAlternativeInjection
         }
 
-        return ConsentOutcome.GivenForIntranasal
+        return ConsentStatus.GivenForIntranasal
       }
 
       // For MMR programme, determine if any consent requested gelatine-free
@@ -268,19 +268,19 @@ export const getConsentOutcome = (patientSession) => {
               hasConsentForAlternativeVaccine
           )
         ) {
-          return ConsentOutcome.GivenForAlternativeInjection
+          return ConsentStatus.GivenForAlternativeInjection
         }
       }
 
       if (replies.every(({ hasGivenConsent }) => hasGivenConsent)) {
-        return ConsentOutcome.Given
+        return ConsentStatus.Given
       }
     }
 
-    return ConsentOutcome.Inconsistent
+    return ConsentStatus.Inconsistent
   }
 
-  return ConsentOutcome.NoResponse
+  return ConsentStatus.NoResponse
 }
 
 /**

--- a/app/utils/triage.js
+++ b/app/utils/triage.js
@@ -1,7 +1,7 @@
 import {
   ProgrammeType,
   ReplyDecision,
-  ScreenOutcome,
+  ScreenStatus,
   ScreenVaccineCriteria,
   VaccinationOutcome
 } from '../enums.js'
@@ -9,13 +9,13 @@ import {
 import { getRepliesWithHealthAnswers } from './reply.js'
 
 /**
- * Get screen outcomes for vaccination method(s) consented to
+ * Get screening statuses for vaccination method(s) consented to
  *
  * @param {Programme} programme - Programme
  * @param {Array<Reply>} replies - Replies
- * @returns {Array<ScreenOutcome>} Screen outcomes
+ * @returns {Array<ScreenStatus>} Screening statuses
  */
-export const getScreenOutcomesForConsentMethod = (programme, replies) => {
+export const getScreenStatusesForConsentMethod = (programme, replies) => {
   const hasConsentForInjection = replies?.every(
     ({ hasConsentForInjection }) => hasConsentForInjection
   )
@@ -25,25 +25,25 @@ export const getScreenOutcomesForConsentMethod = (programme, replies) => {
   )
 
   return [
-    ...(!programme?.alternativeVaccine ? [ScreenOutcome.Vaccinate] : []),
+    ...(!programme?.alternativeVaccine ? [ScreenStatus.Vaccinate] : []),
     ...(programme?.alternativeVaccine &&
     programme.type === ProgrammeType.Flu &&
     !hasConsentForAlternativeInjectionOnly
-      ? [ScreenOutcome.VaccinateIntranasalOnly]
+      ? [ScreenStatus.VaccinateIntranasalOnly]
       : []),
     ...(programme?.alternativeVaccine &&
     programme.type === ProgrammeType.Flu &&
     hasConsentForInjection
-      ? [ScreenOutcome.VaccinateAlternativeFluInjectionOnly]
+      ? [ScreenStatus.VaccinateAlternativeFluInjectionOnly]
       : []),
     ...(programme?.alternativeVaccine && programme.type === ProgrammeType.MMR
-      ? [ScreenOutcome.VaccinateAlternativeFluInjectionOnly]
+      ? [ScreenStatus.VaccinateAlternativeFluInjectionOnly]
       : []),
     'or',
-    ScreenOutcome.NeedsTriage,
-    ScreenOutcome.InvitedToClinic,
-    ScreenOutcome.DelayVaccination,
-    ScreenOutcome.DoNotVaccinate
+    ScreenStatus.NeedsTriage,
+    ScreenStatus.InvitedToClinic,
+    ScreenStatus.DelayVaccination,
+    ScreenStatus.DoNotVaccinate
   ]
 }
 
@@ -82,12 +82,12 @@ export const getScreenVaccineCriteria = (programme, replies) => {
 }
 
 /**
- * Get screen outcome (what was the triage decision)
+ * Get screening status (what was the triage decision)
  *
  * @param {PatientSession} patientSession - Patient session
- * @returns {ScreenOutcome|boolean} Screen outcome
+ * @returns {ScreenStatus|boolean} Screening status
  */
-export const getScreenOutcome = (patientSession) => {
+export const getScreenStatus = (patientSession) => {
   // No consent given, so cannot triage yet
   if (!patientSession.consentGiven) {
     return false
@@ -99,21 +99,21 @@ export const getScreenOutcome = (patientSession) => {
       patientSession.lastVaccinationOutcome.outcome ===
       VaccinationOutcome.InvitedToClinic
     ) {
-      return ScreenOutcome.InvitedToClinic
+      return ScreenStatus.InvitedToClinic
     }
 
     if (
       patientSession.lastVaccinationOutcome.outcome ===
       VaccinationOutcome.DelayVaccination
     ) {
-      return ScreenOutcome.DelayVaccination
+      return ScreenStatus.DelayVaccination
     }
 
     if (
       patientSession.lastVaccinationOutcome.outcome ===
       VaccinationOutcome.DoNotVaccinate
     ) {
-      return ScreenOutcome.DoNotVaccinate
+      return ScreenStatus.DoNotVaccinate
     }
   }
 
@@ -131,7 +131,7 @@ export const getScreenOutcome = (patientSession) => {
 
     // Clinic appointment without any answers to health questions
     if (!responses.length && patientSession.clinicAppointment) {
-      return ScreenOutcome.NeedsTriage
+      return ScreenStatus.NeedsTriage
     }
 
     return false
@@ -143,7 +143,7 @@ export const getScreenOutcome = (patientSession) => {
       return lastTriageNoteWithOutcome.outcome
     }
 
-    return ScreenOutcome.NeedsTriage
+    return ScreenStatus.NeedsTriage
   }
 
   return false

--- a/app/utils/triage.js
+++ b/app/utils/triage.js
@@ -119,14 +119,14 @@ export const getScreenStatus = (patientSession) => {
 
   const responses = Object.values(patientSession.responses)
   const responsesToTriage = getRepliesWithHealthAnswers(responses)
-  const lastTriageNoteWithOutcome = patientSession.triageNotes
-    .filter((event) => event.outcome)
+  const lastTriageNoteWithStatus = patientSession.triageNotes
+    .filter((event) => event.status)
     .at(-1)
 
   if (responsesToTriage.length === 0) {
     // Triage completed without any ‘Yes’ answers to health questions
-    if (lastTriageNoteWithOutcome) {
-      return lastTriageNoteWithOutcome.outcome
+    if (lastTriageNoteWithStatus) {
+      return lastTriageNoteWithStatus.status
     }
 
     // Clinic appointment without any answers to health questions
@@ -139,8 +139,8 @@ export const getScreenStatus = (patientSession) => {
 
   // Triage needed or completed due to answers to health questions
   if (responsesToTriage.length > 0) {
-    if (lastTriageNoteWithOutcome) {
-      return lastTriageNoteWithOutcome.outcome
+    if (lastTriageNoteWithStatus) {
+      return lastTriageNoteWithStatus.status
     }
 
     return ScreenStatus.NeedsTriage

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -116,7 +116,7 @@
           size: "s"
         }
       },
-      items: enumItems(ConsentOutcome),
+      items: enumItems(ConsentStatus),
       decorate: "consent"
     }) if account.isSchoolUser }}
 

--- a/app/views/patient-programme/form/triage.njk
+++ b/app/views/patient-programme/form/triage.njk
@@ -18,12 +18,12 @@
   {% set delayVaccinationHtml = dateInput({
     fieldset: {
       legend: {
-        text: __("triage.outcomeAt.title", { patient: patient }),
+        text: __("triage.statusInvalidAt.title", { patient: patient }),
         size: "s"
       }
     },
-    hint: { text: __("triage.outcomeAt.hint", { date: DelayDate }) },
-    decorate: "triage.outcomeAt_"
+    hint: { text: __("triage.statusInvalidAt.hint", { date: DelayDate }) },
+    decorate: "triage.statusInvalidAt_"
   }) %}
 
   {% set statusItems = injectConditionalHtml(triageStatusItems(patientSession.screenStatusesForConsentMethod), ScreenStatus.VaccinateIntranasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine else triageStatusItems(patientSession.screenStatusesForConsentMethod) %}

--- a/app/views/patient-programme/form/triage.njk
+++ b/app/views/patient-programme/form/triage.njk
@@ -39,7 +39,7 @@
       text: patientSession.screenVaccineCriteria
     } if patientSession.screenVaccineCriteria,
     items: injectConditionalHtml(statusItems, ScreenStatus.DelayVaccination, delayVaccinationHtml),
-    decorate: "triage.outcome"
+    decorate: "triage.status"
   }) }}
 
   {{ textarea({

--- a/app/views/patient-programme/form/triage.njk
+++ b/app/views/patient-programme/form/triage.njk
@@ -26,7 +26,7 @@
     decorate: "triage.outcomeAt_"
   }) %}
 
-  {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(patientSession.screenOutcomesForConsentMethod), ScreenOutcome.VaccinateIntranasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine else triageOutcomeItems(patientSession.screenOutcomesForConsentMethod) %}
+  {% set statusItems = injectConditionalHtml(triageStatusItems(patientSession.screenStatusesForConsentMethod), ScreenStatus.VaccinateIntranasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine else triageStatusItems(patientSession.screenStatusesForConsentMethod) %}
 
   {{ radios({
     fieldset: {
@@ -38,7 +38,7 @@
     hint: {
       text: patientSession.screenVaccineCriteria
     } if patientSession.screenVaccineCriteria,
-    items: injectConditionalHtml(outcomeItems, ScreenOutcome.DelayVaccination, delayVaccinationHtml),
+    items: injectConditionalHtml(statusItems, ScreenStatus.DelayVaccination, delayVaccinationHtml),
     decorate: "triage.outcome"
   }) }}
 

--- a/app/views/patient-session/_register.njk
+++ b/app/views/patient-session/_register.njk
@@ -6,7 +6,7 @@
   {{ patientSession.registerDescription | nhsukMarkdown }}
 
   {# Actions #}
-  {% if patientSession.register == RegistrationOutcome.Pending %}
+  {% if patientSession.register == RegistrationStatus.Pending %}
     <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--l">
 
     {{ radios({
@@ -18,10 +18,10 @@
       },
       items: [{
         text: __("patientSession.registration.present"),
-        value: RegistrationOutcome.Present
+        value: RegistrationStatus.Present
       }, {
         text: __("patientSession.registration.absent"),
-        value: RegistrationOutcome.Absent
+        value: RegistrationStatus.Absent
       }],
       decorate: "patientSession.register"
     }) }}
@@ -32,7 +32,7 @@
         formaction: patientSession.uri + "/edit/registration?referrer=" + referrer
       }
     }) }}
-  {% elif patientSession.register != RegistrationOutcome.Complete %}
+  {% elif patientSession.register != RegistrationStatus.Complete %}
     {{ actionLink({
       text: __("patientSession.registration.title"),
       href: patientSession.uri + "/edit/registration?referrer=" + referrer

--- a/app/views/patient-session/_triage.njk
+++ b/app/views/patient-session/_triage.njk
@@ -37,8 +37,8 @@
         html: triageNote.note or "—" | nhsukMarkdown
       },
       {
-        header: __("event.outcome.label"),
-        html: triageNote.formatted.outcome
+        header: __("event.status.label"),
+        html: triageNote.formatted.status
       }
     ]) %}
   {% endfor %}
@@ -57,7 +57,7 @@
         },
         { text: __("event.note.label") },
         {
-          text: __("event.outcome.label"),
+          text: __("event.status.label"),
           attributes: {
             width: "25%"
           }
@@ -103,7 +103,7 @@
         text: patientSession.screenVaccineCriteria
       } if patientSession.screenVaccineCriteria,
       items: injectConditionalHtml(statusItems, ScreenStatus.DelayVaccination, delayVaccinationHtml),
-      decorate: "triage.outcome"
+      decorate: "triage.status"
     }) }}
 
     {{ textarea({

--- a/app/views/patient-session/_triage.njk
+++ b/app/views/patient-session/_triage.njk
@@ -82,12 +82,12 @@
     {% set delayVaccinationHtml = dateInput({
       fieldset: {
         legend: {
-          text: __("triage.outcomeAt.title", { patient: patient }),
+          text: __("triage.statusInvalidAt.title", { patient: patient }),
           size: "s"
         }
       },
-      hint: { text: __("triage.outcomeAt.hint", { date: DelayDate }) },
-      decorate: "triage.outcomeAt_"
+      hint: { text: __("triage.statusInvalidAt.hint", { date: DelayDate }) },
+      decorate: "triage.statusInvalidAt_"
     }) %}
 
     {% set statusItems = injectConditionalHtml(triageStatusItems(patientSession.screenStatusesForConsentMethod), ScreenStatus.VaccinateIntranasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine else triageStatusItems(patientSession.screenStatusesForConsentMethod) %}

--- a/app/views/patient-session/_triage.njk
+++ b/app/views/patient-session/_triage.njk
@@ -90,7 +90,7 @@
       decorate: "triage.outcomeAt_"
     }) %}
 
-    {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(patientSession.screenOutcomesForConsentMethod), ScreenOutcome.VaccinateIntranasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine else triageOutcomeItems(patientSession.screenOutcomesForConsentMethod) %}
+    {% set statusItems = injectConditionalHtml(triageStatusItems(patientSession.screenStatusesForConsentMethod), ScreenStatus.VaccinateIntranasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine else triageStatusItems(patientSession.screenStatusesForConsentMethod) %}
 
     {{ radios({
       fieldset: {
@@ -102,7 +102,7 @@
       hint: {
         text: patientSession.screenVaccineCriteria
       } if patientSession.screenVaccineCriteria,
-      items: injectConditionalHtml(outcomeItems, ScreenOutcome.DelayVaccination, delayVaccinationHtml),
+      items: injectConditionalHtml(statusItems, ScreenStatus.DelayVaccination, delayVaccinationHtml),
       decorate: "triage.outcome"
     }) }}
 

--- a/app/views/patient-session/form/registration.njk
+++ b/app/views/patient-session/form/registration.njk
@@ -15,15 +15,15 @@
     },
     items: [{
       text: __("patientSession.registration.present"),
-      value: RegistrationOutcome.Present
+      value: RegistrationStatus.Present
     }, {
       text: __("patientSession.registration.absent"),
-      value: RegistrationOutcome.Absent
+      value: RegistrationStatus.Absent
     }, {
       divider: "or"
     }, {
       text: __("patientSession.registration.pending"),
-      value: RegistrationOutcome.Pending
+      value: RegistrationStatus.Pending
     }],
     decorate: "patientSession.register"
   }) }}

--- a/app/views/reply/form/check-answers.njk
+++ b/app/views/reply/form/check-answers.njk
@@ -108,9 +108,9 @@
     },
     lastRowBorder: false,
     rows: summaryRows(triage, {
-      outcome: {
-        label: __("triage.outcome.label"),
-        value: triage.outcome,
+      status: {
+        label: __("triage.status.label"),
+        value: triage.status,
         href: reply.uri + "/new/triage"
       },
       note: {
@@ -119,5 +119,5 @@
         href: reply.uri + "/new/triage"
       }
     })
-  }) if triage.outcome }}
+  }) if triage.status }}
 {% endblock %}

--- a/app/views/reply/form/triage.njk
+++ b/app/views/reply/form/triage.njk
@@ -26,7 +26,7 @@
     decorate: "triage.outcomeAt_"
   }) %}
 
-  {% set outcomeItems = injectConditionalHtml(triageOutcomeItems(screenOutcomesForConsentMethod), ScreenOutcome.VaccinateIntranasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine and reply.decision != ReplyDecision.OnlyAlternativeInjection and account.canPrescribe else triageOutcomeItems(screenOutcomesForConsentMethod) %}
+  {% set statusItems = injectConditionalHtml(triageStatusItems(screenStatusesForConsentMethod), ScreenStatus.VaccinateIntranasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine and reply.decision != ReplyDecision.OnlyAlternativeInjection and account.canPrescribe else triageStatusItems(screenStatusesForConsentMethod) %}
 
   {{ radios({
     fieldset: {
@@ -38,7 +38,7 @@
     hint: {
       text: screenVaccineCriteria
     } if screenVaccineCriteria,
-    items: injectConditionalHtml(outcomeItems, ScreenOutcome.DelayVaccination, delayVaccinationHtml),
+    items: injectConditionalHtml(statusItems, ScreenStatus.DelayVaccination, delayVaccinationHtml),
     decorate: "triage.outcome"
   }) }}
 

--- a/app/views/reply/form/triage.njk
+++ b/app/views/reply/form/triage.njk
@@ -18,12 +18,12 @@
   {% set delayVaccinationHtml = dateInput({
     fieldset: {
       legend: {
-        text: __("triage.outcomeAt.title", { patient: patient }),
+        text: __("triage.statusInvalidAt.title", { patient: patient }),
         size: "s"
       }
     },
-    hint: { text: __("triage.outcomeAt.hint", { date: DelayDate }) },
-    decorate: "triage.outcomeAt_"
+    hint: { text: __("triage.statusInvalidAt.hint", { date: DelayDate }) },
+    decorate: "triage.statusInvalidAt_"
   }) %}
 
   {% set statusItems = injectConditionalHtml(triageStatusItems(screenStatusesForConsentMethod), ScreenStatus.VaccinateIntranasal, psdRadiosHtml) if patientSession.programme.alternativeVaccine and reply.decision != ReplyDecision.OnlyAlternativeInjection and account.canPrescribe else triageStatusItems(screenStatusesForConsentMethod) %}

--- a/app/views/reply/form/triage.njk
+++ b/app/views/reply/form/triage.njk
@@ -32,14 +32,14 @@
     fieldset: {
       legend: {
         classes: "nhsuk-fieldset__legend--m",
-        text: __("triage.outcome.label")
+        text: __("triage.status.label")
       }
     },
     hint: {
       text: screenVaccineCriteria
     } if screenVaccineCriteria,
     items: injectConditionalHtml(statusItems, ScreenStatus.DelayVaccination, delayVaccinationHtml),
-    decorate: "triage.outcome"
+    decorate: "triage.status"
   }) }}
 
   {{ textarea({

--- a/app/views/session/appointments.njk
+++ b/app/views/session/appointments.njk
@@ -22,7 +22,7 @@
           {{ appointment.formatted.register | safe }}
         {% else %}
           {{ tag({
-            text: RegistrationOutcome.Pending,
+            text: RegistrationStatus.Pending,
             classes: "nhsuk-tag--grey"
           }) }}
         {% endif %}

--- a/app/views/session/patients.njk
+++ b/app/views/session/patients.njk
@@ -128,7 +128,7 @@
                 register: {
                   label: __("patientSession.register.label"),
                   value: patientSession.formatted.register,
-                  href: (patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view) if view == "patients" and patientSession.register != RegistrationOutcome.Pending
+                  href: (patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view) if view == "patients" and patientSession.register != RegistrationStatus.Pending
                 } if showRegistration,
                 status: {
                   label: __("patientSession.consent.label") if account.isSchoolUser else __("patientSession.status.label"),
@@ -156,7 +156,7 @@
                 small: true,
                 variant: "secondary",
                 decorate: "patientSession.register",
-                value: RegistrationOutcome.Present,
+                value: RegistrationStatus.Present,
                 attributes: {
                   "aria-label": __("patientSession.registration.actions.present.title", { patient: patientSession.patient }),
                   formaction: patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view + "&register=" + data.register,
@@ -167,14 +167,14 @@
                 text: __("patientSession.registration.actions.absent.label"),
                 small: true,
                 decorate: "patientSession.register",
-                value: RegistrationOutcome.Absent,
+                value: RegistrationStatus.Absent,
                 attributes: {
                   "aria-label": __("patientSession.registration.actions.absent.title", { patient: patientSession.patient }),
                   formaction: patientSession.uri + "/edit/registration?referrer=" + session.uri + "/" + view + "&register=" + data.register,
                   formmethod: "post"
                 }
               }]
-            }) if showRegistration and patientSession.register == RegistrationOutcome.Pending }}
+            }) if showRegistration and patientSession.register == RegistrationStatus.Pending }}
           {% endcall %}
         {% endfor %}
 

--- a/app/views/vaccination/form/decline.njk
+++ b/app/views/vaccination/form/decline.njk
@@ -42,14 +42,14 @@
           html: dateInput({
             fieldset: {
               legend: {
-                text: __("triage.outcomeAt.title", {
+                text: __("triage.statusInvalidAt.title", {
                   patient: vaccination.patient
                 }),
                 size: "s"
               }
             },
-            hint: { text: __("triage.outcomeAt.hint", { date: DelayDate }) },
-            decorate: "triage.outcomeAt_"
+            hint: { text: __("triage.statusInvalidAt.hint", { date: DelayDate }) },
+            decorate: "triage.statusInvalidAt_"
           })
         }
       },

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -16,7 +16,7 @@ import {
   ProgrammeType,
   NoticeType,
   MoveSource,
-  RegistrationOutcome,
+  RegistrationStatus,
   SchoolPhase,
   ScreenOutcome,
   SessionPresets,
@@ -505,7 +505,7 @@ for (const patientSession of Object.values(context.patientSessions)) {
               createdAt: addMinutes(vaccination.createdAt, -10),
               createdBy_uid: nurse.uid
             },
-            RegistrationOutcome.Present
+            RegistrationStatus.Present
           )
 
           // PRE-SCREEN (5 minutes before vaccination)

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -397,7 +397,7 @@ for (const patientSession of Object.values(context.patientSessions)) {
     for (const response of patientSession.responsesWithTriageNotes) {
       const triaged = faker.datatype.boolean(0.5)
       if (triaged) {
-        let outcome = faker.helpers.weightedArrayElement([
+        let status = faker.helpers.weightedArrayElement([
           { value: ScreenStatus.NeedsTriage, weight: 4 },
           { value: ScreenStatus.InvitedToClinic, weight: 1 },
           { value: ScreenStatus.DelayVaccination, weight: 1 },
@@ -406,10 +406,10 @@ for (const patientSession of Object.values(context.patientSessions)) {
         ])
 
         // For programmes that offer alternative vaccine methods, we use
-        // screening outcomes specific to each vaccine method
-        if (outcome === ScreenStatus.Vaccinate) {
+        // screening statuses specific to each vaccine method
+        if (status === ScreenStatus.Vaccinate) {
           if (patientSession.programme.alternativeVaccine) {
-            outcome = patientSession.hasConsentForAlternativeInjectionOnly
+            status = patientSession.hasConsentForAlternativeInjectionOnly
               ? patientSession.programme.type === ProgrammeType.Flu
                 ? ScreenStatus.VaccinateAlternativeFluInjectionOnly
                 : ScreenStatus.VaccinateAlternativeMMRInjectionOnly
@@ -419,7 +419,7 @@ for (const patientSession of Object.values(context.patientSessions)) {
 
         let note = response.triageNote
 
-        switch (outcome) {
+        switch (status) {
           case ScreenStatus.NeedsTriage:
             note = 'Keep in triage until can contact GP.'
             break
@@ -431,9 +431,9 @@ for (const patientSession of Object.values(context.patientSessions)) {
             break
         }
 
-        // 4️⃣ SCREEN with triage outcome (initial)
+        // 4️⃣ SCREEN with triage status (initial)
         patientSession.patientProgramme.recordTriage({
-          outcome,
+          status,
           note,
           createdAt: response.createdAt,
           createdBy_uid: nurse.uid
@@ -468,9 +468,9 @@ for (const patientSession of Object.values(context.patientSessions)) {
   if (session.isCompleted) {
     // Ensure any outstanding triage has been completed
     if (patientSession.screen === ScreenStatus.NeedsTriage) {
-      // 4️⃣ SCREEN with triage outcome (final)
+      // 4️⃣ SCREEN with triage status (final)
       patientSession.patientProgramme.recordTriage({
-        outcome: ScreenStatus.Vaccinate,
+        status: ScreenStatus.Vaccinate,
         note: 'Spoke to GP, safe to vaccinate.',
         createdAt: removeDays(session.date, 2),
         createdBy_uid: nurse.uid

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -444,7 +444,7 @@ for (const patientSession of Object.values(context.patientSessions)) {
 
   const { patient, session } = patientSession
 
-  // Add instruction outcome to completed sessions
+  // Add instruction to completed sessions
   if (session.isCompleted) {
     // Don’t add a PSD if patient needs triage
     const canInstruct = patientSession.status !== PatientStatus.Triage

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -18,7 +18,7 @@ import {
   MoveSource,
   RegistrationStatus,
   SchoolPhase,
-  ScreenOutcome,
+  ScreenStatus,
   SessionPresets,
   SessionType,
   UploadType,
@@ -392,41 +392,41 @@ context.instructions = {}
 context.vaccinations = {}
 for (const patientSession of Object.values(context.patientSessions)) {
   // Screen answers to health questions
-  if (patientSession.screen === ScreenOutcome.NeedsTriage) {
+  if (patientSession.screen === ScreenStatus.NeedsTriage) {
     // Get triage notes
     for (const response of patientSession.responsesWithTriageNotes) {
       const triaged = faker.datatype.boolean(0.5)
       if (triaged) {
         let outcome = faker.helpers.weightedArrayElement([
-          { value: ScreenOutcome.NeedsTriage, weight: 4 },
-          { value: ScreenOutcome.InvitedToClinic, weight: 1 },
-          { value: ScreenOutcome.DelayVaccination, weight: 1 },
-          { value: ScreenOutcome.DoNotVaccinate, weight: 1 },
-          { value: ScreenOutcome.Vaccinate, weight: 2 }
+          { value: ScreenStatus.NeedsTriage, weight: 4 },
+          { value: ScreenStatus.InvitedToClinic, weight: 1 },
+          { value: ScreenStatus.DelayVaccination, weight: 1 },
+          { value: ScreenStatus.DoNotVaccinate, weight: 1 },
+          { value: ScreenStatus.Vaccinate, weight: 2 }
         ])
 
         // For programmes that offer alternative vaccine methods, we use
         // screening outcomes specific to each vaccine method
-        if (outcome === ScreenOutcome.Vaccinate) {
+        if (outcome === ScreenStatus.Vaccinate) {
           if (patientSession.programme.alternativeVaccine) {
             outcome = patientSession.hasConsentForAlternativeInjectionOnly
               ? patientSession.programme.type === ProgrammeType.Flu
-                ? ScreenOutcome.VaccinateAlternativeFluInjectionOnly
-                : ScreenOutcome.VaccinateAlternativeMMRInjectionOnly
-              : ScreenOutcome.VaccinateIntranasalOnly
+                ? ScreenStatus.VaccinateAlternativeFluInjectionOnly
+                : ScreenStatus.VaccinateAlternativeMMRInjectionOnly
+              : ScreenStatus.VaccinateIntranasalOnly
           }
         }
 
         let note = response.triageNote
 
         switch (outcome) {
-          case ScreenOutcome.NeedsTriage:
+          case ScreenStatus.NeedsTriage:
             note = 'Keep in triage until can contact GP.'
             break
-          case ScreenOutcome.DelayVaccination:
+          case ScreenStatus.DelayVaccination:
             note = 'Delay vaccination until later session.'
             break
-          case ScreenOutcome.DoNotVaccinate:
+          case ScreenStatus.DoNotVaccinate:
             note = 'Decided to not vaccinate at this time.'
             break
         }
@@ -467,10 +467,10 @@ for (const patientSession of Object.values(context.patientSessions)) {
   // Add vaccination outcome
   if (session.isCompleted) {
     // Ensure any outstanding triage has been completed
-    if (patientSession.screen === ScreenOutcome.NeedsTriage) {
+    if (patientSession.screen === ScreenStatus.NeedsTriage) {
       // 4️⃣ SCREEN with triage outcome (final)
       patientSession.patientProgramme.recordTriage({
-        outcome: ScreenOutcome.Vaccinate,
+        outcome: ScreenStatus.Vaccinate,
         note: 'Spoke to GP, safe to vaccinate.',
         createdAt: removeDays(session.date, 2),
         createdBy_uid: nurse.uid


### PR DESCRIPTION
- `RegistrationOutcome` → `RegistrationStatus`
- `InstructionOutcome` → `InstructionStatus`
- `ConsentOutcome` → `ConsentStatus`
- `ScreenOutcome` → `ScreenStatus`

And assorted other changes to align with these updated names.

`VaccinationOutcome` remains, pending a larger refactor to align with the changes happening in production for session outcomes.