### PR TITLE
Add a "Do not vaccinate in school" substatus to "Has a refusal"

### DIFF
--- a/app/enums.js
+++ b/app/enums.js
@@ -473,6 +473,7 @@ export const PatientDueStatus = {
 export const PatientRefusedStatus = {
   Conflict: 'Conflicting consent',
   FollowUp: 'Follow-up requested',
+  NotInSchool: 'Do not vaccinate in school',
   Refusal: 'Consent refused'
 }
 

--- a/app/models/patient-programme.js
+++ b/app/models/patient-programme.js
@@ -267,15 +267,15 @@ export class PatientProgramme extends BaseModel {
         const lastPatientSession = this.lastPatientSession
         if (!lastPatientSession) return false
 
+        const patientRefusedStatus = lastPatientSession.patientRefused
+
         // Parent refused but wanted a follow-up --> OK to invite
-        if (
-          lastPatientSession.patientRefused === PatientRefusedStatus.FollowUp
-        ) {
+        if (patientRefusedStatus === PatientRefusedStatus.FollowUp) {
           return true
         }
 
         // Parent(s) refused on grounds of it being in school --> OK to invite
-        if (lastPatientSession.isVaccinationWantedOutsideSchool) {
+        if (patientRefusedStatus === PatientRefusedStatus.NotInSchool) {
           return true
         }
 
@@ -713,18 +713,8 @@ export class PatientProgramme extends BaseModel {
         return this.lastVaccinationOutcome
           ? `${this.lastPatientSession.patientDeferred} on ${this.lastVaccinationOutcome.formatted.administeredAt_date}`
           : this.lastPatientSession.patientDeferred
-      case PatientStatus.Refused: {
-        const lastPatientSession = this.lastPatientSession
-        const patientRefusedStatus = lastPatientSession.patientRefused
-        if (
-          patientRefusedStatus === PatientRefusedStatus.Refusal &&
-          lastPatientSession.isVaccinationWantedOutsideSchool
-        ) {
-          return 'Do not vaccinate in school'
-        }
-
-        return patientRefusedStatus
-      }
+      case PatientStatus.Refused:
+        return this.lastPatientSession.patientRefused
       case PatientStatus.Consent:
         return this.lastPatientSession
           ? this.lastPatientSession.patientConsent

--- a/app/utils/patient-session.js
+++ b/app/utils/patient-session.js
@@ -322,7 +322,9 @@ export function getPatientRefusedStatus(patientSession) {
       return PatientRefusedStatus.FollowUp
     case ConsentStatus.Refused:
     case ConsentStatus.FinalRefusal:
-      return PatientRefusedStatus.Refusal
+      return patientSession.isVaccinationWantedOutsideSchool
+        ? PatientRefusedStatus.NotInSchool
+        : PatientRefusedStatus.Refusal
   }
 }
 


### PR DESCRIPTION
As described in MAV-13417, this substatus will only apply when all consent responses are refusals with a reason of "Do not want vaccination in school"