### PR TITLE
Change pre-screening content based on vaccinator’s role

### DIFF
--- a/app/controllers/vaccination.js
+++ b/app/controllers/vaccination.js
@@ -137,7 +137,7 @@ export const vaccinationController = {
       case patientProgramme.hasInstruction && session.hasPsdProtocol:
         protocol = VaccinationProtocol.PSD
         break
-      case account.isHealthcareAssistant && session.hasVgdProtocol:
+      case account.isHCA && session.hasVgdProtocol:
         protocol = VaccinationProtocol.VGD
         break
       case account.isRegisteredNurse && session.hasVgdProtocol:

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -2360,9 +2360,9 @@ export const en = {
   },
   preScreen: {
     label: 'Pre-screening checks',
-    description: 'Have you checked that {{patient.firstName}}:',
+    description: '{{ prefix }} checked that {{patient.firstName}}:',
     hasSelfIdentified: {
-      label: 'Has {{patient.firstName}} confirmed their identity?',
+      label: '{{ prefix }} confirmed {{patient.firstName}}’s identity?',
       true: 'Yes',
       false: 'No, it was confirmed by somebody else'
     },

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -89,7 +89,7 @@ export class User extends BaseModel {
    *
    * @returns {boolean} User is a registered practitioner?
    */
-  get isHealthcareAssistant() {
+  get isHCA() {
     return this.role === UserRole.HCA
   }
 
@@ -108,7 +108,7 @@ export class User extends BaseModel {
    * @returns {boolean} User can vaccinate?
    */
   get canVaccinate() {
-    return this.isHealthcareAssistant || this.isRegisteredNurse
+    return this.isHCA || this.isRegisteredNurse
   }
 
   /**

--- a/app/utils/account.js
+++ b/app/utils/account.js
@@ -11,7 +11,7 @@ export function getAccountVaccineMethods(account, patientSession) {
   if (account.isRegisteredNurse) {
     // Nurses can record all vaccines under any protocol
     vaccineMethods = [VaccineMethod.Injection, VaccineMethod.Intranasal]
-  } else if (account.isHealthcareAssistant) {
+  } else if (account.isHCA) {
     // HCAs can record all vaccines under VGD
     if (patientSession.session.protocolHCA === VaccinationProtocol.VGD) {
       vaccineMethods = [VaccineMethod.Injection, VaccineMethod.Intranasal]

--- a/app/views/patient-session/_record.njk
+++ b/app/views/patient-session/_record.njk
@@ -1,14 +1,14 @@
 {% set heading -%}
-  {%- if patientSession.programme.alternativeVaccine %}
-    <span class="app-vaccine-criteria" data-value="{{ patientSession.vaccineCriteria }}">
+  {%- if patientProgramme.programme.alternativeVaccine %}
+    <span class="app-vaccine-criteria" data-value="{{ patientProgramme.vaccineCriteria }}">
       {{- __("patientSession.record.titleWithMethod", {
-        programme: patientSession.programme,
-        method: patientSession.vaccineCriteria | lower | replace("only", "") | replace("preferred", "")
+        programme: patientProgramme.programme,
+        method: patientProgramme.vaccineCriteria | lower | replace("only", "") | replace("preferred", "")
       }) | safe -}}
     </span>
   {%- else -%}
     {{- __("patientSession.record.title", {
-      programme: patientSession.programme
+      programme: patientProgramme.programme
     }) | safe -}}
   {%- endif -%}
 {% endset %}
@@ -22,6 +22,7 @@
       legend: {
         classes: "nhsuk-u-font-size-22",
         text: __("preScreen.hasSelfIdentified.label", {
+          prefix: "Has a nurse" if account.isHCA else "Have you",
           patient: patient
         }),
         size: "s"
@@ -67,8 +68,11 @@
   }) }}
 
 {% filter nhsukMarkdown %}
-{{ __("preScreen.description", { patient: patient }) }}
-{% for question in patientSession.patientProgramme.vaccine.preScreenQuestions %}
+{{ __("preScreen.description", {
+  prefix: "Has a nurse" if account.isHCA else "Have you",
+  patient: patient
+}) }}
+{% for question in patientProgramme.vaccine.preScreenQuestions %}
 - {{ question }}
 {% endfor %}
 {% endfilter %}
@@ -154,8 +158,8 @@
         classes: "nhsuk-fieldset__legend--m nhsuk-u-font-size-22",
         text: __("preScreen.ready.label", {
           patient: patient,
-          programme: patientSession.programme,
-          method: patientSession.patientProgramme.vaccine.method | lower
+          programme: patientProgramme.programme,
+          method: patientProgramme.vaccine.method | lower
         }) | safe
       }
     },
@@ -186,7 +190,7 @@
     _validate: {
       presence: {
         message: __("preScreen.ready.error", {
-          programme: patientSession.programme
+          programme: patientProgramme.programme
         })
       }
     }


### PR DESCRIPTION
Slight tweak to content on record vaccination card. If a vaccinating user is an HCA, ask ‘Has a nurse…’, else if a nurse ask ‘Have you…’.

## Recording a vaccination as a nurse (‘Have you…’)

<img width="1634" height="2244" alt="Pre-screening checks for a nurse." src="https://github.com/user-attachments/assets/9c6cfd39-5cf8-44fe-955a-8d8184607cdf" />

## Recording a vaccination as a HCA (‘Has a nurse…‘)

<img width="1634" height="2308" alt="Pre-screening checks for a HCA." src="https://github.com/user-attachments/assets/4db0a7a4-3698-408c-9748-2812b3d3c271" />
