### PR TITLE
Make `session_id` an optional property for consent responses

### DIFF
--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -209,12 +209,12 @@ export const replyController = {
       response.locals.reply = new Reply(reply, data)
 
       // Only ask for programme if more than 1 administered in a session
-      const isMultiProgrammeSession = reply?.session.programmes.length > 1
+      const isMultiProgrammeSession = reply?.session?.programmes.length > 1
       response.locals.isMultiProgrammeSession = isMultiProgrammeSession
 
       const programme = isMultiProgrammeSession
         ? reply.programme_id && Programme.findOne(reply.programme_id, data)
-        : reply?.session.programmes[0]
+        : reply?.session?.programmes[0]
       response.locals.programme = programme
 
       response.locals.triage = {
@@ -254,7 +254,7 @@ export const replyController = {
         },
         [`/${reply_uuid}/${type}/can-notify`]: {},
         [`/${reply_uuid}/${type}/health-answers`]: {
-          [`/${reply_uuid}/${type}/${countAnswersNeedingTriage(request.session.data.reply?.healthAnswers) ? 'triage' : 'check-answers'}`]: true
+          [`/${reply_uuid}/${type}/${countAnswersNeedingTriage(data.reply?.healthAnswers) ? 'triage' : 'check-answers'}`]: true
         },
         [`/${reply_uuid}/${type}/refusal-reason`]: {
           [`/${reply_uuid}/${type}/refusal-reason-details`]: {
@@ -309,7 +309,7 @@ export const replyController = {
       }
 
       if (isMultiProgrammeSession) {
-        response.locals.programmeItems = reply.session.programmes.map(
+        response.locals.programmeItems = reply.session?.programmes.map(
           (programme) => ({
             text: programme.name,
             value: programme.id
@@ -373,7 +373,6 @@ export const replyController = {
             },
             data.wizard
           ).uuid
-          reply.hasSelfConsent = false
           break
         case 'self':
           reply.method = ReplyMethod.InPerson
@@ -382,7 +381,6 @@ export const replyController = {
         default: // Consent response is an existing respondent
           reply.method = ReplyMethod.Phone
           reply.contact_uuid = respondent
-          reply.hasSelfConsent = false
 
           // Store reply that needs marked as invalid
           // We only want to do this when submitting replacement reply

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -8,13 +8,7 @@ import {
   ReplyRefusal,
   VaccinationOutcome
 } from '../enums.js'
-import {
-  Contact,
-  PatientSession,
-  Programme,
-  Reply,
-  Vaccination
-} from '../models.js'
+import { Contact, Patient, Programme, Reply, Vaccination } from '../models.js'
 import { today } from '../utils/date.js'
 import { saveAndRedirect } from '../utils/redirect.js'
 import { countAnswersNeedingTriage } from '../utils/reply.js'
@@ -30,13 +24,13 @@ export const replyController = {
    */
   read(request, response, next, reply_uuid) {
     const { patient_uuid, programme_id } = request.params
+    const { data } = request.session
 
-    response.locals.reply = Reply.findOne(reply_uuid, request.session.data)
-    response.locals.patientSession = PatientSession.findAll(
-      request.session.data
-    )
-      .filter(({ programme }) => programme.id === programme_id)
-      .find(({ patient }) => patient.uuid === patient_uuid)
+    const patient = Patient.findOne(String(patient_uuid), data)
+    const reply = Reply.findOne(reply_uuid, data)
+
+    response.locals.reply = reply
+    response.locals.patientProgramme = patient.programmes[String(programme_id)]
 
     next()
   },
@@ -66,21 +60,21 @@ export const replyController = {
    */
   new(request, response) {
     const { patient_uuid, programme_id } = request.params
+    const { session_id } = request.query
     const { data } = request.session
     const { account } = response.locals
 
-    const patientSession = PatientSession.findAll(request.session.data)
-      .filter(({ programme }) => programme.id === programme_id)
-      .find(({ patient }) => patient.uuid === patient_uuid)
+    const patient = Patient.findOne(String(patient_uuid), data)
+    const patientProgramme = patient.programmes[String(programme_id)]
 
     const createdReply = Reply.create(
       {
-        child: patientSession.patient,
-        patient_uuid: patientSession.patient.uuid,
-        programme_id: patientSession.programme.id,
-        session_id: patientSession.session.id,
+        child: patientProgramme.patient,
+        patient_uuid,
+        programme_id,
+        session_id,
         createdBy_uid: account.uid,
-        hasSelfConsent: patientSession?.patient?.isPost16
+        hasSelfConsent: patientProgramme?.patient?.isPost16
       },
       data
     )
@@ -88,7 +82,7 @@ export const replyController = {
     const reply = new Reply(createdReply, data)
 
     let next
-    if (patientSession?.patient?.isPost16) {
+    if (patientProgramme?.patient?.isPost16) {
       next = `${reply.uri}/new/decision`
     } else {
       next = `${reply.uri}/new/respondent`
@@ -105,8 +99,8 @@ export const replyController = {
     return (request, response) => {
       const { invalidUuid } = request.app.locals
       const { reply_uuid } = request.params
-      const { data } = request.session
-      const { __, account, patientSession, triage, vaccination } =
+      const { data, referrer } = request.session
+      const { __, account, patientProgramme, triage, vaccination } =
         response.locals
 
       let reply
@@ -118,7 +112,7 @@ export const replyController = {
         Reply.update(reply_uuid, request.body.reply, data)
       } else {
         reply = new Reply(Reply.findOne(reply_uuid, data.wizard), data)
-        next = patientSession.uri
+        next = referrer || patientProgramme.uri
 
         // Remove any contact details in reply if self consent
         if (reply.hasSelfConsent) {
@@ -126,14 +120,14 @@ export const replyController = {
         }
 
         if (triage?.psd) {
-          patientSession.patientProgramme.giveInstruction({
+          patientProgramme.giveInstruction({
             createdBy_uid: account.uid,
-            programme_id: patientSession.programme.id
+            programme_id: patientProgramme.programme_id
           })
         }
 
         if (triage?.status) {
-          patientSession.patientProgramme.recordTriage({
+          patientProgramme.recordTriage({
             ...triage,
             ...data?.wizard?.triage, // Wizard values
             createdBy_uid: account.uid,
@@ -146,9 +140,8 @@ export const replyController = {
           const createdVaccination = Vaccination.create(
             {
               outcome: VaccinationOutcome.AlreadyVaccinated,
-              patient_uuid: patientSession.patient.uuid,
-              programme_id: patientSession.programme.id,
-              session_id: patientSession.session.id,
+              patient_uuid: patientProgramme.patient_uuid,
+              programme_id: patientProgramme.programme_id,
               administeredAt_: vaccination.administeredAt_,
               administeredBy_uid: account.uid,
               createdBy_uid: account.uid,
@@ -164,7 +157,7 @@ export const replyController = {
             data
           )
 
-          patientSession.patient.recordVaccination(createdVaccination)
+          patientProgramme.patient.recordVaccination(createdVaccination)
         }
 
         // Invalidate any replaced response
@@ -174,7 +167,7 @@ export const replyController = {
           delete request.app.locals.invalidUuid
         }
 
-        patientSession.patient.addReply(reply)
+        patientProgramme.patient.addReply(reply)
 
         // Update session data
         Reply.update(reply_uuid, reply, data)
@@ -185,10 +178,7 @@ export const replyController = {
       delete data.triage
       delete data.vaccination
 
-      request.flash(
-        'success',
-        __(`reply.${type}.success`, { reply, patientSession })
-      )
+      request.flash('success', __(`reply.${type}.success`, { reply }))
 
       saveAndRedirect(request, response, next)
     }
@@ -202,7 +192,7 @@ export const replyController = {
     return (request, response, next) => {
       const { reply_uuid } = request.params
       const { data, referrer } = request.session
-      const { patientSession, triage, vaccination } = response.locals
+      const { patientProgramme, triage, vaccination } = response.locals
 
       let reply
       if (type === 'edit') {
@@ -213,19 +203,19 @@ export const replyController = {
         if (!reply) {
           reply = Reply.create(response.locals.reply, data.wizard)
         }
+        reply = new Reply(reply, data)
       }
 
       response.locals.reply = new Reply(reply, data)
-      response.locals.patient = patientSession.patient
+      response.locals.patient = patientProgramme.patient
 
       // Only ask for programme if more than 1 administered in a session
-      const isMultiProgrammeSession =
-        patientSession.session.programmes.length > 1
+      const isMultiProgrammeSession = reply?.session.programmes.length > 1
       response.locals.isMultiProgrammeSession = isMultiProgrammeSession
 
       const programme = isMultiProgrammeSession
         ? reply.programme_id && Programme.findOne(reply.programme_id, data)
-        : patientSession.session.programmes[0]
+        : reply?.session.programmes[0]
       response.locals.programme = programme
 
       response.locals.triage = {
@@ -249,7 +239,7 @@ export const replyController = {
           [`/${reply_uuid}/${type}/programme`]: {}
         }),
         [`/${reply_uuid}/${type}/decision`]: {
-          [`/${reply_uuid}/${type}/${reply?.hasSelfConsent && !patientSession.patient.isPost16 ? 'can-notify' : 'health-answers'}`]:
+          [`/${reply_uuid}/${type}/${reply?.hasSelfConsent && !patientProgramme.patient.isPost16 ? 'can-notify' : 'health-answers'}`]:
             {
               data: 'reply.decision',
               value: ReplyDecision.Given
@@ -297,13 +287,13 @@ export const replyController = {
       response.locals.paths = {
         ...wizard(journey, request),
         ...(type === 'edit' && {
-          back: `${patientSession.uri}/replies/${reply_uuid}/edit`,
-          next: `${patientSession.uri}/replies/${reply_uuid}/edit`
+          back: `${reply.uri}/edit`,
+          next: `${reply.uri}/edit`
         }),
         ...(referrer && { back: referrer })
       }
 
-      response.locals.respondentItems = patientSession.patient.contacts.map(
+      response.locals.respondentItems = patientProgramme.patient.contacts.map(
         (contact) => ({
           text: formatContact(contact, false),
           hint: { text: contact.tel },
@@ -312,15 +302,15 @@ export const replyController = {
       )
 
       // Child can self consent if assessed as Gillick competent
-      if (patientSession.gillick?.competent === GillickCompetent.True) {
+      if (reply?.patientSession?.gillick?.competent === GillickCompetent.True) {
         response.locals.respondentItems.unshift({
-          text: `${patientSession.patient?.firstName} (child)`,
+          text: `${patientProgramme.patient?.firstName} (child)`,
           value: 'self'
         })
       }
 
       if (isMultiProgrammeSession) {
-        response.locals.programmeItems = patientSession.session.programmes.map(
+        response.locals.programmeItems = reply.session.programmes.map(
           (programme) => ({
             text: programme.name,
             value: programme.id
@@ -366,7 +356,7 @@ export const replyController = {
     const { respondent } = request.body
     const { reply_uuid } = request.params
     const { data } = request.session
-    let { paths, patientSession, triage, vaccination } = response.locals
+    let { paths, triage, vaccination } = response.locals
 
     // Add contacts from global context to wizard
     data.wizard.contacts = data.contacts
@@ -421,8 +411,7 @@ export const replyController = {
     return saveAndRedirect(
       request,
       response,
-      paths.next ||
-        `${patientSession.uri}/replies/${reply_uuid}/new/check-answers`
+      paths.next || `${reply.uri}/new/check-answers`
     )
   },
 
@@ -432,7 +421,7 @@ export const replyController = {
   followUp(request, response) {
     const { decision } = request.body
     const { data } = request.session
-    const { patientSession, reply } = response.locals
+    const { patientProgramme, reply } = response.locals
 
     if (decision === 'true') {
       return saveAndRedirect(request, response, `${reply.uri}/edit/outcome`)
@@ -444,11 +433,10 @@ export const replyController = {
 
     const newReply = Reply.create(
       {
-        child: patientSession.patient,
+        child: patientProgramme.patient,
         contact_uuid: reply.contact_uuid,
-        patient_uuid: patientSession.patient_uuid,
-        session_id: patientSession.session_id,
-        programme_id: patientSession.programme_id,
+        patient_uuid: patientProgramme.patient_uuid,
+        programme_id: patientProgramme.programme_id,
         method: ReplyMethod.Phone
       },
       data.wizard
@@ -473,7 +461,7 @@ export const replyController = {
     const { note } = request.body.reply
     const { reply_uuid } = request.params
     const { data } = request.session
-    const { __, patientSession } = response.locals
+    const { __, referrer } = response.locals
 
     // Clean up session data
     delete data.reply
@@ -483,7 +471,7 @@ export const replyController = {
 
     request.flash('success', __(`reply.invalidate.success`, { reply }))
 
-    return saveAndRedirect(request, response, patientSession.uri)
+    return saveAndRedirect(request, response, referrer || reply.uri)
   },
 
   /**
@@ -492,8 +480,8 @@ export const replyController = {
   withdraw(request, response) {
     const { refusalReason, refusalReasonOther, note } = request.body.reply
     const { reply_uuid } = request.params
-    const { data } = request.session
-    const { __, account, patientSession, reply } = response.locals
+    const { data, referrer } = request.session
+    const { __, account, patientProgramme, reply } = response.locals
 
     // Create a new reply
     const newReply = Reply.create(
@@ -510,23 +498,22 @@ export const replyController = {
       data
     )
 
-    patientSession.patient.addReply(newReply)
+    patientProgramme.patient.addReply(newReply)
 
     // Add vaccination if refusal reason is already given
     if (refusalReason === ReplyRefusal.AlreadyVaccinated) {
       const vaccination = Vaccination.create(
         {
           outcome: VaccinationOutcome.AlreadyVaccinated,
-          patient_uuid: patientSession.patient_uuid,
-          programme_id: patientSession.programme.id,
-          session_id: patientSession.session.id,
+          patient_uuid: patientProgramme.patient_uuid,
+          programme_id: patientProgramme.programme_id,
           createdBy_uid: account.uid,
           ...(data.reply?.note && { note })
         },
         data
       )
 
-      patientSession.patient.recordVaccination(vaccination)
+      patientProgramme.patient.recordVaccination(vaccination)
     }
 
     // Invalidate existing reply
@@ -537,7 +524,7 @@ export const replyController = {
 
     request.flash('success', __(`reply.withdraw.success`, { reply }))
 
-    return saveAndRedirect(request, response, patientSession.uri)
+    return saveAndRedirect(request, response, referrer || reply.uri)
   }
 }
 

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -207,7 +207,6 @@ export const replyController = {
       }
 
       response.locals.reply = new Reply(reply, data)
-      response.locals.patient = patientProgramme.patient
 
       // Only ask for programme if more than 1 administered in a session
       const isMultiProgrammeSession = reply?.session.programmes.length > 1

--- a/app/controllers/reply.js
+++ b/app/controllers/reply.js
@@ -29,14 +29,14 @@ export const replyController = {
    * @type {RequestParamHandler}
    */
   read(request, response, next, reply_uuid) {
-    const { nhsn, programme_id } = request.params
+    const { patient_uuid, programme_id } = request.params
 
     response.locals.reply = Reply.findOne(reply_uuid, request.session.data)
     response.locals.patientSession = PatientSession.findAll(
       request.session.data
     )
       .filter(({ programme }) => programme.id === programme_id)
-      .find(({ patient }) => patient.nhsn === nhsn)
+      .find(({ patient }) => patient.uuid === patient_uuid)
 
     next()
   },
@@ -45,12 +45,12 @@ export const replyController = {
    * @type {RequestHandler<Record<string, string>>}
    */
   redirect(request, response) {
-    const { nhsn, programme_id, session_id } = request.params
+    const { patient_uuid, programme_id } = request.params
 
     return saveAndRedirect(
       request,
       response,
-      `/sessions/${session_id}/patients/${nhsn}/${programme_id}`
+      `/patients/${patient_uuid}/${programme_id}`
     )
   },
 
@@ -65,13 +65,13 @@ export const replyController = {
    * @type {RequestHandler<Record<string, string>>}
    */
   new(request, response) {
-    const { programme_id, nhsn } = request.params
+    const { patient_uuid, programme_id } = request.params
     const { data } = request.session
     const { account } = response.locals
 
     const patientSession = PatientSession.findAll(request.session.data)
       .filter(({ programme }) => programme.id === programme_id)
-      .find(({ patient }) => patient.nhsn === nhsn)
+      .find(({ patient }) => patient.uuid === patient_uuid)
 
     const createdReply = Reply.create(
       {

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -18,6 +18,7 @@ import {
   Child,
   Contact,
   Patient,
+  PatientSession,
   Programme,
   Session,
   Vaccination
@@ -391,6 +392,22 @@ export class Reply extends BaseModel {
     }
 
     return Object.fromEntries(healthQuestionsForDecision)
+  }
+
+  /**
+   * Get patient session
+   *
+   * @returns {PatientSession|undefined} Patient session
+   */
+  get patientSession() {
+    if (this.session_id) {
+      return PatientSession.findAll(this.context).find(
+        ({ patient_uuid, programme_id, session_id }) =>
+          patient_uuid === this.patient_uuid &&
+          programme_id === this.programme_id &&
+          session_id === this.session_id
+      )
+    }
   }
 
   /**

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -135,7 +135,7 @@ export class Reply extends BaseModel {
         ? false // Don’t show non response as invalid
         : stringToBoolean(options?.isInvalidated) || false
     this.method = options?.method
-    this.hasSelfConsent = options?.hasSelfConsent
+    this.hasSelfConsent = options?.hasSelfConsent || false
     this.note = options?.note || ''
     this.contact_uuid = options?.contact_uuid
     this.patient_uuid = options?.patient_uuid
@@ -306,14 +306,11 @@ export class Reply extends BaseModel {
    */
   get healthQuestionsForDecision() {
     const { Flu, HPV, MenACWY, TdIPV, MMR } = ProgrammeType
-    // TODO: is this consent reply really only ever for the session's first programme?
-    const programme = this.session.programmes[0]
-
     const healthQuestionsForDecision = new Map()
     let consentedVaccine
 
     // Consent given for flu programme with method of vaccination
-    if (programme?.type === Flu) {
+    if (this.programme?.type === Flu) {
       consentedVaccine = Object.values(vaccines).filter(
         (programme) => programme.type === Flu
       )
@@ -342,7 +339,7 @@ export class Reply extends BaseModel {
     }
 
     // Consent given for HPV programme
-    if (programme?.type === HPV) {
+    if (this.programme?.type === HPV) {
       consentedVaccine = Object.values(vaccines).find(
         ({ type }) => type === HPV
       )
@@ -363,7 +360,7 @@ export class Reply extends BaseModel {
     }
 
     // Consent given for MMR programme (gelatine-free, or either vaccine)
-    if (programme?.type == MMR) {
+    if (this.programme?.type == MMR) {
       const allowedCriteria = [
         VaccineCriteria.AlternativeInjection,
         ...(this.hasConsentForAlternativeVaccine
@@ -489,7 +486,7 @@ export class Reply extends BaseModel {
    * @returns {string} URI
    */
   get uri() {
-    return `/patients/${this.patient.uuid}/programmes/${this.programme_id}/replies/${this.uuid}`
+    return `/patients/${this.patient_uuid}/programmes/${this.programme_id}/replies/${this.uuid}`
   }
 
   /**

--- a/app/models/reply.js
+++ b/app/models/reply.js
@@ -472,7 +472,7 @@ export class Reply extends BaseModel {
    * @returns {string} URI
    */
   get uri() {
-    return `/sessions/${this.session_id}/patients/${this.patient.nhsn}/${this.programme_id}/replies/${this.uuid}`
+    return `/patients/${this.patient.uuid}/programmes/${this.programme_id}/replies/${this.uuid}`
   }
 
   /**

--- a/app/routes.js
+++ b/app/routes.js
@@ -75,9 +75,13 @@ router.use('/teams', teamRoutes)
 router.use('/teams/:team_id/clinics', clinicRoutes)
 router.use('/contacts', contactRoutes)
 router.use('/patients/:patient_uuid/book-into-a-clinic', bookIntoClinicRoutes)
+router.use(
+  '/patients/:patient_uuid/programmes/:programme_id/replies',
+  replyRoutes
+)
 router.use('/patients/:patient_uuid/programmes', patientProgrammeRoutes)
 router.use('/patients', patientRoutes)
-router.use('/patients', patientRoutes)
+
 router.use('/pds', pdsRecordRoutes)
 router.use('/reports', reportRoutes)
 router.use('/reports/:programme_id/vaccinations', vaccinationRoutes)
@@ -95,10 +99,6 @@ router.use(
 router.use('/sessions/:session_id/consents', consentRoutes)
 router.use('/sessions/:session_id/default-batch', defaultBatchRoutes)
 router.use('/sessions/:session_id/patients', patientSessionRoutes)
-router.use(
-  '/sessions/:session_id/patients/:nhsn/:programme_id/replies',
-  replyRoutes
-)
 router.use('/sessions', sessionRoutes)
 router.use('/uploads', uploadRoutes)
 router.use('/uploads/:upload_id/vaccinations', vaccinationRoutes)

--- a/app/views/patient-session/_consent.njk
+++ b/app/views/patient-session/_consent.njk
@@ -19,7 +19,7 @@
   {% if not isVaccinated and not patientSession.patient.isPost16 %}
     {{ actionLink({
       text: __("reply.new.title"),
-      href: patientSession.uri + "/replies/new?referrer=" + referrer
+      href: patientSession.patientProgramme.uri + "/replies/new?session_id=" + session.id + "&referrer=" + referrer
     }) if not isVaccinated }}
 
     {{ appButtonGroup({

--- a/app/views/reply/form/can-notify.njk
+++ b/app/views/reply/form/can-notify.njk
@@ -7,7 +7,7 @@
     fieldset: {
       legend: {
         html: appHeading({
-          caption: patient.fullName,
+          caption: reply.patient.fullName,
           title: title
         })
       }

--- a/app/views/reply/form/check-answers.njk
+++ b/app/views/reply/form/check-answers.njk
@@ -6,7 +6,7 @@
 
 {% block form %}
   {{ appHeading({
-    caption: patient.fullName,
+    caption: reply.patient.fullName,
     title: title
   }) }}
 

--- a/app/views/reply/form/contact.njk
+++ b/app/views/reply/form/contact.njk
@@ -8,7 +8,7 @@
 
 {% block form %}
   {{ appHeading({
-    caption: patient.fullName,
+    caption: reply.patient.fullName,
     title: title
   }) }}
 

--- a/app/views/reply/form/decision.njk
+++ b/app/views/reply/form/decision.njk
@@ -1,9 +1,14 @@
 {% extends "_layouts/form.njk" %}
 
 {% if reply.hasSelfConsent %}
-  {% set title = __("reply.decision.title.Child", { programme: programme }) %}
+  {% set title = __("reply.decision.title.Child", {
+    programme: reply.programme
+  }) %}
 {% else %}
-  {% set title = __("reply.decision.title.Contact", { programme: programme, patient: patient }) %}
+  {% set title = __("reply.decision.title.Contact", {
+    programme: reply.programme,
+    patient: reply.patient
+  }) %}
 {% endif %}
 
 {% block form %}
@@ -12,7 +17,7 @@
       legend: {
         html: appHeading({
           classes: "nhsuk-fieldset__legend--l",
-          caption: patient.fullName,
+          caption: reply.patient.fullName,
           title: title
         })
       }

--- a/app/views/reply/form/health-answers.njk
+++ b/app/views/reply/form/health-answers.njk
@@ -1,7 +1,7 @@
 {% extends "_layouts/form.njk" %}
 
 {% set title = __("reply.healthAnswers.title") %}
-{% set vaccineName = "nasal spray flu" if "Flu" in reply.session.presetNames else "MMR" %}
+{% set vaccineName = "nasal spray flu" if reply.programme_id == "flu" else "MMR" %}
 
 {% macro questions(healthQuestions) %}
   {% for key, value in healthQuestions %}

--- a/app/views/reply/form/health-answers.njk
+++ b/app/views/reply/form/health-answers.njk
@@ -36,7 +36,7 @@
 
 {% block form %}
   {{ appHeading({
-    caption: patient.fullName,
+    caption: reply.patient.fullName,
     title: title
   }) }}
 

--- a/app/views/reply/form/method.njk
+++ b/app/views/reply/form/method.njk
@@ -8,7 +8,7 @@
       legend: {
         html: appHeading({
           classes: "nhsuk-fieldset__legend--l",
-          caption: patient.fullName,
+          caption: reply.patient.fullName,
           title: title
         })
       }

--- a/app/views/reply/form/programme.njk
+++ b/app/views/reply/form/programme.njk
@@ -12,7 +12,7 @@
       legend: {
         html: appHeading({
           classes: "nhsuk-fieldset__legend--l",
-          caption: patient.fullName,
+          caption: reply.patient.fullName,
           title: title
         })
       }

--- a/app/views/reply/form/refusal-already-vaccinated.njk
+++ b/app/views/reply/form/refusal-already-vaccinated.njk
@@ -4,7 +4,7 @@
 
 {% block form %}
   {{ appHeading({
-    caption: patient.fullName,
+    caption: reply.patient.fullName,
     title: title
   }) }}
 

--- a/app/views/reply/form/refusal-notification.njk
+++ b/app/views/reply/form/refusal-notification.njk
@@ -8,7 +8,7 @@
       legend: {
         html: appHeading({
           classes: "nhsuk-fieldset__legend--l",
-          caption: patient.fullName,
+          caption: reply.patient.fullName,
           title: title
         })
       }

--- a/app/views/reply/form/refusal-reason-details.njk
+++ b/app/views/reply/form/refusal-reason-details.njk
@@ -6,7 +6,7 @@
   {{ textarea({
     label: {
       html: appHeading({
-        caption: patient.fullName,
+        caption: reply.patient.fullName,
         title: title
       })
     },

--- a/app/views/reply/form/refusal-reason.njk
+++ b/app/views/reply/form/refusal-reason.njk
@@ -8,7 +8,7 @@
       legend: {
         html: appHeading({
           classes: "nhsuk-fieldset__legend--l",
-          caption: patient.fullName,
+          caption: reply.patient.fullName,
           title: title
         })
       }

--- a/app/views/reply/form/respondent.njk
+++ b/app/views/reply/form/respondent.njk
@@ -8,7 +8,7 @@
       legend: {
         html: appHeading({
           classes: "nhsuk-fieldset__legend--l",
-          caption: patient.fullName,
+          caption: reply.patient.fullName,
           title: title
         })
       }

--- a/app/views/reply/form/triage.njk
+++ b/app/views/reply/form/triage.njk
@@ -1,10 +1,10 @@
 {% extends "_layouts/form.njk" %}
 
-{% set title = __("triage.label", { patient: patient }) %}
+{% set title = __("triage.label", { patient: reply.patient }) %}
 
 {% block form %}
   {{ appHeading({
-    caption: patient.fullName,
+    caption: reply.patient.fullName,
     title: title
   }) }}
 
@@ -18,7 +18,7 @@
   {% set delayVaccinationHtml = dateInput({
     fieldset: {
       legend: {
-        text: __("triage.statusInvalidAt.title", { patient: patient }),
+        text: __("triage.statusInvalidAt.title", { patient: reply.patient }),
         size: "s"
       }
     },


### PR DESCRIPTION
Replies are related to a programme, not a (patient) session. This PR makes `session_id` an optional property of `Reply`, and uses `PatientProgramme` in the reply controller instead of `PatientSession` (which given session is optional, may not always be present).

More refactoring in this direction to come. Have tested the various reply-related journeys and they haven’t broken 😅