### PR TITLE
Fix adding PSD instructions

### DIFF
--- a/app/controllers/patient-programme.js
+++ b/app/controllers/patient-programme.js
@@ -1,6 +1,5 @@
 import { ProgrammeType, VaccinationOutcome } from '../enums.js'
 import {
-  Instruction,
   PatientProgramme,
   Patient,
   Vaccination,
@@ -128,23 +127,17 @@ export const patientProgrammeController = {
     const { __, account, patientProgramme } = response.locals
 
     if (triage.psd) {
-      const instruction = Instruction.create(
-        {
-          createdBy_uid: account.uid,
-          programme_id: patientProgramme.programme.id,
-          patient_uuid: patientProgramme.patient.uuid
-        },
-        data
-      )
-
-      patientProgramme.giveInstruction(instruction)
+      patientProgramme.giveInstruction({
+        createdBy_uid: account.uid,
+        programme_id: patientProgramme.programme.id
+      })
     }
 
     patientProgramme.recordTriage({
+      createdBy_uid: account.uid,
       status: triage.status,
       statusInvalidAt_: triage.statusInvalidAt_,
-      note: triage.note,
-      createdBy_uid: account.uid
+      note: triage.note
     })
 
     // Clean up session data

--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -17,7 +17,6 @@ import {
   Clinic,
   ClinicBooking,
   DefaultBatch,
-  Instruction,
   PatientSession,
   Patient,
   Programme,
@@ -1058,16 +1057,10 @@ export const sessionController = {
       .filter(({ instruct }) => instruct === InstructionStatus.Needed)
 
     for (const patientSession of patientsToInstruct) {
-      const instruction = Instruction.create(
-        {
-          createdBy_uid: account.uid,
-          programme_id: patientSession.programme.id,
-          patientSession_uuid: patientSession.uuid
-        },
-        data
-      )
-
-      patientSession.patientProgramme.giveInstruction(instruction)
+      patientSession.patientProgramme.giveInstruction({
+        createdBy_uid: account.uid,
+        programme_id: patientSession.programme.id
+      })
 
       PatientSession.update(patientSession.uuid, patientSession, data)
     }

--- a/app/data.js
+++ b/app/data.js
@@ -2,7 +2,6 @@ import batches from '../.data/batches.json' with { type: 'json' }
 import clinicBookings from '../.data/clinic-bookings.json' with { type: 'json' }
 import clinics from '../.data/clinics.json' with { type: 'json' }
 import contacts from '../.data/contacts.json' with { type: 'json' }
-import instructions from '../.data/instructions.json' with { type: 'json' }
 import moves from '../.data/moves.json' with { type: 'json' }
 import notices from '../.data/notices.json' with { type: 'json' }
 import patientSessions from '../.data/patient-sessions.json' with { type: 'json' }
@@ -35,7 +34,6 @@ const data = {
   contacts,
   defaultBatches: {},
   downloads: {},
-  instructions,
   moves,
   notices,
   patients,

--- a/app/generators/instruction.js
+++ b/app/generators/instruction.js
@@ -4,22 +4,20 @@ import { Instruction } from '../models.js'
 import { removeDays } from '../utils/date.js'
 
 /**
- * Generate fake instruction
+ * Generate fake PSD instruction
  *
- * @param {PatientSession} patientSession - Patient session
  * @param {Programme} programme - Programme
  * @param {Session} session - Session
  * @param {Array<User>} users - Users
- * @returns {Instruction} Instruction
+ * @returns {Instruction} PSD instruction
  */
-export function generateInstruction(patientSession, programme, session, users) {
+export function generateInstruction(programme, session, users) {
   const user = faker.helpers.arrayElement(users)
 
   return new Instruction({
     createdAt: removeDays(session.date, 7),
     createdBy_uid: user.uid,
-    programme_id: programme?.id,
-    patientSession_uuid: patientSession.uuid
+    programme_id: programme?.id
   })
 }
 

--- a/app/models/instruction.js
+++ b/app/models/instruction.js
@@ -1,6 +1,4 @@
-import { fakerEN_GB as faker } from '@faker-js/faker'
-
-import { Patient, Programme } from '../models.js'
+import { Programme } from '../models.js'
 
 import { BaseModel } from './base.js'
 
@@ -26,23 +24,15 @@ export class Instruction extends BaseModel {
     super(options, context)
 
     /** @type {string|undefined} */
-    this.patient_uuid
-
-    /** @type {Patient|undefined} */
-    this.patient
-
-    /** @type {string|undefined} */
     this.programme_id
 
     /** @type {Programme|undefined} */
     this.programme
 
     this.context = context
-    this.uuid = options?.uuid || faker.string.uuid()
   }
 }
 
-Instruction.relate('patient_uuid', () => Patient, 'patient')
 Instruction.relate('programme_id', () => Programme, 'programme')
 
 /**

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -65,12 +65,6 @@ export class PatientProgramme extends BaseModel {
     super(options, context)
 
     /** @type {string|undefined} */
-    this.instruction_uuid
-
-    /** @type {Patient|undefined} */
-    this.instruction
-
-    /** @type {string|undefined} */
     this.patient_uuid
 
     /** @type {Patient|undefined} */
@@ -461,6 +455,17 @@ export class PatientProgramme extends BaseModel {
   }
 
   /**
+   * Get PSD instruction
+   *
+   * @returns {Instruction|undefined} PSD instruction
+   */
+  get instruction() {
+    return this.patient?.instructions.find(
+      (instruction) => instruction.programme_id === this.programme_id
+    )
+  }
+
+  /**
    * Get vaccination outcomes
    *
    * @returns {Array<Vaccination>|undefined} Vaccinations
@@ -818,10 +823,10 @@ export class PatientProgramme extends BaseModel {
   /**
    * Give PSD instruction
    *
-   * @param {Instruction} instruction - Instruction
+   * @param {Partial<Instruction>} instruction - Instruction
    */
   giveInstruction(instruction) {
-    this.instruction_uuid = instruction.uuid
+    this.patient?.addInstruction(instruction)
 
     this.patient?.addEvent({
       name: activity.psd.added,
@@ -878,7 +883,6 @@ export class PatientProgramme extends BaseModel {
   }
 }
 
-PatientProgramme.relate('instruction_uuid', () => Instruction, 'instruction')
 PatientProgramme.relate('patient_uuid', () => Patient, 'patient')
 PatientProgramme.relate('programme_id', () => Programme, 'programme')
 

--- a/app/models/patient.js
+++ b/app/models/patient.js
@@ -21,6 +21,7 @@ import {
   Child,
   ClinicAppointment,
   Contact,
+  Instruction,
   Move,
   PatientProgramme,
   PatientSession,
@@ -62,10 +63,11 @@ import {
  * @property {ArchiveRecordReason} [archiveReason] - Archival reason
  * @property {string} [archiveReasonOther] - Other archival reason
  * @property {Array<AuditEvent>} [events] - Events
+ * @property {Array<Instruction>} [instructions] - PSD instruction UUIDs
  * @property {Array<string>} [clinicProgramme_ids] - Clinic programme invitations
- * @property {Array<string>} [reply_uuids] - Reply IDs
- * @property {Array<string>} [contact_uuids] - Contact UUIDS
+ * @property {Array<string>} [contact_uuids] - Contact UUIDs
  * @property {Array<string>} [patientSession_uuids] - Patient session IDs
+ * @property {Array<string>} [reply_uuids] - Reply IDs
  * @property {Array<string>} [vaccination_uuids] - Vaccination UUIDs
  */
 
@@ -98,10 +100,11 @@ export class Patient extends Child {
     this.pendingChanges = options?.pendingChanges || {}
 
     this.events = options?.events || []
+    this.instructions = options?.instructions || []
     this.clinicProgramme_ids = stringToArray(options?.clinicProgramme_ids)
-    this.reply_uuids = stringToArray(options?.reply_uuids)
     this.contact_uuids = stringToArray(options?.contact_uuids)
     this.patientSession_uuids = stringToArray(options?.patientSession_uuids)
+    this.reply_uuids = stringToArray(options?.reply_uuids)
     this.vaccination_uuids = stringToArray(options?.vaccination_uuids)
   }
 
@@ -456,7 +459,7 @@ export class Patient extends Child {
   /**
    * Get clinic appointments
    *
-   * @returns {Array<ClinicAppointment>} appointments
+   * @returns {Array<ClinicAppointment>} Appointments
    */
   get appointments() {
     return ClinicAppointment.findAll(this.context).filter(
@@ -723,15 +726,6 @@ export class Patient extends Child {
   }
 
   /**
-   * Add event to activity log
-   *
-   * @param {object} event - Event
-   */
-  addEvent(event) {
-    this.events.push(new AuditEvent(event))
-  }
-
-  /**
    * Add updates to activity log
    *
    * @param {Patient} before - Original values
@@ -762,6 +756,24 @@ export class Patient extends Child {
       name: activity.patient.contact(contact),
       type: AuditEventType.Record
     })
+  }
+
+  /**
+   * Add event to activity log
+   *
+   * @param {Partial<AuditEvent>} event - Event
+   */
+  addEvent(event) {
+    this.events.push(new AuditEvent(event))
+  }
+
+  /**
+   * Add PSD instruction
+   *
+   * @param {Partial<Instruction>} instruction - PSD instruction
+   */
+  addInstruction(instruction) {
+    this.instructions.push(new Instruction(instruction))
   }
 
   /**

--- a/lib/create-data.js
+++ b/lib/create-data.js
@@ -48,7 +48,6 @@ import {
 import {
   Clinic,
   Gillick,
-  Instruction,
   Move,
   PatientSession,
   Patient,
@@ -388,7 +387,6 @@ for (const patientSession of Object.values(context.patientSessions)) {
 }
 
 // Screen and record
-context.instructions = {}
 context.vaccinations = {}
 for (const patientSession of Object.values(context.patientSessions)) {
   // Screen answers to health questions
@@ -450,14 +448,7 @@ for (const patientSession of Object.values(context.patientSessions)) {
     const canInstruct = patientSession.status !== PatientStatus.Triage
 
     if (session.hasPsdProtocol && canInstruct) {
-      let instruction = generateInstruction(
-        patientSession,
-        programme,
-        session,
-        nurses
-      )
-      instruction = new Instruction(instruction, context)
-      context.instructions[instruction.uuid] = instruction
+      const instruction = generateInstruction(programme, session, nurses)
 
       // GIVE INSTRUCTION for PSD
       patientSession.patientProgramme.giveInstruction(instruction)
@@ -765,7 +756,6 @@ generateDataFile('.data/batches.json', context.batches)
 generateDataFile('.data/clinic-bookings.json', context.clinicBookings)
 generateDataFile('.data/clinics.json', context.clinics)
 generateDataFile('.data/contacts.json', context.contacts)
-generateDataFile('.data/instructions.json', context.instructions)
 generateDataFile('.data/moves.json', context.moves)
 generateDataFile('.data/notices.json', context.notices)
 generateDataFile('.data/patients.json', context.patients)


### PR DESCRIPTION
A side-effect of #379 is that, unlike `PatientSession`, a `PatientProgramme` is a set of properties inferred from `Patient`, meaning we can’t store or update values directly upon it.

This PR moves instructions to the `Patient` model, and uses the same set up used for `AuditEvent`s (objects stored directly on the patient object as opposed to a separate store in session data).