### PR TITLE
Update session protocol options and allow nurses to record another nurse as administering

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -7,15 +7,16 @@ import {
   PreScreenQuestion,
   RegistrationStatus,
   SessionType,
-  UserRole,
   VaccinationOutcome,
   VaccinationProtocol,
+  VaccineCriteria,
   VaccineMethod
 } from '../enums.js'
 import {
   ClinicBooking,
   PatientSession,
   Programme,
+  User,
   Vaccination
 } from '../models.js'
 import { today } from '../utils/date.js'
@@ -29,12 +30,21 @@ export const patientSessionController = {
   read(request, response, next, nhsn) {
     const { programme_id, session_id } = request.params
     const { __, account } = response.locals
+    const { data } = request.session
 
-    const patientSession = PatientSession.findAll(request.session.data).find(
+    const patientSession = PatientSession.findAll(data).find(
       (patientSession) =>
         patientSession.session_id === session_id &&
         patientSession.programme_id === programme_id &&
         patientSession.patient.nhsn === nhsn
+    )
+
+    const registeredNurseUsers = User.findAll(data).filter(
+      (user) => user.isRegisteredNurse
+    )
+
+    const allVaccinatingUsers = User.findAll(data).filter(
+      (user) => user.canVaccinate
     )
 
     const {
@@ -61,25 +71,23 @@ export const patientSessionController = {
       (patientProgramme) => patientProgramme.programme_id === programme_id
     )
 
-    // PSD protocol
-    // Nurses can record all vaccines
-    // HCAs can only record nasal sprays for children with a PSD
-    const userIsHCA = account.role === UserRole.HCA
     const patientHasPsd = patientSession.instruct === InstructionStatus.Given
-    if (userIsHCA && !patientHasPsd) {
-      // Remove permissions for HCAs as patient doesn’t have a PSD
-      account.vaccineMethods = []
-    }
 
-    // VGD protocol
-    // Nurses can record all vaccines
-    // HCAs can record all vaccines (but must record practitioner)
-    if (userIsHCA && session.fluProtocol === VaccinationProtocol.VGD) {
-      // Remove permissions for HCAs as patient doesn’t have a PSD
-      account.vaccineMethods = [
-        VaccineMethod.Injection,
-        VaccineMethod.Intranasal
-      ]
+    let vaccineMethods = []
+
+    // Nurses can record all vaccines under any protocol
+    if (account.isRegisteredNurse) {
+      vaccineMethods = [VaccineMethod.Injection, VaccineMethod.Intranasal]
+    } else if (account.isHealthcareAssistant) {
+      // HCAs can record all vaccines under VGD
+      if (session.protocolHCA === VaccinationProtocol.VGD) {
+        vaccineMethods = [VaccineMethod.Injection, VaccineMethod.Intranasal]
+      }
+
+      // HCAs can record only nasal vaccines under PSD
+      if (session.protocolHCA === VaccinationProtocol.PSD) {
+        vaccineMethods = patientHasPsd ? [VaccineMethod.Intranasal] : []
+      }
     }
 
     response.locals.options = {
@@ -93,20 +101,26 @@ export const patientSessionController = {
         consent === ConsentStatus.NoResponse,
       // Perform Gillick assessment
       canGillick:
-        session.isActive && !vaccinated && !consentGiven && !userIsHCA,
+        account.isRegisteredNurse &&
+        session.isActive &&
+        !vaccinated &&
+        !consentGiven,
       // Perform triage
-      canTriage: !userIsHCA,
+      canTriage: account.isRegisteredNurse,
       // Patient needs triage
       needsTriage: status === PatientStatus.Triage,
       // Patient already triaged
       hasTriage: triageNotes.length > 0,
-      hasInstruct: session.hasPsdProtocol && patientSession.instruct,
-      userIsHCA,
+      hasInstruct:
+        session.protocolHCA === VaccinationProtocol.PSD &&
+        patientSession.instruct,
       canRegister: session.hasRegistration && session.isActive,
       canRecord:
-        account.vaccineMethods?.includes(patientSession.vaccine?.method) &&
+        vaccineMethods?.includes(patientSession.vaccine?.method) &&
         patientSession.canRecordOutcome &&
-        session.isActive
+        session.isActive,
+      canRecordInjectionSite:
+        patientSession.vaccine?.criteria !== VaccineCriteria.Intranasal
     }
 
     // Vaccinator has permission to record using the alternative vaccine
@@ -157,6 +171,8 @@ export const patientSessionController = {
     response.locals.programme = programme
     response.locals.session = session
     response.locals.clinicAppointment = clinicAppointment
+    response.locals.registeredNurseUsers = registeredNurseUsers
+    response.locals.allVaccinatingUsers = allVaccinatingUsers
 
     // Use different values for pre-screening questions
     // `IsWell` and `IsPregnant` should persist per patient

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -3,7 +3,6 @@ import wizard from '@x-govuk/govuk-prototype-wizard'
 import {
   VaccinationMethod,
   VaccinationOutcome,
-  VaccinationProtocol,
   VaccinationSite,
   VaccineCriteria,
   UserRole,
@@ -93,9 +92,10 @@ export const vaccinationController = {
       String(patientSession_uuid),
       data
     )
-    const { session, programme, vaccine, instruction } = patientSession
+    const { session, programme, vaccine } = patientSession
     const { identifiedBy, injectionSite, ready, hasSelfIdentified } =
       data.preScreen
+    const administeredBy_uid = data.preScreen?.administeredBy_uid || account.uid
     const assessedBy_uid = data.preScreen?.assessedBy_uid
 
     // Check for default batch
@@ -135,14 +135,8 @@ export const vaccinationController = {
     const role = account.role || UserRole.Nurse
 
     // Flu programme can have PGD or VGD as protocol
-    let protocol = session.fluProtocol || VaccinationProtocol.PGD
-
-    // HCAs uses different protocol depending on vaccine and programme
-    if (role === UserRole.HCA) {
-      if (session.hasPsdProtocol && instruction) {
-        protocol = VaccinationProtocol.PSD
-      }
-    }
+    const protocol =
+      role === UserRole.HCA ? session.protocolHCA : session.protocolNurse
 
     const vaccination = Vaccination.create(
       {
@@ -157,7 +151,7 @@ export const vaccinationController = {
         createdAt: today(),
         createdBy_uid: account.uid,
         administeredAt: today(),
-        administeredBy_uid: account.uid,
+        administeredBy_uid,
         ...(injectionSite && {
           dose: vaccine.dose,
           injectionMethod: VaccinationMethod.Intramuscular,
@@ -387,6 +381,7 @@ export const vaccinationController = {
         })
 
       response.locals.userItems = User.findAll(data)
+        .filter((user) => user.canVaccinate)
         .map((user) => ({
           text: user.fullName,
           value: user.uid

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2373,8 +2373,12 @@ export const en = {
       }
     },
     assessedBy: {
-      label: 'Practitioner',
+      label: 'Assessed by',
       title: 'Which nurse identified and pre-screened the child'
+    },
+    administeredBy: {
+      label: 'Vaccinated by',
+      title: 'Who will vaccinate the child?'
     },
     check: {
       error:
@@ -2894,14 +2898,34 @@ export const en = {
       count:
         '{count, plural, =0 {no children for {programme}} one {# child for {programme}} other {# children for {programme}}}'
     },
-    fluProtocol: {
+    protocol: {
       label: 'Protocol',
-      title: 'Which protocol will you use for flu vaccinations in this session?'
+      title: 'Vaccination protocol'
     },
-    hasPsdProtocol: {
-      label: 'Use patient specific direction (PSD)',
-      title:
-        'Can healthcare assistants give the nasal spray vaccine using a patient specific direction (PSD)?'
+    protocolNurse: {
+      label: 'Protocol',
+      title: 'Which protocol will registered nurses use to vaccinate children?',
+      pgd: {
+        label: 'A patient group direction (PGD)'
+      },
+      vgd: {
+        label: 'A vaccine group direction (VGD)'
+      }
+    },
+    protocolHCA: {
+      label: 'Protocol for healthcare assistants',
+      title: 'Can healthcare assistants give vaccinations?',
+      no: {
+        label: 'No'
+      },
+      psd: {
+        label:
+          'Yes, the flu nasal spray vaccine under a patient specific direction (PSD)'
+      },
+      vgd: {
+        label:
+          'Yes, the flu nasal spray and injected vaccines under a vaccine group direction (VGD)'
+      }
     },
     'upload-class-list': {
       title: 'Upload class lists'

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -82,8 +82,8 @@ import { BaseModel } from './base.js'
  * @property {Date} [cancelledAt] - Date session cancelled
  * @property {number} [reminderWeeks] - Weeks before session to send reminders
  * @property {object} [register] - Patient register
- * @property {VaccinationProtocol} [fluProtocol] - Default protocol for flu programme
- * @property {boolean} [hasPsdProtocol] - Enable PSD protocol
+ * @property {VaccinationProtocol} [protocolNurse] - Default protocol for nurse
+ * @property {VaccinationProtocol} [protocolHCA] - Default protocol for HCA
  */
 
 /**
@@ -122,6 +122,7 @@ export class Session extends BaseModel {
     this.presetNames = stringToArray(options?.presetNames)
     this.cancelledAt = options?.cancelledAt && new Date(options.cancelledAt)
     this.hasRegistration = stringToBoolean(options?.hasRegistration)
+    this.register = options?.register || {}
 
     if (this.type === SessionType.Clinic) {
       this.vaccinationPeriods = options?.vaccinationPeriods
@@ -150,15 +151,9 @@ export class Session extends BaseModel {
 
     // Sessions administering the flu programme can use PGD or VGD protocol
     if (this.programme_ids.includes('flu')) {
-      this.fluProtocol = options?.fluProtocol || VaccinationProtocol.PGD
+      this.protocolNurse = options?.protocolNurse || VaccinationProtocol.PGD
+      this.protocolHCA = options?.protocolHCA || ''
     }
-
-    // PSD protocol can only be enabled if flu protocol is PGD
-    if (this.fluProtocol === VaccinationProtocol.PGD) {
-      this.hasPsdProtocol = stringToBoolean(options?.hasPsdProtocol) || false
-    }
-
-    this.register = options?.register || {}
   }
 
   /**
@@ -348,6 +343,27 @@ export class Session extends BaseModel {
    */
   get isPastSession() {
     return this.academicYear < getCurrentAcademicYear()
+  }
+
+  /**
+   * Does session need to support the PSD protocol?
+   *
+   * @returns {boolean} Session need to support the PSD protocol?
+   */
+  get hasPsdProtocol() {
+    return this.protocolHCA === VaccinationProtocol.PSD
+  }
+
+  /**
+   * Does session need to support the VGD protocol?
+   *
+   * @returns {boolean} Session need to support the VGD protocol?
+   */
+  get hasVgdProtocol() {
+    return (
+      this.protocolNurse === VaccinationProtocol.VGD ||
+      this.protocolHCA === VaccinationProtocol.VGD
+    )
   }
 
   /**

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,6 +1,6 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 
-import { UserRole, VaccineMethod } from '../enums.js'
+import { UserRole } from '../enums.js'
 import { formatCode, formatLink } from '../utils/string.js'
 
 import { BaseModel } from './base.js'
@@ -84,28 +84,30 @@ export class User extends BaseModel {
   }
 
   /**
-   * Set authorised vaccine methods
+   * User is a registered practitioner?
    *
-   * @param {Array<VaccineMethod>} methods - Vaccine methods
+   * @returns {boolean} User is a registered practitioner?
    */
-  set vaccineMethods(methods) {
-    this.vaccinations = methods
+  get isHealthcareAssistant() {
+    return this.role === UserRole.HCA
   }
 
   /**
-   * Get authorised vaccine methods
+   * User is a registered practitioner?
    *
-   * @returns {Array<VaccineMethod>} Vaccine methods
+   * @returns {boolean} User is a registered practitioner?
    */
-  get vaccineMethods() {
-    switch (true) {
-      case [UserRole.Nurse, UserRole.NursePrescriber].includes(this.role):
-        return [VaccineMethod.Injection, VaccineMethod.Intranasal]
-      case this.role === UserRole.HCA:
-        return [VaccineMethod.Intranasal]
-      default:
-        return []
-    }
+  get isRegisteredNurse() {
+    return [UserRole.Nurse, UserRole.NursePrescriber].includes(this.role)
+  }
+
+  /**
+   * User can vaccinate?
+   *
+   * @returns {boolean} User can vaccinate?
+   */
+  get canVaccinate() {
+    return this.isHealthcareAssistant || this.isRegisteredNurse
   }
 
   /**

--- a/app/views/patient-session/_record.njk
+++ b/app/views/patient-session/_record.njk
@@ -83,7 +83,7 @@
         message: __("preScreen.check.error")
       }
     }
-  }) }}
+  }) if account.isRegisteredNurse }}
 
   {{ textarea({
     label: { text: __("preScreen.note.label") + " (optional)" },

--- a/app/views/patient-session/_record.njk
+++ b/app/views/patient-session/_record.njk
@@ -91,15 +91,15 @@
     decorate: "preScreen.note"
   }) }}
 
-  {% if session.fluProtocol == VaccinationProtocol.VGD %}
+  {% if session.hasVgdProtocol %}
     {{ select({
       label: { text: __("preScreen.assessedBy.title") },
-      items: userItems(data.users, preScreen.assessedBy),
+      items: userItems(registeredNurseUsers, preScreen.assessedBy),
       decorate: "preScreen.assessedBy_uid",
       attributes: {
         "data-module": "app-autocomplete"
       }
-    }) if options.userIsHCA else input({
+    }) if not account.isRegisteredNurse else input({
       type: "hidden",
       value: account.uid,
       decorate: "preScreen.assessedBy_uid"
@@ -131,6 +131,23 @@
     }
   }) %}
 
+  {% set administeredByHtml = select({
+    label: { text: __("preScreen.administeredBy.title") },
+    items: userItems(allVaccinatingUsers, preScreen.assessedBy),
+    decorate: "preScreen.administeredBy_uid",
+    attributes: {
+      "data-module": "app-autocomplete"
+    }
+  }) %}
+
+  {% if session.hasVgdProtocol and account.isRegisteredNurse and options.canRecordInjectionSite %}
+    {% set preScreenReadyHtml = administeredByHtml + vaccinationSiteHtml %}
+  {% elif session.hasVgdProtocol and account.isRegisteredNurse %}
+    {% set preScreenReadyHtml = administeredByHtml %}
+  {% elif options.canRecordInjectionSite %}
+    {% set preScreenReadyHtml = vaccinationSiteHtml %}
+  {% endif %}
+
   {{ radios({
     fieldset: {
       legend: {
@@ -147,8 +164,8 @@
         text: __("preScreen.ready.yes"),
         value: true,
         conditional: {
-          html: vaccinationSiteHtml
-        } if patientSession.vaccine.criteria != VaccineCriteria.Intranasal
+          html: preScreenReadyHtml
+        } if preScreenReadyHtml
       },
       {
         text: __("preScreen.ready.no"),
@@ -161,7 +178,7 @@
         text: __("preScreen.ready.alternative"),
         value: "alternative",
         conditional: {
-          html: vaccinationSiteHtml
+          html: preScreenReadyHtml
         }
       } if canRecordAlternativeVaccine
     ],

--- a/app/views/session/edit.njk
+++ b/app/views/session/edit.njk
@@ -48,10 +48,10 @@
         hasRegistration: {
           href: session.uri + "/edit/registration"
         },
-        fluProtocol: {
+        protocolNurse: {
           href: session.uri + "/edit/protocol"
         },
-        hasPsdProtocol: {
+        protocolHCA: {
           href: session.uri + "/edit/protocol"
         }
       })

--- a/app/views/session/form/check-answers.njk
+++ b/app/views/session/form/check-answers.njk
@@ -43,10 +43,10 @@
         hasRegistration: {
           href: session.uri + "/new/registration"
         },
-        fluProtocol: {
+        protocolNurse: {
           href: session.uri + "/edit/protocol"
         },
-        hasPsdProtocol: {
+        protocolHCA: {
           href: session.uri + "/new/protocol"
         }
       })

--- a/app/views/session/form/protocol.njk
+++ b/app/views/session/form/protocol.njk
@@ -1,39 +1,47 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("session.fluProtocol.title") %}
+{% set title = __("session.protocol.title") %}
 
 {% block form %}
-  {% set conditionalHtml = {
-    html: radios({
-      fieldset: {
-        legend: {
-          text: __("session.hasPsdProtocol.title")
-        }
-      },
-      items: getBooleanItems(),
-      decorate: "session.hasPsdProtocol"
-    })
-  } %}
+  {{ appHeading({
+    caption: session.location.name,
+    title: title
+  }) }}
 
   {{ radios({
-    formGroup: {
-      classes: "nhsuk-u-margin-bottom-6"
-    },
     fieldset: {
       legend: {
-        classes: "nhsuk-fieldset__legend--l",
-        html: appHeading({
-          caption: session.location.name,
-          title: title
-        })
+        text: __("session.protocolNurse.title"),
+        size: "m"
       }
     },
     items: [{
-      text: VaccinationProtocol.PGD,
-      conditional: conditionalHtml
+      text: __("session.protocolNurse.pgd.label"),
+      value: VaccinationProtocol.PGD
     }, {
-      text: VaccinationProtocol.VGD
+      text: __("session.protocolNurse.vgd.label"),
+      value: VaccinationProtocol.VGD
     }],
-    decorate: "session.fluProtocol"
+    decorate: "session.protocolNurse"
+  }) }}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        text: __("session.protocolHCA.title"),
+        size: "m"
+      }
+    },
+    items: [{
+      text: __("session.protocolHCA.no.label"),
+      value: ""
+    }, {
+      text: __("session.protocolHCA.psd.label"),
+      value: VaccinationProtocol.PSD
+    }, {
+      text: __("session.protocolHCA.vgd.label"),
+      value: VaccinationProtocol.VGD
+    }],
+    decorate: "session.protocolHCA"
   }) }}
 {% endblock %}

--- a/app/views/session/show.njk
+++ b/app/views/session/show.njk
@@ -49,8 +49,8 @@
       consentForms: {},
       mmrConsent: {},
       hasRegistration: {},
-      fluProtocol: {},
-      hasPsdProtocol: {}
+      protocolNurse: {},
+      protocolHCA: {}
     } %}
     {% if session.type === SessionType.Clinic %}
       {% set sessionDetailsRows = {


### PR DESCRIPTION
Following on from #349, this PR:

- Updates the session options to give teams a little more flexibility on how they can set up the protocols used for sessions administering the 2026 to 2027 flu programme. Protocol options are now per user type, and means nurses can vaccinate under one protocol, and HCAs under either PSD or VGD
- For nurses recording a vaccination under VGD, they can now select another nurse who administered the vaccine. (Not reflected in the prototype) but the value for the administering user defaults to the logged in user, but reflects the last selected user thereafter.

## Session vaccination protocol options

<img width="2400" height="2292" alt="session-protocol" src="https://github.com/user-attachments/assets/a53a1376-c99c-42d5-8871-b7d47477d345" />

## Recording a vaccination under VGD

### HCAs no longer confirm they have checked the pre-screening statements

HCAs must still select which registered nurse identified and assessed the child, but we no longer ask them to confirm that they have checked the pre-screening statements, as that’s not their responsibility.

<img width="2400" height="2468" alt="patient-session-hca" src="https://github.com/user-attachments/assets/9b945e7c-3a13-4ca6-aeea-893aa959b158" />

## Nurses can now change who administered the vaccination

For nasal spray:

<p><img width="2400" height="2592" alt="patient-session-nurse" src="https://github.com/user-attachments/assets/d3eb811c-ad13-460c-a434-55a2cc8caa90" /></p>

For injection:

<p><img width="2400" height="2880" alt="patient-session-nurse-im" src="https://github.com/user-attachments/assets/a5cf69f1-15e8-434c-8e5d-fddfe1d17610" /></p>