### PR TITLE
Include directions to a clinic as part of the location's definition

### DIFF
--- a/app/controllers/session.js
+++ b/app/controllers/session.js
@@ -848,6 +848,7 @@ export const sessionController = {
             }
           : {
               [`/${session_id}/${type}/clinic`]: {},
+              [`/${session_id}/${type}/clinic-directions`]: {},
               [`/${session_id}/${type}/date`]: {},
               [`/${session_id}/${type}/vaccination-periods`]: {},
               [`/${session_id}/${type}/vaccinators`]: {},
@@ -972,6 +973,12 @@ export const sessionController = {
       // Add the first vaccination period, if not already there
       if (!session.vaccinationPeriods?.length) {
         session.addVaccinationPeriod()
+        Session.update(session_id, session, data.wizard)
+      }
+
+      // Copy the default directions from the clinic location
+      if (view === 'clinic') {
+        session.directions = Clinic.findOne(session.clinic_id, data)?.directions
         Session.update(session_id, session, data.wizard)
       }
 

--- a/app/datasets/clinics.js
+++ b/app/datasets/clinics.js
@@ -136,6 +136,8 @@ export default [
     addressLine2: '',
     addressLevel1: 'Coventry',
     postalCode: 'CV4 9DR',
+    directions:
+      'Please use the car park on Rotary Way and enter via the rear of the building',
     tel: '024 76466106',
     team_id: '001',
     presetNames
@@ -213,6 +215,8 @@ export default [
     addressLine2: '',
     addressLevel1: 'Coventry',
     postalCode: 'CV3 2FD',
+    directions:
+      'If attending by car, please use the free car park opposite the Civic Centre, not the staff car park',
     tel: '024 76458777',
     team_id: '001',
     presetNames
@@ -345,6 +349,8 @@ export default [
     addressLine2: '2 Stoney Stanton Road',
     addressLevel1: 'Coventry',
     postalCode: 'CV1 4FS',
+    directions:
+      'Please note that the bus stop on Upper Stanton Road is currently out of use',
     tel: '024 75263599',
     team_id: '001',
     presetNames

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -45,6 +45,9 @@ export const en = {
     },
     postalCode: {
       label: 'Postcode'
+    },
+    directions: {
+      label: 'Directions'
     }
   },
   defaultBatch: {
@@ -3129,6 +3132,14 @@ export const en = {
       search: {
         label: 'Enter the clinic location'
       }
+    },
+    clinicDirections: {
+      label: 'Directions (optional)',
+      hint: 'These will be included in booking confirmation and reminder emails',
+      title: 'Give directions to the site, a specific entrance, or a room'
+    },
+    directions: {
+      label: 'Directions'
     },
     vaccinationPeriods: {
       title: 'When will the session start and end?',

--- a/app/models/location.js
+++ b/app/models/location.js
@@ -14,6 +14,7 @@ import { BaseModel } from './base.js'
  * @property {string} [addressLine2] - Address line 2
  * @property {string} [addressLevel1] - Address level 1
  * @property {string} [postalCode] - Postcode
+ * @property {string} [directions] - Directions
  * @property {Array<SessionPresetName>} [presetNames] - Session preset names
  */
 
@@ -44,6 +45,7 @@ export class Location extends BaseModel {
     this.addressLine2 = options?.addressLine2
     this.addressLevel1 = options?.addressLevel1
     this.postalCode = options?.postalCode
+    this.directions = options?.directions
     this.presetNames = options?.presetNames || []
   }
 

--- a/app/models/session.js
+++ b/app/models/session.js
@@ -50,6 +50,7 @@ import {
 import {
   formatLink,
   formatList,
+  formatMarkdown,
   formatWithSecondaryText,
   formatYearGroups,
   sentenceCaseProgrammeName,
@@ -73,6 +74,7 @@ import { BaseModel } from './base.js'
  *   Clinics only
  * @property {Array<ClinicVaccinationPeriod>} [vaccinationPeriods] - Vaccination periods
  * @property {number} [appointmentLength] - Standard length of the clinic appointment, in minutes
+ * @property {string} [directions] - Directions to the clinic or to the specific room on-site
  *
  *   Schools only
  * @property {Array<number>} [yearGroups] - Year groups
@@ -131,6 +133,7 @@ export class Session extends BaseModel {
           )
         : []
       this.appointmentLength = options?.appointmentLength
+      this.directions = options?.directions
     }
 
     if (this.type === SessionType.School) {
@@ -1158,6 +1161,10 @@ export class Session extends BaseModel {
               return Object.values(this.location).filter(Boolean).join(', ')
             case 'clinic':
               return this.clinic && this.clinic.name
+            case 'directions':
+              return this.directions
+                ? formatMarkdown(this.directions, { inline: true })
+                : 'None given'
             case 'school':
               return this.school && this.school.name
             case 'school_id':

--- a/app/views/clinic/form.njk
+++ b/app/views/clinic/form.njk
@@ -2,6 +2,7 @@
 
 {% set title = __("clinic." + type + ".title") %}
 {% set confirmButtonText = __("clinic." + type + ".confirm") %}
+{% set optionalSuffix = " (optional)" %}
 
 {% block form %}
   {% call fieldset({
@@ -23,7 +24,7 @@
     }) }}
 
     {{ input({
-      label: __("location.addressLine2.label") + " (optional)",
+      label: __("location.addressLine2.label") + optionalSuffix,
       autocomplete: "address-line2",
       decorate: "clinic.addressLine2"
     }) }}
@@ -40,6 +41,13 @@
       autocomplete: "postal-code",
       width: 10,
       decorate: "clinic.postalCode"
+    }) }}
+
+    {{ textarea({
+      label: {
+        text: __("location.directions.label") + optionalSuffix
+      },
+      decorate: "clinic.directions"
     }) }}
   {% endcall %}
 {% endblock %}

--- a/app/views/session/form/check-answers.njk
+++ b/app/views/session/form/check-answers.njk
@@ -74,6 +74,9 @@
         location: {
           href: session.uri + "/new/clinic"
         },
+        directions: {
+          href: session.uri + "/new/clinic-directions"
+        },
         date: {
           href: session.uri + "/new/date"
         },

--- a/app/views/session/form/clinic-directions.njk
+++ b/app/views/session/form/clinic-directions.njk
@@ -1,0 +1,17 @@
+{% extends "_layouts/form.njk" %}
+
+{% set title = __("session.clinicDirections.title") %}
+
+{% block form %}
+  {{ heading({
+    text: title,
+    size: "l"
+  }) }}
+
+  {{ textarea({
+    label: __("session.clinicDirections.label"),
+    hint: __("session.clinicDirections.hint"),
+    decorate: "session.directions"
+  }) }}
+
+{% endblock %}


### PR DESCRIPTION
Jira: [MAV-18149: Send directions to clinic in appointment confirmations and reminders](https://nhsd-jira.digital.nhs.uk/browse/MAV-18149)

Include directions to a clinic as part of the location's definition. This will then be carried through to clinic sessions that are set up at that location.

Editing a clinic location:
<img width="1126" height="1094" alt="image" src="https://github.com/user-attachments/assets/724642d2-9154-442d-82b1-695ebf8f6748" />

Customising the directions when setting up a clinic session:
<img width="1126" height="660" alt="image" src="https://github.com/user-attachments/assets/635f267e-3417-4294-83f4-c795aee47c45" />

Showing the direction in the Check and confirm page:
<img width="1126" height="1152" alt="image" src="https://github.com/user-attachments/assets/88196bdd-0da2-4a94-a6bc-796a61f50794" />
