### PR TITLE
Clinic status: drop the requirement for contact details so that teams can transfer bookings

### DIFF
--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -597,12 +597,14 @@ export const patientController = {
     // Invite each of the children to clinic for the subset of the selected programmes
     // that make sense for that child
     let invitedChildrenCount = 0
+    let notInvitedChildrenCount = 0
     for (const patient of clinicPatient_ids.map((id) =>
       Patient.findOne(id, data)
     )) {
       // Work out which of the selected programmes this patient was clinic-ready for
       const { clinicReadyProgramme_ids } = patient
       if (patient.hasNoContactDetails) {
+        notInvitedChildrenCount++
         continue
       }
 
@@ -621,12 +623,19 @@ export const patientController = {
       }
     }
 
-    request.flash(
-      'success',
-      __mf('patient.bulkInviteToClinic.success', {
-        count: invitedChildrenCount
-      })
-    )
+    // Report success (or otherwise)
+    const details = [
+      invitedChildrenCount > 0 &&
+        __mf('patient.bulkInviteToClinic.success.invited', {
+          count: invitedChildrenCount
+        }),
+      notInvitedChildrenCount > 0 &&
+        __mf('patient.bulkInviteToClinic.success.notInvited', {
+          count: notInvitedChildrenCount
+        })
+    ].filter(Boolean)
+    const messageType = invitedChildrenCount > 0 ? 'success' : 'message'
+    request.flash(messageType, details.join('<br>'))
 
     // Reset the cohort
     delete data.clinicPatient_ids

--- a/app/controllers/patient.js
+++ b/app/controllers/patient.js
@@ -602,6 +602,10 @@ export const patientController = {
     )) {
       // Work out which of the selected programmes this patient was clinic-ready for
       const { clinicReadyProgramme_ids } = patient
+      if (patient.hasNoContactDetails) {
+        continue
+      }
+
       const invitedProgramme_ids = [
         ...new Set(clinicReadyProgramme_ids).intersection(
           new Set(clinicProgramme_ids)

--- a/app/enums.js
+++ b/app/enums.js
@@ -418,7 +418,7 @@ export const PatientStatus = {
  * @enum {string}
  */
 export const PatientClinicStatus = {
-  Ready: 'Can be invited',
+  Ready: 'Eligible for clinic',
   Invited: 'Invited',
   Booked: 'Booked'
 }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1834,8 +1834,12 @@ export const en = {
       },
       confirm: 'Send clinic invitations',
       cancel: 'Go back to children list',
-      success:
-        '{count, plural, one {1 child has been invited to clinic} other {{count} children have been invited to clinic}}'
+      success: {
+        invited:
+          '{count, plural, one {1 child has been invited to clinic} other {{count} children have been invited to clinic}}',
+        notInvited:
+          '{count, plural, one {1 child could not be invited due to lack of contact details} other {{count} children could not be invited due to lack of contact details}}'
+      }
     },
     auditEvents: {
       label: 'Activity log'

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -245,8 +245,9 @@ export class PatientProgramme extends BaseModel {
     switch (status) {
       case PatientStatus.Ineligible:
         return false
-      case PatientStatus.Due:
+      case PatientStatus.Consent:
       case PatientStatus.Triage:
+      case PatientStatus.Due:
         return true
       case PatientStatus.Deferred: {
         switch (this.lastPatientSession?.patientDeferred) {
@@ -261,8 +262,6 @@ export class PatientProgramme extends BaseModel {
             return true
         }
       }
-      case PatientStatus.Consent:
-        return !this.patient?.hasNoContactDetails
       case PatientStatus.Refused: {
         const lastPatientSession = this.lastPatientSession
         if (!lastPatientSession) return false

--- a/app/views/book-into-a-clinic/form/contact.njk
+++ b/app/views/book-into-a-clinic/form/contact.njk
@@ -29,7 +29,7 @@
     {% include "book-into-a-clinic/form/_parental-relationship.njk" %}
 
     {{ input({
-      label: { text: __("clinicBooking.contact.email.label") },
+      label: { text: __("clinicBooking.contact.email.label") + ("" if isParentFacing else " (optional)") },
       hint: { text: __("clinicBooking.contact.email.hint") } if isParentFacing,
       decorate: "booking.contact.email"
     }) }}

--- a/app/views/patient/bulk-invite-to-clinic.njk
+++ b/app/views/patient/bulk-invite-to-clinic.njk
@@ -88,7 +88,7 @@
     {% endif %}
 
     {# Fake the user's selection of a checkbox for this one programme #}
-    <input type="hidden" id="clinicProgramme_ids" name="clinicProgramme_ids" value="{{clinicReadyProgrammes[0].programme_id}}" />
+    <input type="hidden" id="clinicProgramme_ids" name="clinicProgramme_ids" value="{{clinicReadyProgrammes[0].id}}" />
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
This relates to MAV-14212.

This renames the "Can be invited" clinic status to "Eligible for clinic" and makes it so that there's no requirement for contact details to be present for that status. During the clinics pilot SAIS teams had reported that this was a major blocker in them being able to add appointments that they were transferring from other systems. This change means that the "Book into a clinic" link can still appear in a child record and, during the team's booking process (but not the parent's), the email address field is optional.

For this PR, the changes to the feedback around the ability (or inability) to send an invite are _knowingly_ suboptimal — it would be better to warn before clicking send rather than reporting inability after doing so — but this change is a lighter touch that will allow faster implementation. The addition of a warning in the bulk invite page would have got messy, as other warnings can appear there too, and a multi-page flow might've been required instead.