### PR TITLE
Allow PSDs to be used in flu sessions by all vaccinators

### DIFF
--- a/app/controllers/patient-session.js
+++ b/app/controllers/patient-session.js
@@ -2,13 +2,11 @@ import {
   AuditEventType,
   ConsentStatus,
   ConsentWindow,
-  InstructionStatus,
   PatientStatus,
   PreScreenQuestion,
   RegistrationStatus,
   SessionType,
   VaccinationOutcome,
-  VaccinationProtocol,
   VaccineCriteria,
   VaccineMethod
 } from '../enums.js'
@@ -71,22 +69,19 @@ export const patientSessionController = {
       (patientProgramme) => patientProgramme.programme_id === programme_id
     )
 
-    const patientHasPsd = patientSession.instruct === InstructionStatus.Given
-
     let vaccineMethods = []
-
-    // Nurses can record all vaccines under any protocol
     if (account.isRegisteredNurse) {
+      // Nurses can record all vaccines under any protocol
       vaccineMethods = [VaccineMethod.Injection, VaccineMethod.Intranasal]
     } else if (account.isHealthcareAssistant) {
       // HCAs can record all vaccines under VGD
-      if (session.protocolHCA === VaccinationProtocol.VGD) {
+      if (session.hasVgdProtocol) {
         vaccineMethods = [VaccineMethod.Injection, VaccineMethod.Intranasal]
       }
 
-      // HCAs can record only nasal vaccines under PSD
-      if (session.protocolHCA === VaccinationProtocol.PSD) {
-        vaccineMethods = patientHasPsd ? [VaccineMethod.Intranasal] : []
+      // HCAs can only record nasal vaccines for children with a PSD
+      if (session.hasPsdProtocol && patientSession.hasInstruction) {
+        vaccineMethods = [VaccineMethod.Intranasal]
       }
     }
 
@@ -111,9 +106,7 @@ export const patientSessionController = {
       needsTriage: status === PatientStatus.Triage,
       // Patient already triaged
       hasTriage: triageNotes.length > 0,
-      hasInstruct:
-        session.protocolHCA === VaccinationProtocol.PSD &&
-        patientSession.instruct,
+      hasInstruction: session.hasPsdProtocol && patientSession.hasInstruction,
       canRegister: session.hasRegistration && session.isActive,
       canRecord:
         vaccineMethods?.includes(patientSession.vaccine?.method) &&

--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -1,12 +1,12 @@
 import wizard from '@x-govuk/govuk-prototype-wizard'
 
 import {
+  ProgrammeType,
   VaccinationMethod,
   VaccinationOutcome,
   VaccinationSite,
-  VaccineCriteria,
-  UserRole,
-  ProgrammeType
+  VaccinationProtocol,
+  VaccineCriteria
 } from '../enums.js'
 import {
   Batch,
@@ -127,12 +127,21 @@ export const vaccinationController = {
     }
     data.patientSession_uuid = String(patientSession_uuid)
 
-    // Used logged in user as vaccinator, or default to example user
-    const role = account.role || UserRole.Nurse
-
-    // Flu programme can have PGD or VGD as protocol
-    const protocol =
-      role === UserRole.HCA ? session.protocolHCA : session.protocolNurse
+    // Flu programme can use PGD, PSD or VGD protocol
+    let protocol
+    switch (true) {
+      case patientSession.hasInstruction && session.hasPsdProtocol:
+        protocol = VaccinationProtocol.PSD
+        break
+      case account.isHealthcareAssistant && session.hasVgdProtocol:
+        protocol = VaccinationProtocol.VGD
+        break
+      case account.isRegisteredNurse && session.hasVgdProtocol:
+        protocol = VaccinationProtocol.VGD
+        break
+      default:
+        protocol = VaccinationProtocol.PGD
+    }
 
     const vaccination = Vaccination.create(
       {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2914,17 +2914,25 @@ export const en = {
     },
     protocolHCA: {
       label: 'Protocol for healthcare assistants',
-      title: 'Can healthcare assistants give vaccinations?',
+      title:
+        'Can healthcare assistants give vaccinations under a vaccine group direction (VGD)?',
       no: {
         label: 'No'
       },
-      psd: {
-        label:
-          'Yes, the flu nasal spray vaccine under a patient specific direction (PSD)'
+      yes: {
+        label: 'Yes'
+      }
+    },
+    hasPsdProtocol: {
+      label: 'Can use PSDs',
+      title:
+        'Can the flu nasal spray vaccine be given under a patient specific direction (PSD)?',
+      hint: 'If a PSD is added to a child, they will be vaccinated under a PSD instead of a PGD or VGD',
+      no: {
+        label: 'No'
       },
-      vgd: {
-        label:
-          'Yes, the flu nasal spray and injected vaccines under a vaccine group direction (VGD)'
+      yes: {
+        label: 'Yes'
       }
     },
     'upload-class-list': {

--- a/app/models/patient-session.js
+++ b/app/models/patient-session.js
@@ -7,6 +7,7 @@ import {
   AuditEventType,
   ClinicAttendanceType,
   ConsentStatus,
+  InstructionStatus,
   PatientStatus,
   PatientClinicStatus,
   PatientConsentStatus,
@@ -695,10 +696,19 @@ export class PatientSession extends BaseModel {
   /**
    * Get instruction status
    *
-   * @returns {InstructionStatus|boolean} Instruction status
+   * @returns {InstructionStatus|undefined} Instruction status
    */
   get instruct() {
     return getInstructionStatus(this)
+  }
+
+  /**
+   * Patient has PSD instruction
+   *
+   * @returns {boolean} Patient has PSD instruction
+   */
+  get hasInstruction() {
+    return this.instruct === InstructionStatus.Given
   }
 
   /**
@@ -996,7 +1006,7 @@ PatientSession.relate('programme_id', () => Programme, 'programme')
 PatientSession.relate('session_id', () => Session, 'session')
 
 /**
- * @import { InstructionStatus, ScreenVaccineCriteria } from '../enums.js'
+ * @import { ScreenVaccineCriteria } from '../enums.js'
  * @import { Contact, PatientProgramme, Reply, Vaccination, Vaccine } from '../models.js'
  * @import { BaseModelOptions } from './base.js'
  */

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -153,6 +153,7 @@ export class Session extends BaseModel {
     if (this.programme_ids.includes('flu')) {
       this.protocolNurse = options?.protocolNurse || VaccinationProtocol.PGD
       this.protocolHCA = options?.protocolHCA || ''
+      this.hasPsdProtocol = stringToBoolean(options?.hasPsdProtocol) || false
     }
   }
 
@@ -343,15 +344,6 @@ export class Session extends BaseModel {
    */
   get isPastSession() {
     return this.academicYear < getCurrentAcademicYear()
-  }
-
-  /**
-   * Does session need to support the PSD protocol?
-   *
-   * @returns {boolean} Session need to support the PSD protocol?
-   */
-  get hasPsdProtocol() {
-    return this.protocolHCA === VaccinationProtocol.PSD
   }
 
   /**

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -125,11 +125,11 @@ export function getScreenStatusDescription(patientSession) {
  * Get instruction status for nasal spray
  *
  * @param {PatientSession} patientSession - Patient session
- * @returns {InstructionStatus|boolean} Instruction status
+ * @returns {InstructionStatus|undefined} Instruction status
  */
 export function getInstructionStatus(patientSession) {
   if (!patientSession.vaccine) {
-    return false
+    return
   }
 
   if (patientSession.vaccine.criteria === VaccineCriteria.Intranasal) {
@@ -138,7 +138,7 @@ export function getInstructionStatus(patientSession) {
       : InstructionStatus.Needed
   }
 
-  return false
+  return
 }
 
 /**

--- a/app/views/patient-session/show.njk
+++ b/app/views/patient-session/show.njk
@@ -70,7 +70,7 @@
 
       {% include "patient-session/_triage.njk" %}
 
-      {% if options.hasInstruct %}
+      {% if options.hasInstruction %}
         {% include "patient-session/_instruct.njk" %}
       {% endif %}
 

--- a/app/views/session/edit.njk
+++ b/app/views/session/edit.njk
@@ -53,6 +53,9 @@
         },
         protocolHCA: {
           href: session.uri + "/edit/protocol"
+        },
+        hasPsdProtocol: {
+          href: session.uri + "/edit/protocol"
         }
       })
     }) }}

--- a/app/views/session/form/check-answers.njk
+++ b/app/views/session/form/check-answers.njk
@@ -48,6 +48,9 @@
         },
         protocolHCA: {
           href: session.uri + "/new/protocol"
+        },
+        hasPsdProtocol: {
+          href: session.uri + "/new/protocol"
         }
       })
     }) }}

--- a/app/views/session/form/protocol.njk
+++ b/app/views/session/form/protocol.njk
@@ -36,12 +36,29 @@
       text: __("session.protocolHCA.no.label"),
       value: ""
     }, {
-      text: __("session.protocolHCA.psd.label"),
-      value: VaccinationProtocol.PSD
-    }, {
-      text: __("session.protocolHCA.vgd.label"),
+      text: __("session.protocolHCA.yes.label"),
       value: VaccinationProtocol.VGD
     }],
     decorate: "session.protocolHCA"
+  }) }}
+
+  {{ radios({
+    fieldset: {
+      legend: {
+        text: __("session.hasPsdProtocol.title"),
+        size: "m"
+      }
+    },
+    hint: {
+      text: __("session.hasPsdProtocol.hint")
+    },
+    items: [{
+      text: __("session.hasPsdProtocol.no.label"),
+      value: false
+    }, {
+      text: __("session.hasPsdProtocol.yes.label"),
+      value: true
+    }],
+    decorate: "session.hasPsdProtocol"
   }) }}
 {% endblock %}

--- a/app/views/session/show.njk
+++ b/app/views/session/show.njk
@@ -50,7 +50,8 @@
       mmrConsent: {},
       hasRegistration: {},
       protocolNurse: {},
-      protocolHCA: {}
+      protocolHCA: {},
+      hasPsdProtocol: {}
     } %}
     {% if session.type === SessionType.Clinic %}
       {% set sessionDetailsRows = {


### PR DESCRIPTION
Follows up #349 and #384

[Jira Issue - MAV-14222](https://nhsd-jira.digital.nhs.uk/browse/MAV-14222)

After speaking to teams, we want to offer more flexibility around how they use PSDs. Some teams use PSDs as a way to bulk delegate to HCAs, other use the protocol for children with specific health conditions and medical needs. And if a child has a PSD added, then the protocol the vaccine is administered under will be PSD, regardless of the default protocol(s) used in the session by nurse (and HCA) users.

This PR makes it so that PSDs can be used in a session separate to the protocols used by nurses, or whether HCAs can vaccinate children (under the VGD protocol).

It also ensures children vaccinated who have a PSD added, get vaccinated under that protocol, not the protocol used by the user role.

<img width="2400" height="2742" alt="Editing a session protocol." src="https://github.com/user-attachments/assets/8568e2ec-6455-4121-8e20-caa06f8702cc" />

<img width="2400" height="2868" alt="Editing a session." src="https://github.com/user-attachments/assets/b6329364-8e55-46a6-a57a-c5ddbaf1f8fc" />