### PR TITLE
Help teams find children who can be offered more vaccinations in a clinic session

### DIFF
--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -380,7 +380,8 @@ export const sessionController = {
    */
   readPatientSessions(request, response, next) {
     const { view } = request.params
-    const { additional, option, q, programme_id, yearGroup } = request.query
+    const { canBeOfferedCatchUps, option, q, programme_id, yearGroup } =
+      request.query
     const { data } = request.session
     const { account, session } = response.locals
 
@@ -499,10 +500,9 @@ export const sessionController = {
     }
 
     // Remove patients that don't have any additional catch-up vaccinations they can be offered
-    if (additional) {
+    if (canBeOfferedCatchUps) {
       results = results.filter(
-        ({ canBeOfferedAdditionalProgrammes }) =>
-          canBeOfferedAdditionalProgrammes
+        ({ canBeOfferedCatchUps }) => canBeOfferedCatchUps
       )
     }
 
@@ -623,7 +623,7 @@ export const sessionController = {
       request,
       ['clinicStatus', 'instruct', 'q', 'register', 'status'],
       [
-        'additional',
+        'canBeOfferedCatchUps',
         'option',
         'patientConsent',
         'patientDeferred',

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -4,7 +4,6 @@ import _ from 'lodash'
 import {
   AcademicYear,
   InstructionStatus,
-  PatientClinicStatus,
   PatientStatus,
   ProgrammeType,
   RecordVaccineCriteria,
@@ -501,24 +500,10 @@ export const sessionController = {
 
     // Remove patients that don't have any additional catch-up vaccinations they can be offered
     if (additional) {
-      results = results.filter((patientSession) => {
-        const bookedProgramme_ids = patientSession.siblingPatientSessions.map(
-          (sibling) => sibling.programme_id
-        )
-        const offerProgramme_ids = Object.values(
-          patientSession.patient.activeProgrammes
-        )
-          .filter((programme) =>
-            [PatientClinicStatus.Ready, PatientClinicStatus.Invited].includes(
-              String(programme.clinicStatus)
-            )
-          )
-          .map((programme) => programme.programme_id)
-
-        return offerProgramme_ids.some(
-          (id) => !bookedProgramme_ids.includes(id)
-        )
-      })
+      results = results.filter(
+        ({ canBeOfferedAdditionalProgrammes }) =>
+          canBeOfferedAdditionalProgrammes
+      )
     }
 
     // Remove patient sessions where outcome returns false

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -4,6 +4,7 @@ import _ from 'lodash'
 import {
   AcademicYear,
   InstructionStatus,
+  PatientClinicStatus,
   PatientStatus,
   ProgrammeType,
   RecordVaccineCriteria,
@@ -380,7 +381,7 @@ export const sessionController = {
    */
   readPatientSessions(request, response, next) {
     const { view } = request.params
-    const { option, q, programme_id, yearGroup } = request.query
+    const { additional, option, q, programme_id, yearGroup } = request.query
     const { data } = request.session
     const { account, session } = response.locals
 
@@ -498,7 +499,29 @@ export const sessionController = {
       }
     }
 
-    // Remove patient sessions where status returns false
+    // Remove patients that don't have any additional catch-up vaccinations they can be offered
+    if (additional) {
+      results = results.filter((patientSession) => {
+        const bookedProgramme_ids = patientSession.siblingPatientSessions.map(
+          (sibling) => sibling.programme_id
+        )
+        const offerProgramme_ids = Object.values(
+          patientSession.patient.activeProgrammes
+        )
+          .filter((programme) =>
+            [PatientClinicStatus.Ready, PatientClinicStatus.Invited].includes(
+              String(programme.clinicStatus)
+            )
+          )
+          .map((programme) => programme.programme_id)
+
+        return offerProgramme_ids.some(
+          (id) => !bookedProgramme_ids.includes(id)
+        )
+      })
+    }
+
+    // Remove patient sessions where outcome returns false
     results = results.filter((patientSession) => patientSession[view] !== false)
 
     // Only show patients ready to vaccinate, and that a user can vaccinate
@@ -615,6 +638,7 @@ export const sessionController = {
       request,
       ['clinicStatus', 'instruct', 'q', 'register', 'status'],
       [
+        'additional',
         'option',
         'patientConsent',
         'patientDeferred',

--- a/app/globals.js
+++ b/app/globals.js
@@ -426,6 +426,11 @@ export default () => {
         key: 'patientRefused',
         value: PatientRefusedStatus.Conflict
       },
+      offerCatchUps: {
+        view: 'patients',
+        key: 'canBeOfferedCatchUps',
+        value: true
+      },
       instruct: {
         view: 'instruct',
         key: 'instruct',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2256,6 +2256,9 @@ export const en = {
     },
     clinicAttendanceType: {
       label: 'Attendance type'
+    },
+    additionalProgrammes: {
+      label: 'Can also offer'
     }
   },
   pdsRecord: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2987,6 +2987,11 @@ export const en = {
         count:
           '{count, plural, =0 {No children} one {# child} other {# children}} with conflicting consent'
       },
+      offerCatchUps: {
+        label: 'Offer catch-ups',
+        count:
+          '{count, plural, =0 {No children} one {# child} other {# children}} can be offered additional vaccinations'
+      },
       instruct: {
         label: 'PSD review needed',
         count:

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2988,7 +2988,7 @@ export const en = {
           '{count, plural, =0 {No children} one {# child} other {# children}} with conflicting consent'
       },
       offerCatchUps: {
-        label: 'Offer catch-ups',
+        label: 'Offer additional vaccinations',
         count:
           '{count, plural, =0 {No children} one {# child} other {# children}} can be offered additional vaccinations'
       },

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -346,6 +346,40 @@ export class PatientSession extends BaseModel {
   }
 
   /**
+   * Is the patient booked into clinic for only a subset of the programmes they can be vaccinated for at clinic?
+   *
+   * @returns {boolean} true if can be offered other vaccinations, or false otherwise
+   */
+  get canBeOfferedAdditionalProgrammes() {
+    return this.additionalProgrammesToOffer.length > 0
+  }
+
+  /**
+   * Get any extra programmes that can be offered at clinic beyond what's already planned
+   *
+   * @returns {Array<PatientProgramme>} the additional programmes that can be offered
+   */
+  get additionalProgrammesToOffer() {
+    if (this.session.type !== SessionType.Clinic) {
+      return []
+    }
+
+    const bookedProgramme_ids = this.siblingPatientSessions.map(
+      (sibling) => sibling.programme_id
+    )
+    const programmesToOffer = Object.values(
+      this.patient.activeProgrammes
+    ).filter(
+      (patientProgramme) =>
+        [PatientClinicStatus.Ready, PatientClinicStatus.Invited].includes(
+          String(patientProgramme.clinicStatus)
+        ) && !bookedProgramme_ids.includes(patientProgramme.programme_id)
+    )
+
+    return programmesToOffer
+  }
+
+  /**
    * Get related patient sessions
    *
    * @returns {Array<PatientSession>|undefined} Patient sessions

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -350,7 +350,7 @@ export class PatientSession extends BaseModel {
    *
    * @returns {boolean} true if can be offered other vaccinations, or false otherwise
    */
-  get canBeOfferedAdditionalProgrammes() {
+  get canBeOfferedCatchUps() {
     return this.additionalProgrammesToOffer.length > 0
   }
 

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -840,6 +840,18 @@ export class PatientSession extends BaseModel {
               )
               return filters.formatList(outstanding)
             }
+            case 'additionalProgrammesToOffer': {
+              const additionalProgrammesToOffer =
+                this.additionalProgrammesToOffer
+              return additionalProgrammesToOffer.length
+                ? additionalProgrammesToOffer
+                    .map(
+                      (patientProgramme) =>
+                        patientProgramme.formatted.programmeStatus
+                    )
+                    .join('<br>')
+                : undefined
+            }
             case 'vaccineCriteria':
               return formatVaccineCriteria(this.vaccineCriteria)
             case 'yearGroup': {

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -80,6 +80,23 @@
       decorate: "clinicStatus"
     }) if not params.hideClinicStatuses }}
 
+    {{ checkboxes({
+      fieldset: {
+        legend: {
+          text: "Additional programmes",
+          size: "s"
+        }
+      },
+      small: true,
+      items: [
+      {
+        text: 'Can be offered additional vaccinations',
+        value: true
+      }
+      ],
+      decorate: "additional"
+    }) if params.showAdditionalProgrammes }}
+
     {% for name, enums in params.checkboxFilters %}
       {{ checkboxes({
         fieldset: {

--- a/app/views/_macros/patient-search.njk
+++ b/app/views/_macros/patient-search.njk
@@ -94,7 +94,7 @@
         value: true
       }
       ],
-      decorate: "additional"
+      decorate: "canBeOfferedCatchUps"
     }) if params.showAdditionalProgrammes }}
 
     {% for name, enums in params.checkboxFilters %}

--- a/app/views/session/_session-activity-summary.njk
+++ b/app/views/session/_session-activity-summary.njk
@@ -36,6 +36,13 @@
   {% set sessionActivityRows = sessionActivityRows | push(sessionActivityRow("resolveConsent")) %}
 {% endif %}
 
+{% if session.type === SessionType.Clinic %}
+  {% set catchUpRow = sessionActivityRow("offerCatchUps") %}
+  {% if catchUpRow %}
+    {% set sessionActivityRows = sessionActivityRows | push(catchUpRow) %}
+  {% endif %}
+{% endif %}
+
 {% if sessionActivityRow("instruct") and session.hasPsdProtocol %}
   {% set sessionActivityRows = sessionActivityRows | push(sessionActivityRow("instruct")) %}
 {% endif %}

--- a/app/views/session/_session-activity-summary.njk
+++ b/app/views/session/_session-activity-summary.njk
@@ -1,41 +1,58 @@
 {% set sessionActivityRows = [] %}
 
-{% if session.type === SessionType.School and session.consents.length > 0 %}
-  {% set sessionActivityRows = sessionActivityRows | push(
-    {
-      key: {
-        text: __("session.activity.unmatchedConsent.label")
-      },
-      value: {
-        html: link(session.uri + "/consents", __mf("consent.count", { count: session.consents.length })) | nhsukMarkdown
-      }
-    }) %}
+{# Unmatched consent for school sessions #}
+{% if session.type === SessionType.School %}
+  {% set consents = session.consents %}
+  {% if consents.length > 0 %}
+    {% set sessionActivityRows = sessionActivityRows | push(
+      {
+        key: {
+          text: __("session.activity.unmatchedConsent.label")
+        },
+        value: {
+          html: link(session.uri + "/consents", __mf("consent.count", { count: consents.length })) | nhsukMarkdown
+        }
+      }) %}
+  {% endif %}
 {% endif %}
 
-{% if session.type === SessionType.Clinic and session.unmatchedAppointments.length > 0 %}
-  {% set sessionActivityRows = sessionActivityRows | push(
-    {
-      key: {
-        text: __("session.activity.unmatchedAppointments.label")
-      },
-      value: {
-        html: link(session.uri + "/unmatched-appointments", __mf("appointments.count.activity", { count: session.unmatchedAppointments.length })) | nhsukMarkdown
-      }
-    }) %}
+{# Unmatched appointments for clinic sessions #}
+{% if session.type === SessionType.Clinic %}
+  {% set unmatchedAppointments = session.unmatchedAppointments %}
+  {% if unmatchedAppointments.length > 0 %}
+    {% set sessionActivityRows = sessionActivityRows | push(
+      {
+        key: {
+          text: __("session.activity.unmatchedAppointments.label")
+        },
+        value: {
+          html: link(session.uri + "/unmatched-appointments", __mf("appointments.count.activity", { count: unmatchedAppointments.length })) | nhsukMarkdown
+        }
+      }) %}
+  {% endif %}
 {% endif %}
 
-{% if sessionActivityRow("getConsent") and session.school_id %}
-  {% set sessionActivityRows = sessionActivityRows | push(sessionActivityRow("getConsent")) %}
+{# No consent response #}
+{% if session.type === SessionType.School %}
+  {% set noConsentRow = sessionActivityRow("getConsent") %}
+  {% if noConsentRow %}
+    {% set sessionActivityRows = sessionActivityRows | push(noConsentRow) %}
+  {% endif %}
 {% endif %}
 
-{% if sessionActivityRow("followUp") %}
-  {% set sessionActivityRows = sessionActivityRows | push(sessionActivityRow("followUp")) %}
+{# Consent follow-up requested #}
+{% set followUpRow = sessionActivityRow("followUp") %}
+{% if followUpRow %}
+  {% set sessionActivityRows = sessionActivityRows | push(followUpRow) %}
 {% endif %}
 
-{% if sessionActivityRow("resolveConsent") %}
-  {% set sessionActivityRows = sessionActivityRows | push(sessionActivityRow("resolveConsent")) %}
+{# Conflicting consent #}
+{% set resolveConsentRow = sessionActivityRow("resolveConsent") %}
+{% if resolveConsentRow %}
+  {% set sessionActivityRows = sessionActivityRows | push(resolveConsentRow) %}
 {% endif %}
 
+{# Can offer additional catch-up vaccinations #}
 {% if session.type === SessionType.Clinic %}
   {% set catchUpRow = sessionActivityRow("offerCatchUps") %}
   {% if catchUpRow %}
@@ -43,12 +60,20 @@
   {% endif %}
 {% endif %}
 
-{% if sessionActivityRow("instruct") and session.hasPsdProtocol %}
-  {% set sessionActivityRows = sessionActivityRows | push(sessionActivityRow("instruct")) %}
+{# PSD review needed #}
+{% if session.hasPsdProtocol %}
+  {% set psdReviewRow = sessionActivityRow("instruct") %}
+  {% if psdReviewRow %}
+    {% set sessionActivityRows = sessionActivityRows | push(psdReviewRow) %}
+  {% endif %}
 {% endif %}
 
-{% if sessionActivityRow("record") and session.isActive %}
-  {% set sessionActivityRows = sessionActivityRows | push(sessionActivityRow("record")) %}
+{# Ready for vaccinator #}
+{% if session.isActive %}
+  {% set readyToVaccinateRow = sessionActivityRow("record") %}
+  {% if readyToVaccinateRow %}
+    {% set sessionActivityRows = sessionActivityRows | push(readyToVaccinateRow) %}
+  {% endif %}
 {% endif %}
 
 {% if sessionActivityRows.length > 0 or session.isCompleted %}

--- a/app/views/session/patients.njk
+++ b/app/views/session/patients.njk
@@ -82,9 +82,15 @@
           }) }}
         {% endif %}
 
+        {% if data.programme_id %}
+          {% set ids = data.programme_id %}
+        {% else %}
+          {# TODO: For clinics, show union of booked and targeted programmes #}
+          {% set ids = session.programme_ids %}
+        {% endif %}
+
         {% for patientSession in results.page %}
           {% set statusHtml %}
-            {% set ids = data.programme_id or session.programme_ids %}
             {% for patientSession in patientSession.siblingPatientSessions %}
               {% if ids | includes(patientSession.programme_id) %}
                 {{ patientSession.formatted.status | nhsukMarkdown }}
@@ -93,7 +99,6 @@
           {% endset %}
 
           {% set consentStatusHtml -%}
-            {% set ids = data.programme_id or session.programme_ids %}
             {% for patientSession in patientSession.siblingPatientSessions %}
               {% if ids | includes(patientSession.programme_id) %}
                 {{ patientSession.formatted.programmeConsent | nhsukMarkdown }}

--- a/app/views/session/patients.njk
+++ b/app/views/session/patients.njk
@@ -26,7 +26,7 @@
           hideClinicStatuses: true,
           hidePatientIneligibleStatus: true,
           hideProgrammeStatuses: account.isSchoolUser,
-          showAdditionalProgrammes: session.type === SessionType.Clinic and (session.isPlanned or session.isActive) and view === 'report',
+          showAdditionalProgrammes: session.type === SessionType.Clinic and (session.isPlanned or session.isActive) and view === 'patients',
           view: view
         }) }}
       </app-auto-submit>
@@ -140,6 +140,10 @@
                   label: __("patientSession.consent.label") if account.isSchoolUser else __("patientSession.status.label"),
                   value: consentStatusHtml if account.isSchoolUser else statusHtml
                 } if view != "instruct",
+                additionalProgrammes: {
+                  label: __("patientSession.additionalProgrammes.label"),
+                  value: patientSession.formatted.additionalProgrammesToOffer
+                },
                 clinicAppointment: {
                   label: __("patientSession.clinicAppointment.label"),
                   value: patientSession.clinicAppointment.formatted.timeSlot

--- a/app/views/session/patients.njk
+++ b/app/views/session/patients.njk
@@ -26,6 +26,7 @@
           hideClinicStatuses: true,
           hidePatientIneligibleStatus: true,
           hideProgrammeStatuses: account.isSchoolUser,
+          showAdditionalProgrammes: session.type === SessionType.Clinic and (session.isPlanned or session.isActive) and view === 'report',
           view: view
         }) }}
       </app-auto-submit>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 export interface PatientFilterQuery {
-  additional?: string
+  canBeOfferedCatchUps?: string
   clinicStatus?: string
   consent?: string
   instruct?: string

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,5 @@
 export interface PatientFilterQuery {
+  additional?: string
   clinicStatus?: string
   consent?: string
   instruct?: string


### PR DESCRIPTION
Two key changes:
 - Add the ability to filter the Children in session and Record vaccination lists to show those children who can be vaccinated at clinic for more than they're currently booked in for
 - Add a line to the Action required card on the session overview tab, alerting the user to the possibility of offering relevant children additional vaccinations, and linking to the new filter

This is design work for [MAV-11208 Finding and adding catch-up vaccinations to an appointment](https://nhsd-jira.digital.nhs.uk/browse/MAV-13418)

The new filter, shown only for scheduled and active clinic sessions:
<img width="1128" height="1037" alt="image" src="https://github.com/user-attachments/assets/aa2bdc7b-30ec-4856-aed7-eb0d1993402d" />

The new entry in the Action required card:
<img width="1128" height="1174" alt="image" src="https://github.com/user-attachments/assets/c964f16f-518c-4e73-84fd-2162c681edde" />
